### PR TITLE
Add Alembic migrations and CLI support

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -1,0 +1,4 @@
+from app.app import create_app, db  # noqa: F401
+
+app = create_app()
+

--- a/migrations/README
+++ b/migrations/README
@@ -1,0 +1,2 @@
+Generic single-database configuration.
+

--- a/migrations/alembic.ini
+++ b/migrations/alembic.ini
@@ -1,0 +1,40 @@
+[alembic]
+script_location = migrations
+prepend_sys_path = .
+
+sqlalchemy.url =
+
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+qualname =
+
+[logger_sqlalchemy]
+level = WARN
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s
+datefmt = %H:%M:%S
+

--- a/migrations/env.py
+++ b/migrations/env.py
@@ -1,0 +1,50 @@
+from __future__ import with_statement
+
+import logging
+from logging.config import fileConfig
+
+from flask import current_app
+from alembic import context
+
+config = context.config
+
+fileConfig(config.config_file_name)
+logger = logging.getLogger("alembic.env")
+
+target_metadata = current_app.extensions["migrate"].db.metadata
+
+
+def run_migrations_offline() -> None:
+    url = config.get_main_option("sqlalchemy.url")
+    if not url:
+        url = str(current_app.extensions["migrate"].db.engine.url)
+    context.configure(
+        url=url,
+        target_metadata=target_metadata,
+        literal_binds=True,
+        dialect_opts={"paramstyle": "named"},
+    )
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online() -> None:
+    connectable = current_app.extensions["migrate"].db.engine
+
+    with connectable.connect() as connection:
+        context.configure(
+            connection=connection,
+            target_metadata=target_metadata,
+            compare_type=True,
+        )
+
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()
+

--- a/migrations/script.py.mako
+++ b/migrations/script.py.mako
@@ -1,0 +1,18 @@
+"""${message}
+
+Revision ID: ${up_revision}
+Revises: ${down_revision | comma,n}
+Create Date: ${create_date}
+"""
+from alembic import op
+import sqlalchemy as sa
+${imports if imports else ""}
+
+
+def upgrade() -> None:
+    ${upgrades if upgrades else "pass"}
+
+
+def downgrade() -> None:
+    ${downgrades if downgrades else "pass"}
+

--- a/migrations/versions/0001_create_users_table.py
+++ b/migrations/versions/0001_create_users_table.py
@@ -1,0 +1,37 @@
+"""create users table
+
+Revision ID: 0001
+Revises: 
+Create Date: 2024-06-03 00:00:00.000000
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "0001"
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "users",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("email", sa.String(), nullable=False),
+        sa.Column("name", sa.String(), nullable=True),
+        sa.Column("is_kt_admin", sa.Boolean(), nullable=True),
+        sa.Column("is_kt_crm", sa.Boolean(), nullable=True),
+        sa.Column("is_kt_delivery", sa.Boolean(), nullable=True),
+        sa.Column("is_kt_contractor", sa.Boolean(), nullable=True),
+        sa.Column("is_kt_staff", sa.Boolean(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), server_default=sa.text("now()")),
+    )
+    op.create_index("ix_users_email", "users", ["email"], unique=True)
+
+
+def downgrade() -> None:
+    op.drop_index("ix_users_email", table_name="users")
+    op.drop_table("users")
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,6 @@ Flask==3.0.3
 gunicorn==22.0.0
 SQLAlchemy==2.0.29
 psycopg2-binary==2.9.9
+Flask-SQLAlchemy==3.1.1
+Flask-Migrate==4.0.5
+alembic==1.13.1


### PR DESCRIPTION
## Summary
- integrate Flask-Migrate and Flask-SQLAlchemy into app
- add manual seeding guarded by table existence
- initialize Alembic environment and initial users migration

## Testing
- `pytest`
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement Flask-SQLAlchemy==3.1.1)*

------
https://chatgpt.com/codex/tasks/task_e_68a4222738b8832eb18d0e61218277fe