### PR TITLE
Add Flask-Migrate setup and initial migration

### DIFF
--- a/alembic.ini
+++ b/alembic.ini
@@ -1,0 +1,40 @@
+[alembic]
+script_location = migrations
+prepend_sys_path = .
+
+sqlalchemy.url =
+
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+qualname =
+
+[logger_sqlalchemy]
+level = WARN
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s
+datefmt = %H:%M:%S
+

--- a/app/app.py
+++ b/app/app.py
@@ -2,12 +2,10 @@ import os
 
 from flask import Flask, jsonify
 from flask_sqlalchemy import SQLAlchemy
-from flask_migrate import Migrate
 from sqlalchemy.orm import validates
 
 
 db = SQLAlchemy()
-migrate = Migrate()
 
 
 def create_app():
@@ -26,7 +24,6 @@ def create_app():
     app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
 
     db.init_app(app)
-    migrate.init_app(app, db)
 
     @app.get("/healthz")
     def healthz():  # pragma: no cover - simple healthcheck

--- a/manage.py
+++ b/manage.py
@@ -1,6 +1,9 @@
 """Flask CLI entry point for migration commands."""
 
-from app.app import create_app, db  # noqa: F401
+from flask_migrate import Migrate
+
+from app.app import create_app, db
 
 app = create_app()
+migrate = Migrate(app, db)
 


### PR DESCRIPTION
## Summary
- configure Flask CLI entry point with Flask-Migrate
- remove inline migration setup from application factory
- provide Alembic configuration at repository root

## Testing
- `DATABASE_URL=sqlite:///test.db flask --app manage.py db upgrade`
- `DATABASE_URL=sqlite:///test.db python - <<'PY'
import manage
from app.app import db, User
with manage.app.app_context():
    print('count', db.session.query(User).count())
    for u in db.session.query(User).all():
        print(u.email)
PY`

------
https://chatgpt.com/codex/tasks/task_e_68a4280488d4832e8893e19e36fe47fb