### PR TITLE
Add workshop, company and session models with migrations

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -4,5 +4,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends build-essential
 COPY requirements.txt /app/requirements.txt
 RUN pip install --no-cache-dir -r /app/requirements.txt
 COPY . /app
+RUN chmod +x /app/entrypoint.sh
 EXPOSE 8000
-CMD ["python","/app/app.py"]
+CMD ["/app/entrypoint.sh"]

--- a/app/alembic.ini
+++ b/app/alembic.ini
@@ -1,0 +1,3 @@
+[alembic]
+script_location = alembic
+sqlalchemy.url = 

--- a/app/alembic/env.py
+++ b/app/alembic/env.py
@@ -1,0 +1,56 @@
+import os
+from logging.config import fileConfig
+
+from sqlalchemy import engine_from_config, pool
+from alembic import context
+
+from models import Base
+
+config = context.config
+
+if not config.get_main_option("sqlalchemy.url"):
+    user = os.environ.get("DB_USER", "cbs")
+    password = os.environ.get("POSTGRES_PASSWORD", "")
+    host = os.environ.get("DB_HOST", "db")
+    name = os.environ.get("DB_NAME", "cbs")
+    config.set_main_option(
+        "sqlalchemy.url",
+        f"postgresql+psycopg2://{user}:{password}@{host}/{name}"
+    )
+
+fileConfig(config.config_file_name)
+
+target_metadata = Base.metadata
+
+
+def run_migrations_offline() -> None:
+    url = config.get_main_option("sqlalchemy.url")
+    context.configure(
+        url=url,
+        target_metadata=target_metadata,
+        literal_binds=True,
+        dialect_opts={"paramstyle": "named"},
+    )
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online() -> None:
+    connectable = engine_from_config(
+        config.get_section(config.config_ini_section, {}),
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+    )
+
+    with connectable.connect() as connection:
+        context.configure(connection=connection, target_metadata=target_metadata)
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()
+

