### PR TITLE
Add magic-link authentication and session management

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -1,7 +1,19 @@
 import os
+import smtplib
+from email.message import EmailMessage
+from functools import wraps
 
-from flask import Flask, jsonify
+from flask import (
+    Flask,
+    jsonify,
+    redirect,
+    render_template,
+    request,
+    session,
+    url_for,
+)
 from flask_sqlalchemy import SQLAlchemy
+from itsdangerous import BadSignature, SignatureExpired, URLSafeTimedSerializer
 from sqlalchemy.orm import validates
 
 
@@ -9,7 +21,8 @@ db = SQLAlchemy()
 
 
 def create_app():
-    app = Flask(__name__)
+    app = Flask(__name__, template_folder="templates")
+    app.secret_key = os.getenv("SECRET_KEY", "dev")
 
     DB_USER = os.getenv("DB_USER", "cbs")
     DB_PASSWORD = os.getenv("POSTGRES_PASSWORD", "postgres")
@@ -25,6 +38,8 @@ def create_app():
 
     db.init_app(app)
 
+    serializer = URLSafeTimedSerializer(app.secret_key)
+
     @app.get("/healthz")
     def healthz():  # pragma: no cover - simple healthcheck
         count = 0
@@ -36,6 +51,76 @@ def create_app():
     @app.get("/")
     def index():  # pragma: no cover - trivial route
         return "CBS minimal stack is running. Visit /healthz for JSON.", 200
+
+    def send_magic_link(email: str, link: str) -> None:
+        smtp_vars = [
+            os.getenv("SMTP_HOST"),
+            os.getenv("SMTP_PORT"),
+            os.getenv("SMTP_USER"),
+            os.getenv("SMTP_PASS"),
+            os.getenv("SMTP_FROM"),
+            os.getenv("SMTP_FROM_NAME"),
+        ]
+        if all(smtp_vars):
+            host, port, user, pwd, sender, sender_name = smtp_vars
+            msg = EmailMessage()
+            msg["Subject"] = "Your login link"
+            msg["From"] = f"{sender_name} <{sender}>"
+            msg["To"] = email
+            msg.set_content(f"Click to sign in: {link}")
+            with smtplib.SMTP(host, int(port)) as s:
+                s.starttls()
+                s.login(user, pwd)
+                s.send_message(msg)
+        else:  # pragma: no cover - depends on environment
+            print(f"[MAGIC-LINK] {link}")
+
+    def login_required(fn):
+        @wraps(fn)
+        def wrapper(*args, **kwargs):
+            if "user_id" not in session:
+                return redirect(url_for("login"))
+            return fn(*args, **kwargs)
+
+        return wrapper
+
+    @app.route("/login", methods=["GET", "POST"])
+    def login():
+        if request.method == "POST":
+            email = request.form.get("email", "").lower()
+            user = User.query.filter_by(email=email).first()
+            if user:
+                token = serializer.dumps(email, salt="magic-link")
+                link = url_for("magic", token=token, _external=True)
+                send_magic_link(email, link)
+            return render_template("login.html", sent=True)
+        return render_template("login.html")
+
+    @app.get("/magic")
+    def magic():
+        token = request.args.get("token")
+        if not token:
+            return redirect(url_for("login"))
+        try:
+            email = serializer.loads(token, salt="magic-link", max_age=1200)
+        except (BadSignature, SignatureExpired):
+            return redirect(url_for("login"))
+        user = User.query.filter_by(email=email).first()
+        if not user:
+            return redirect(url_for("login"))
+        session["user_id"] = user.id
+        session["user_email"] = user.email
+        return redirect(url_for("dashboard"))
+
+    @app.get("/logout")
+    def logout():
+        session.clear()
+        return redirect(url_for("login"))
+
+    @app.get("/dashboard")
+    @login_required
+    def dashboard():
+        return render_template("dashboard.html", email=session.get("user_email"))
 
     with app.app_context():
         seed_initial_user()

--- a/app/templates/dashboard.html
+++ b/app/templates/dashboard.html
@@ -1,0 +1,4 @@
+<!doctype html>
+<title>Dashboard</title>
+<p>Welcome, {{ email }}</p>
+<a href="{{ url_for('logout') }}">Logout</a>

--- a/app/templates/login.html
+++ b/app/templates/login.html
@@ -1,0 +1,7 @@
+<!doctype html>
+<title>Login</title>
+{% if sent %}<p>Check your email for a login link.</p>{% endif %}
+<form method="post">
+  <input type="email" name="email" placeholder="Email" required>
+  <button type="submit">Email me a link</button>
+</form>


### PR DESCRIPTION
## Summary
- implement email-based magic-link login flow
- add dashboard and logout routes with session protection
- log magic-link to stdout when SMTP is not configured

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a46aed10c4832ea0a60a57df5dc875