### PR TITLE
Add admin CRUD for workshop types

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -2,7 +2,7 @@ import csv, io, os, re, zipfile, json, smtplib, ssl
 from datetime import datetime
 from email.message import EmailMessage
 from functools import wraps
-from flask import Flask, request, send_file, send_from_directory, Response, url_for, session, redirect, abort
+from flask import Flask, request, send_file, send_from_directory, Response, url_for, session, redirect, abort, render_template
 import psycopg2
 from PyPDF2 import PdfReader, PdfWriter
 from reportlab.pdfgen import canvas
@@ -204,6 +204,7 @@ def home():
         links.append(('<a href="/importer">Import CSV</a>', "Upload CSV to issue certificates"))
         links.append(('<a href="/cert-form">Create Certificates</a>', "One page form for multiple learners"))
         links.append(('<a href="/issued">Issued PDFs</a>', "Browse generated PDFs"))
+        links.append(('<a href="/admin/workshop-types">Workshop Types</a>', "Manage workshop types"))
     if (session.get("roles") or {}).get("admin"):
         links.append(('<a href="/users">User Management</a>', "Create, edit, reset, deactivate"))
     base = request.path.rstrip('/') + '/'
@@ -759,6 +760,104 @@ def users_delete(user_id):
         else:
             cur.execute("delete from user_account where user_account_id=%s",(user_id,))
     return redirect("/users")
+
+# ---------- workshop types ----------
+
+@app.get("/admin/workshop-types")
+@roles_required_any("admin","staff")
+def workshop_types_list():
+    show_archived = request.args.get("show_archived") == "1"
+    with conn() as cx, cx.cursor() as cur:
+        sql = "select id, short_name, full_name, active from workshop_type"
+        if not show_archived:
+            sql += " where active=true"
+        sql += " order by short_name"
+        cur.execute(sql)
+        rows = cur.fetchall()
+    return render_template("admin/workshop_types_list.html", rows=rows, show_archived=show_archived)
+
+
+@app.get("/admin/workshop-types/new")
+@roles_required_any("admin","staff")
+def workshop_types_new_form():
+    return render_template("admin/workshop_types_form.html", form={}, errors={})
+
+
+@app.post("/admin/workshop-types/new")
+@roles_required_any("admin","staff")
+def workshop_types_new():
+    short = (request.form.get("short_name") or "").strip().upper()
+    full = (request.form.get("full_name") or "").strip()
+    errors = {}
+    if not re.fullmatch(r"[A-Z0-9]{2,8}", short):
+        errors["short_name"] = "Use 2-8 uppercase letters or digits."
+    with conn() as cx, cx.cursor() as cur:
+        if not errors:
+            cur.execute("select 1 from workshop_type where short_name=%s", (short,))
+            if cur.fetchone():
+                errors["short_name"] = "Short name must be unique."
+        if errors:
+            return render_template(
+                "admin/workshop_types_form.html",
+                form={"short_name": short, "full_name": full},
+                errors=errors,
+            )
+        cur.execute(
+            "insert into workshop_type (short_name, full_name, active) values (%s, %s, true)",
+            (short, full),
+        )
+    return redirect("/admin/workshop-types")
+
+
+@app.get("/admin/workshop-types/<int:wt_id>/edit")
+@roles_required_any("admin","staff")
+def workshop_types_edit_form(wt_id):
+    with conn() as cx, cx.cursor() as cur:
+        cur.execute("select short_name, full_name from workshop_type where id=%s", (wt_id,))
+        row = cur.fetchone()
+        if not row:
+            return abort(404)
+    form = {"id": wt_id, "short_name": row[0], "full_name": row[1]}
+    return render_template("admin/workshop_types_form.html", form=form, errors={})
+
+
+@app.post("/admin/workshop-types/<int:wt_id>/edit")
+@roles_required_any("admin","staff")
+def workshop_types_edit(wt_id):
+    short = (request.form.get("short_name") or "").strip().upper()
+    full = (request.form.get("full_name") or "").strip()
+    errors = {}
+    if not re.fullmatch(r"[A-Z0-9]{2,8}", short):
+        errors["short_name"] = "Use 2-8 uppercase letters or digits."
+    with conn() as cx, cx.cursor() as cur:
+        if not errors:
+            cur.execute("select 1 from workshop_type where short_name=%s and id<>%s", (short, wt_id))
+            if cur.fetchone():
+                errors["short_name"] = "Short name must be unique."
+        if errors:
+            form = {"id": wt_id, "short_name": short, "full_name": full}
+            return render_template("admin/workshop_types_form.html", form=form, errors=errors)
+        cur.execute(
+            "update workshop_type set short_name=%s, full_name=%s where id=%s",
+            (short, full, wt_id),
+        )
+    return redirect("/admin/workshop-types")
+
+
+@app.post("/admin/workshop-types/<int:wt_id>/archive")
+@roles_required_any("admin","staff")
+def workshop_types_archive(wt_id):
+    with conn() as cx, cx.cursor() as cur:
+        cur.execute("update workshop_type set active=false where id=%s", (wt_id,))
+    return redirect("/admin/workshop-types")
+
+
+@app.post("/admin/workshop-types/<int:wt_id>/unarchive")
+@roles_required_any("admin","staff")
+def workshop_types_unarchive(wt_id):
+    with conn() as cx, cx.cursor() as cur:
+        cur.execute("update workshop_type set active=true where id=%s", (wt_id,))
+    return redirect("/admin/workshop-types?show_archived=1")
 
 if __name__ == "__main__":
     app.run(host="0.0.0.0", port=8000)

