### PR TITLE
Add session detail view with client manager editing

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -67,7 +67,7 @@ def list_sessions():
     with conn() as cx, cx.cursor() as cur:
         cur.execute(
             """
-            select s.session_id, c.name as company, wt.code as workshop_short,
+            select s.session_uid, s.session_id, c.name as company, wt.code as workshop_short,
                    wt.name as workshop_full, s.start_date, s.end_date, s.created_at
             from session s
             left join client c on s.client_id=c.client_id
@@ -76,6 +76,37 @@ def list_sessions():
             """
         )
         return cur.fetchall()
+
+
+def get_session(session_uid):
+    with conn() as cx, cx.cursor() as cur:
+        cur.execute(
+            """
+            select s.session_uid, s.session_id, c.name as company_name, wt.code as workshop_code,
+                   wt.name as workshop_name, s.start_date, s.end_date, s.status,
+                   s.client_manager_name, s.client_manager_email
+            from session s
+            left join client c on s.client_id=c.client_id
+            left join workshop_type wt on s.workshop_type_id=wt.workshop_type_id
+            where s.session_uid=%s
+            """,
+            (str(session_uid),),
+        )
+        row = cur.fetchone()
+    if not row:
+        return None
+    return {
+        "session_uid": row[0],
+        "session_id": row[1],
+        "company_name": row[2],
+        "workshop_code": row[3],
+        "workshop_name": row[4],
+        "start_date": row[5],
+        "end_date": row[6],
+        "status": row[7],
+        "client_manager_name": row[8],
+        "client_manager_email": row[9],
+    }
 
 # ---------- helpers ----------
 def sanitize(s): return re.sub(r"[^A-Za-z0-9_\-\.]", "_", s or "")
@@ -467,6 +498,33 @@ def sessions_new_post():
         cx.commit()
     flash(f"Created session {new_sid}")
     return redirect(url_for("sessions_list"))
+
+
+@app.get("/sessions/<uuid:session_uid>")
+@staff_required
+def sessions_detail(session_uid):
+    sess = get_session(session_uid)
+    if not sess:
+        abort(404)
+    return render_template("sessions_detail.html", sess=sess)
+
+
+@app.post("/sessions/<uuid:session_uid>/client-manager")
+@staff_required
+def sessions_client_manager_post(session_uid):
+    name = (request.form.get("name") or "").strip()
+    email = (request.form.get("email") or "").strip().lower()
+    if not name:
+        flash("Name required")
+        return redirect(url_for("sessions_detail", session_uid=session_uid))
+    with conn() as cx, cx.cursor() as cur:
+        cur.execute(
+            "update session set client_manager_name=%s, client_manager_email=%s where session_uid=%s",
+            (name, email, str(session_uid)),
+        )
+        cx.commit()
+    flash("Saved")
+    return redirect(url_for("sessions_detail", session_uid=session_uid))
 
 
 # ---------- importer ----------

--- a/app/templates/sessions_detail.html
+++ b/app/templates/sessions_detail.html
@@ -1,0 +1,37 @@
+{% extends "base.html" %}
+{% block content %}
+<h2>Session {{ sess.session_id }}</h2>
+{% with messages = get_flashed_messages() %}
+  {% if messages %}
+  <ul>
+    {% for m in messages %}
+    <li>{{ m }}</li>
+    {% endfor %}
+  </ul>
+  {% endif %}
+{% endwith %}
+<ul>
+  <li><a href="#overview">Overview</a></li>
+  <li><a href="#client-manager">Client Manager</a></li>
+  <li><a href="#learners">Learners</a></li>
+  <li><a href="#shipping">Shipping</a></li>
+</ul>
+<div id="overview">
+  <h3>Overview</h3>
+  <table border="1" cellpadding="4" cellspacing="0">
+    <tr><th>Company</th><td>{{ sess.company_name }}</td></tr>
+    <tr><th>Workshop</th><td>{{ sess.workshop_code }} - {{ sess.workshop_name }}</td></tr>
+    <tr><th>Start</th><td>{{ sess.start_date }}</td></tr>
+    <tr><th>End</th><td>{{ sess.end_date }}</td></tr>
+    <tr><th>Status</th><td>{{ sess.status }}</td></tr>
+  </table>
+</div>
+<div id="client-manager">
+  <h3>Client Manager</h3>
+  <form method="post" action="{{ url_for('sessions_client_manager_post', session_uid=sess.session_uid) }}">
+    <p><label>Name <input type="text" name="name" value="{{ sess.client_manager_name or '' }}" required></label></p>
+    <p><label>Email <input type="email" name="email" value="{{ sess.client_manager_email or '' }}"></label></p>
+    <p><button type="submit">Save</button></p>
+  </form>
+</div>
+{% endblock %}

--- a/app/templates/sessions_list.html
+++ b/app/templates/sessions_list.html
@@ -21,9 +21,9 @@
     <th>End</th>
     <th>Created</th>
   </tr>
-  {% for sid, company, workshop_short, workshop_full, start, end, created in rows %}
+  {% for uid, sid, company, workshop_short, workshop_full, start, end, created in rows %}
   <tr>
-    <td>{{ sid }}</td>
+    <td><a href="{{ url_for('sessions_detail', session_uid=uid) }}">{{ sid }}</a></td>
     <td>{{ company }}</td>
     <td>{{ workshop_short }}</td>
     <td>{{ workshop_full }}</td>


### PR DESCRIPTION
## Summary
- show session details for staff at `/sessions/<session_uid>`
- allow staff to edit client manager name & email
- link session IDs to detail view

## Testing
- `python -m py_compile app/app.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f88169080832e91af535f4751a6d3