### PR TITLE
Ensure admin seed only when users table empty

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -65,17 +65,18 @@ class User(db.Model):
 
 
 def seed_initial_user() -> None:
+    """Seed an initial admin user if the users table is empty."""
     inspector = db.inspect(db.engine)
     if not inspector.has_table(User.__tablename__):
+        return
+
+    # Only seed when no users exist yet
+    if db.session.query(User).count() > 0:
         return
 
     first_admin_email = os.getenv(
         "FIRST_ADMIN_EMAIL", "cackermann@kepner-tregoe.com"
     ).lower()
-    exists = db.session.query(User).filter_by(email=first_admin_email).first()
-    if exists:
-        return
-
     admin = User(
         email=first_admin_email,
         name=first_admin_email,

--- a/manage.py
+++ b/manage.py
@@ -1,3 +1,5 @@
+"""Flask CLI entry point for migration commands."""
+
 from app.app import create_app, db  # noqa: F401
 
 app = create_app()


### PR DESCRIPTION
## Summary
- Seed initial admin user only when the users table exists and is empty
- Add descriptive docstring for manage CLI entry point

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a424cc3fa0832e93627ef4f5bb4015