--- a/app/alembic/versions/0001_create_tables.py
+++ b/app/alembic/versions/0001_create_tables.py
@@ -1,0 +1,70 @@
+"""create workshop, company, session tables
+
+Revision ID: 0001_create_tables
+Revises: 
+Create Date: 2024-01-01 00:00:00
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = '0001_create_tables'
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        'workshop_type',
+        sa.Column('id', sa.Integer(), primary_key=True),
+        sa.Column('short_name', sa.String(), nullable=False),
+        sa.Column('full_name', sa.String(), nullable=False),
+        sa.Column('active', sa.Boolean(), server_default=sa.text('true'), nullable=False),
+        sa.Column('created_at', sa.DateTime(timezone=True), server_default=sa.text('now()'), nullable=False),
+        sa.Column('updated_at', sa.DateTime(timezone=True), server_default=sa.text('now()'), nullable=False),
+    )
+    op.create_index('ux_workshop_type_short_name', 'workshop_type', ['short_name'], unique=True)
+    op.create_index('ux_workshop_type_full_name', 'workshop_type', ['full_name'], unique=True)
+
+    op.create_table(
+        'company',
+        sa.Column('id', sa.Integer(), primary_key=True),
+        sa.Column('name', sa.String(), nullable=False),
+        sa.Column('normalized_name', sa.String(), nullable=False),
+        sa.Column('active', sa.Boolean(), server_default=sa.text('true'), nullable=False),
+        sa.Column('created_at', sa.DateTime(timezone=True), server_default=sa.text('now()'), nullable=False),
+        sa.Column('updated_at', sa.DateTime(timezone=True), server_default=sa.text('now()'), nullable=False),
+    )
+    op.create_index('ux_company_name', 'company', ['name'], unique=True)
+
+    op.create_table(
+        'session',
+        sa.Column('id', sa.Integer(), primary_key=True),
+        sa.Column('session_id', sa.String(), nullable=False),
+        sa.Column('company_id', sa.Integer(), sa.ForeignKey('company.id'), nullable=False),
+        sa.Column('workshop_type_id', sa.Integer(), sa.ForeignKey('workshop_type.id'), nullable=False),
+        sa.Column('start_date', sa.Date(), nullable=False),
+        sa.Column('end_date', sa.Date(), nullable=False),
+        sa.Column('client_manager_name', sa.String(), nullable=True),
+        sa.Column('client_manager_email', sa.String(), nullable=True),
+        sa.Column('created_by_user_id', sa.Integer(), sa.ForeignKey('user_account.user_account_id'), nullable=True),
+        sa.Column('shipping_json', postgresql.JSONB(), server_default=sa.text("'{}'::jsonb"), nullable=False),
+        sa.Column('notes', sa.Text(), nullable=True),
+        sa.Column('created_at', sa.DateTime(timezone=True), server_default=sa.text('now()'), nullable=False),
+        sa.Column('updated_at', sa.DateTime(timezone=True), server_default=sa.text('now()'), nullable=False),
+    )
+    op.create_index('ux_session_session_id', 'session', ['session_id'], unique=True)
+    op.create_index('ix_session_client_manager_email_lower', 'session', [sa.text('lower(client_manager_email)')])
+
+
+def downgrade() -> None:
+    op.drop_index('ix_session_client_manager_email_lower', table_name='session')
+    op.drop_index('ux_session_session_id', table_name='session')
+    op.drop_table('session')
+    op.drop_index('ux_company_name', table_name='company')
+    op.drop_table('company')
+    op.drop_index('ux_workshop_type_full_name', table_name='workshop_type')
+    op.drop_index('ux_workshop_type_short_name', table_name='workshop_type')
+    op.drop_table('workshop_type')

--- a/app/alembic/versions/0002_seed_workshop_types.py
+++ b/app/alembic/versions/0002_seed_workshop_types.py
@@ -1,0 +1,38 @@
+"""seed initial workshop types
+
+Revision ID: 0002_seed_workshop_types
+Revises: 0001_create_tables
+Create Date: 2024-01-01 00:00:00
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = '0002_seed_workshop_types'
+down_revision = '0001_create_tables'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    table = sa.table(
+        'workshop_type',
+        sa.column('short_name', sa.String),
+        sa.column('full_name', sa.String),
+        sa.column('active', sa.Boolean),
+    )
+    op.bulk_insert(
+        table,
+        [
+            {'short_name': 'PSDM', 'full_name': 'Problem Solving and Decision Making', 'active': True},
+            {'short_name': 'PSA', 'full_name': 'Problem Solving App Clinic', 'active': True},
+            {'short_name': 'DA', 'full_name': 'Decision Analysis', 'active': True},
+            {'short_name': 'SA', 'full_name': 'Situation Appraisal', 'active': True},
+            {'short_name': 'PPA', 'full_name': 'Potential Problem Analysis', 'active': True},
+        ],
+    )
+
+
+def downgrade() -> None:
+    op.execute("delete from workshop_type where short_name in ('PSDM','PSA','DA','SA','PPA')")
+

--- a/app/entrypoint.sh
+++ b/app/entrypoint.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+alembic upgrade head
+exec python /app/app.py

