### PR TITLE
Add password authentication and settings

### DIFF
--- a/app/templates/dashboard.html
+++ b/app/templates/dashboard.html
@@ -1,4 +1,10 @@
 <!doctype html>
 <title>Dashboard</title>
+{% with messages = get_flashed_messages() %}
+  {% for message in messages %}
+    <p>{{ message }}</p>
+  {% endfor %}
+{% endwith %}
 <p>Welcome, {{ email }}</p>
+<a href="{{ url_for('settings_password') }}">Set password</a>
 <a href="{{ url_for('logout') }}">Logout</a>

--- a/app/templates/login.html
+++ b/app/templates/login.html
@@ -1,7 +1,10 @@
 <!doctype html>
 <title>Login</title>
+{% if error %}<p>{{ error }}</p>{% endif %}
 {% if sent %}<p>Check your email for a login link.</p>{% endif %}
 <form method="post">
   <input type="email" name="email" placeholder="Email" required>
-  <button type="submit">Email me a link</button>
+  <input type="password" name="password" placeholder="Password">
+  <button type="submit" name="action" value="password">Sign in</button>
+  <button type="submit" name="action" value="magic">Email me a link</button>
 </form>

--- a/app/templates/password.html
+++ b/app/templates/password.html
@@ -1,0 +1,7 @@
+<!doctype html>
+<title>Set Password</title>
+{% if error %}<p>{{ error }}</p>{% endif %}
+<form method="post">
+  <input type="password" name="password" placeholder="New password" required>
+  <button type="submit">Save</button>
+</form>

--- a/migrations/versions/0002_add_password_hash.py
+++ b/migrations/versions/0002_add_password_hash.py
@@ -1,0 +1,26 @@
+"""add password_hash column
+
+Revision ID: 0002
+Revises: 0001
+Create Date: 2024-06-03 00:00:01.000000
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "0002"
+down_revision = "0001"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "users",
+        sa.Column("password_hash", sa.String(length=255), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("users", "password_hash")

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,5 @@ psycopg2-binary==2.9.9
 Flask-SQLAlchemy==3.1.1
 Flask-Migrate==4.0.5
 alembic==1.13.1
+passlib[bcrypt]==1.7.4
+email-validator==2.1.1


### PR DESCRIPTION
## Summary
- support password-based login alongside magic links
- allow authenticated users to set or update passwords
- add bcrypt hashing, email validation, and database migration

## Testing
- ⚠️ `pip install -r requirements.txt` (fails: Could not find a version that satisfies the requirement passlib==1.7.4)
- ✅ `pytest` (no tests ran)


------
https://chatgpt.com/codex/tasks/task_e_68a46da901ac832e802e2ec7d354fa56