### PR TITLE
Include manage CLI and migrations in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends build-essential
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 COPY app ./app
-ENV PORT=8000
+COPY manage.py ./
+COPY migrations ./migrations
+ENV PORT=8000 FLASK_APP=manage.py
 EXPOSE 8000
 CMD ["gunicorn", "-w", "2", "-k", "gthread", "-b", "0.0.0.0:8000", "app.app:app"]


### PR DESCRIPTION
## Summary
- copy manage.py and migrations into container image
- configure FLASK_APP for flask CLI so `flask db` commands work

## Testing
- `python -m py_compile manage.py app/app.py`
- `docker compose build app` *(fails: command not found)*
- `flask --app manage.py db --help` *(fails: could not translate host name "db" to address)*

------
https://chatgpt.com/codex/tasks/task_e_68a42f30b9d4832eb2aa38011f805ae0