--- a/app/models.py
+++ b/app/models.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+from datetime import date
+from typing import Optional
+
+from sqlalchemy import (
+    Boolean,
+    Column,
+    Date,
+    DateTime,
+    ForeignKey,
+    Integer,
+    String,
+    Text,
+    Index,
+    event,
+    func,
+    select,
+    text,
+)
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.orm import declarative_base, relationship, validates, object_session
+
+Base = declarative_base()
+
+
+class TimestampMixin:
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+    updated_at = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())
+
+
+class WorkshopType(Base, TimestampMixin):
+    __tablename__ = "workshop_type"
+
+    id = Column(Integer, primary_key=True)
+    short_name = Column(String, nullable=False, unique=True)
+    full_name = Column(String, nullable=False, unique=True)
+    active = Column(Boolean, nullable=False, server_default=func.true())
+
+    sessions = relationship("Session", back_populates="workshop_type")
+
+    def __repr__(self) -> str:
+        return f"<WorkshopType id={self.id} short_name={self.short_name!r}>"
+
+
+class Company(Base, TimestampMixin):
+    __tablename__ = "company"
+
+    id = Column(Integer, primary_key=True)
+    name = Column(String, nullable=False, unique=True)
+    normalized_name = Column(String, nullable=False)
+    active = Column(Boolean, nullable=False, server_default=func.true())
+
+    sessions = relationship("Session", back_populates="company")
+
+    def __repr__(self) -> str:
+        return f"<Company id={self.id} name={self.name!r}>"
+
+
+class Session(Base, TimestampMixin):
+    __tablename__ = "session"
+
+    id = Column(Integer, primary_key=True)
+    session_id = Column(String, nullable=False)
+    company_id = Column(Integer, ForeignKey("company.id"), nullable=False)
+    workshop_type_id = Column(Integer, ForeignKey("workshop_type.id"), nullable=False)
+    start_date = Column(Date, nullable=False)
+    end_date = Column(Date, nullable=False)
+    client_manager_name = Column(String)
+    client_manager_email = Column(String)
+    created_by_user_id = Column(Integer, ForeignKey("user_account.user_account_id"))
+    shipping_json = Column(JSONB, nullable=False, server_default=text("'{}'::jsonb"))
+    notes = Column(Text)
+
+    __table_args__ = (
+        Index("ux_session_session_id", "session_id", unique=True),
+        Index("ix_session_client_manager_email_lower", func.lower(client_manager_email)),
+    )
+
+    company = relationship("Company", back_populates="sessions")
+    workshop_type = relationship("WorkshopType", back_populates="sessions")
+
+    def __repr__(self) -> str:
+        return f"<Session id={self.id} session_id={self.session_id!r}>"
+
+    @validates("client_manager_email")
+    def _validate_email(self, key: str, value: Optional[str]) -> Optional[str]:
+        value = (value or "").lower()
+        sess = object_session(self)
+        if sess is not None:
+            q = sess.query(Session).filter(func.lower(Session.client_manager_email) == value)
+            if self.id is not None:
+                q = q.filter(Session.id != self.id)
+            if q.first() is not None:
+                raise ValueError("client_manager_email must be unique")
+        return value
+
+
+@event.listens_for(Session, "before_insert")
+def generate_session_id(mapper, connection, target: Session) -> None:
+    company_name = connection.execute(
+        select(Company.normalized_name).where(Company.id == target.company_id)
+    ).scalar() or ""
+    short = connection.execute(
+        select(WorkshopType.short_name).where(WorkshopType.id == target.workshop_type_id)
+    ).scalar() or ""
+    prefix = company_name.strip().upper()[:5]
+    prefix = prefix.ljust(5, "X")
+    date_part = target.end_date.strftime("%Y%m%d") if isinstance(target.end_date, date) else ""
+    target.session_id = f"{prefix}-{short}-{date_part}"

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -2,3 +2,5 @@ Flask==3.0.3
 psycopg2-binary==2.9.9
 PyPDF2==3.0.1
 reportlab==4.1.0
+SQLAlchemy==2.0.23
+alembic==1.12.1


### PR DESCRIPTION
## Summary
- add SQLAlchemy models for workshop types, companies and sessions
- compute session IDs from company prefix, workshop short name and end date
- introduce Alembic with migrations and seed data
- run migrations automatically via entrypoint script

## Testing
- `python -m py_compile app/models.py app/alembic/versions/0001_create_tables.py app/alembic/versions/0002_seed_workshop_types.py app/alembic/env.py`
- `pytest`
- `pip install SQLAlchemy==2.0.23 alembic==1.12.1` *(fails: Cannot connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_689f6ab2ec78832e9c50d729e3d59b2a