--- a/app/templates/admin/workshop_types_form.html
+++ b/app/templates/admin/workshop_types_form.html
@@ -1,0 +1,22 @@
+{% extends "base.html" %}
+{% block content %}
+<h2>{{ 'Edit' if form.get('id') else 'Create' }} Workshop Type</h2>
+{% if errors.get('form') %}<p style="color:red">{{ errors.form }}</p>{% endif %}
+<form method="post">
+  <div>
+    <label>Short name
+      <input type="text" name="short_name" value="{{ form.short_name or '' }}" required pattern="[A-Z0-9]{2,8}" maxlength="8">
+    </label>
+    {% if errors.get('short_name') %}<span style="color:red">{{ errors.short_name }}</span>{% endif %}
+  </div>
+  <div>
+    <label>Full name
+      <input type="text" name="full_name" value="{{ form.full_name or '' }}" required>
+    </label>
+  </div>
+  <div>
+    <button type="submit">Save</button>
+  </div>
+</form>
+<p><a href="{{ url_for('workshop_types_list') }}">Back</a></p>
+{% endblock %}

--- a/app/templates/admin/workshop_types_list.html
+++ b/app/templates/admin/workshop_types_list.html
@@ -1,0 +1,35 @@
+{% extends "base.html" %}
+{% block content %}
+<h2>Workshop Types</h2>
+<p><a href="{{ url_for('workshop_types_new_form') }}">Create new</a></p>
+{% if show_archived %}
+  <p><a href="{{ url_for('workshop_types_list') }}">Hide archived</a></p>
+{% else %}
+  <p><a href="{{ url_for('workshop_types_list', show_archived=1) }}">Show archived</a></p>
+{% endif %}
+<table border="1" cellpadding="4" cellspacing="0">
+  <tr><th>Short</th><th>Full name</th><th>Status</th><th>Actions</th></tr>
+  {% for id, short, full, active in rows %}
+  <tr>
+    <td>{{ short }}</td>
+    <td>{{ full }}</td>
+    <td>{{ 'active' if active else 'archived' }}</td>
+    <td>
+      <a href="{{ url_for('workshop_types_edit_form', wt_id=id) }}">Edit</a>
+      {% if active %}
+      <form method="post" action="{{ url_for('workshop_types_archive', wt_id=id) }}" style="display:inline">
+        <button type="submit">Archive</button>
+      </form>
+      {% else %}
+      <form method="post" action="{{ url_for('workshop_types_unarchive', wt_id=id) }}" style="display:inline">
+        <button type="submit">Unarchive</button>
+      </form>
+      {% endif %}
+    </td>
+  </tr>
+  {% else %}
+  <tr><td colspan="4">No workshop types</td></tr>
+  {% endfor %}
+</table>
+<p><a href="/">Back</a></p>
+{% endblock %}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Certs and Badges</title>
+</head>
+<body>
+  <main>
+    {% block content %}{% endblock %}
+  </main>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add staff-restricted workshop type management
- implement list, create, edit, and archive/unarchive views
- validate short name format and uniqueness with dedicated templates

## Testing
- `python -m py_compile app/app.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689f6dd34094832ea4720f7c9bd1e59f