### PR TITLE
Initialize migrations environment with Flask-Migrate

### DIFF
--- a/migrations/versions/0001_create_users_table.py
+++ b/migrations/versions/0001_create_users_table.py
@@ -26,7 +26,7 @@ def upgrade() -> None:
         sa.Column("is_kt_delivery", sa.Boolean(), nullable=True),
         sa.Column("is_kt_contractor", sa.Boolean(), nullable=True),
         sa.Column("is_kt_staff", sa.Boolean(), nullable=True),
-        sa.Column("created_at", sa.DateTime(), server_default=sa.text("now()")),
+        sa.Column("created_at", sa.DateTime(), server_default=sa.func.now()),
     )
     op.create_index("ix_users_email", "users", ["email"], unique=True)
 


### PR DESCRIPTION
## Summary
- ensure initial migration's timestamp uses SQLAlchemy func.now() for portability
- run `flask db upgrade` to create the `users` table

## Testing
- `FLASK_APP=manage.py DATABASE_URL=sqlite:///app.db flask db upgrade`
- `DATABASE_URL=sqlite:///app.db python - <<'PY'
from app.app import create_app
app = create_app()
with app.test_client() as c:
    resp = c.get('/healthz')
    print(resp.status_code, resp.json)
PY`

------
https://chatgpt.com/codex/tasks/task_e_68a42665a1a4832ebe3dfbfcbb53eefa