### PR TITLE
Add mail settings UI and SMTP scaffold

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -21,17 +21,19 @@
 
 ## 2. Email and Notifications
 2.1 Wire SMTP using Microsoft 365 auth account (authenticate as `ktbooks@kepner-tregoe.com`)  
-2.2 Outbound From address mapping in Settings:  
+2.2 Outbound From address mapping in Settings: [UI + scaffold DONE]  
  • Prework emails From = configurable (default `certificates@kepner-tregoe.com`)  
  • Certificates and badges emails From = configurable (default `certificates@kepner-tregoe.com`)  
  • Client session setup emails From = configurable (default `certificates@kepner-tregoe.com`)  
-2.3 If SMTP env is missing, do not fail; log the composed message with a `[MAIL-OUT]` prefix  
+2.3 If SMTP env is missing, do not fail; log the composed message with a `[MAIL-OUT]` prefix [DONE]  
 2.4 Message templates stored in DB with simple placeholders (name, session, date)  
 2.5 Test mail endpoint in Settings to send a one‑off test to an address  
 2.6 Delivery logging table (to, subject, status, error text)
 
 Environment variables (reference only, do not hardcode secrets in repo):  
 `SMTP_HOST`, `SMTP_PORT`, `SMTP_USER` (auth account), `SMTP_PASS` (secret), `SMTP_FROM_DEFAULT`, `SMTP_FROM_NAME`
+
+Note: If SMTP env vars are missing, composed mails are logged with a [MAIL-OUT] prefix
 
 ## 3. Session Management (with client self‑service)
 3.1 Create Session form (staff only): title, code, start date, end date, timezone, location, delivery type, facilitator(s)  
@@ -73,7 +75,7 @@ Environment variables (reference only, do not hardcode secrets in repo):
 
 ## 7. Settings (Application Admin only)
 7.1 Settings landing page visible only to Application Admin (see Roles in section 11)  
-7.2 Mail Settings page:  
+7.2 Mail Settings page: [UI + scaffold DONE]  
  • Display and edit From address mapping per category (prework, certs and badges, client session setup)  
  • Read SMTP host, port, auth user from environment; allow test send only  
  • Never display or store SMTP password in DB; it is provided via environment/secret  

--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
 CBS bootstrap. Health endpoint at /healthz. Stack: Flask, Caddy, Postgres. Deployed on cbs.ktapps.net.
+
+## Mail setup
+
+Environment variables:
+
+- SMTP_HOST
+- SMTP_PORT (default 587)
+- SMTP_USER
+- SMTP_PASS
+- SMTP_FROM_DEFAULT
+- SMTP_FROM_NAME
+
+Authenticate as ktbooks@kepner-tregoe.com; default From is certificates@kepner-tregoe.com via settings.

--- a/app/emailer.py
+++ b/app/emailer.py
@@ -1,0 +1,41 @@
+import os
+import smtplib
+from email.message import EmailMessage
+
+from .app import db, AppSetting
+
+
+def get_from_for(category: str) -> str:
+    try:
+        setting = db.session.get(AppSetting, f"mail.from.{category}")
+    except Exception:
+        setting = None
+    if setting:
+        return setting.value
+    return os.getenv("SMTP_FROM_DEFAULT", "certificates@kepner-tregoe.com")
+
+
+def send_mail(to_email: str, subject: str, text_body: str, category: str = "certificates"):
+    resolved_from = get_from_for(category)
+    host = os.getenv("SMTP_HOST")
+    port = os.getenv("SMTP_PORT", "587")
+    user = os.getenv("SMTP_USER")
+    pwd = os.getenv("SMTP_PASS")
+    if not all([host, port, user, pwd]):
+        snippet = text_body[:120].replace("\n", " ")
+        print(f'[MAIL-OUT] to={to_email} from={resolved_from} subject="{subject}" body="{snippet}"')
+        return {"mock": True}
+    msg = EmailMessage()
+    from_name = os.getenv("SMTP_FROM_NAME")
+    if from_name:
+        msg["From"] = f"{from_name} <{resolved_from}>"
+    else:
+        msg["From"] = resolved_from
+    msg["To"] = to_email
+    msg["Subject"] = subject
+    msg.set_content(text_body)
+    with smtplib.SMTP(host, int(port)) as s:
+        s.starttls()
+        s.login(user, pwd)
+        s.send_message(msg)
+    return {"sent": True}

--- a/app/settings_bp.py
+++ b/app/settings_bp.py
@@ -1,0 +1,62 @@
+from functools import wraps
+
+from flask import Blueprint, flash, redirect, render_template, request, session, url_for
+
+from .app import db, AppSetting, User
+
+bp = Blueprint('settings', __name__, url_prefix='/settings')
+
+
+def require_app_admin(fn):
+    @wraps(fn)
+    def wrapper(*args, **kwargs):
+        user_id = session.get('user_id')
+        if not user_id:
+            return redirect(url_for('login'))
+        user = db.session.get(User, user_id)
+        if not user or not user.is_kt_admin:
+            return redirect(url_for('dashboard'))
+        return fn(*args, **kwargs)
+
+    return wrapper
+
+
+@bp.get('/')
+@require_app_admin
+def index():
+    return render_template('settings/index.html')
+
+
+@bp.route('/mail', methods=['GET', 'POST'])
+@require_app_admin
+def mail_settings():
+    from . import emailer
+    categories = ['prework', 'certificates', 'clientsetup']
+    if request.method == 'POST':
+        for cat in categories:
+            key = f'mail.from.{cat}'
+            val = request.form.get(cat, '')
+            setting = db.session.get(AppSetting, key)
+            if setting:
+                setting.value = val
+            else:
+                db.session.add(AppSetting(key=key, value=val))
+        db.session.commit()
+        flash('Saved')
+        return redirect(url_for('settings.mail_settings'))
+    values = {cat: emailer.get_from_for(cat) for cat in categories}
+    return render_template('settings/mail.html', values=values)
+
+
+@bp.post('/mail/test')
+@require_app_admin
+def mail_test():
+    from . import emailer
+    to_email = request.form.get('test_email', '')
+    category = request.form.get('test_category', 'certificates')
+    result = emailer.send_mail(to_email, 'Test Email', 'This is a test message', category=category)
+    if result.get('sent'):
+        flash('Email sent')
+    else:
+        flash('Logged email to stdout')
+    return redirect(url_for('settings.mail_settings'))

--- a/app/templates/dashboard.html
+++ b/app/templates/dashboard.html
@@ -5,6 +5,5 @@
     <p>{{ message }}</p>
   {% endfor %}
 {% endwith %}
+{% include 'nav.html' %}
 <p>Welcome, {{ email }}</p>
-<a href="{{ url_for('settings_password') }}">Set password</a>
-<a href="{{ url_for('logout') }}">Logout</a>

--- a/app/templates/nav.html
+++ b/app/templates/nav.html
@@ -1,0 +1,8 @@
+<nav>
+  <a href="{{ url_for('dashboard') }}">Dashboard</a>
+  <a href="{{ url_for('settings_password') }}">Set password</a>
+  {% if current_user and current_user.is_kt_admin %}
+  <a href="{{ url_for('settings.index') }}">Settings</a>
+  {% endif %}
+  <a href="{{ url_for('logout') }}">Logout</a>
+</nav>

--- a/app/templates/password.html
+++ b/app/templates/password.html
@@ -1,5 +1,6 @@
 <!doctype html>
 <title>Set Password</title>
+{% include 'nav.html' %}
 {% if error %}<p>{{ error }}</p>{% endif %}
 <form method="post">
   <input type="password" name="password" placeholder="New password" required>

--- a/app/templates/settings/index.html
+++ b/app/templates/settings/index.html
@@ -1,0 +1,6 @@
+<!doctype html>
+<title>Settings</title>
+{% include 'nav.html' %}
+<ul>
+  <li><a href="{{ url_for('settings.mail_settings') }}">Mail Settings</a></li>
+</ul>

--- a/app/templates/settings/mail.html
+++ b/app/templates/settings/mail.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<title>Mail Settings</title>
+{% with messages = get_flashed_messages() %}
+  {% for message in messages %}
+    <p>{{ message }}</p>
+  {% endfor %}
+{% endwith %}
+{% include 'nav.html' %}
+<form method="post">
+  <label>Prework From</label>
+  <input type="email" name="prework" value="{{ values.prework }}">
+  <label>Certificates From</label>
+  <input type="email" name="certificates" value="{{ values.certificates }}">
+  <label>Client Setup From</label>
+  <input type="email" name="clientsetup" value="{{ values.clientsetup }}">
+  <button type="submit">Save</button>
+</form>
+<h2>Test Send</h2>
+<form method="post" action="{{ url_for('settings.mail_test') }}">
+  <input type="email" name="test_email" placeholder="Recipient email">
+  <select name="test_category">
+    <option value="prework">prework</option>
+    <option value="certificates">certificates</option>
+    <option value="clientsetup">clientsetup</option>
+  </select>
+  <button type="submit">Send Test</button>
+</form>

--- a/migrations/versions/0003_create_app_settings_table.py
+++ b/migrations/versions/0003_create_app_settings_table.py
@@ -1,0 +1,42 @@
+"""create app_settings table
+
+Revision ID: 0003_create_app_settings_table
+Revises: 0002_add_password_hash
+Create Date: 2024-05-25
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '0003_create_app_settings_table'
+down_revision = '0002_add_password_hash'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        'app_settings',
+        sa.Column('key', sa.String(length=120), primary_key=True),
+        sa.Column('value', sa.Text(), nullable=False),
+        sa.Column('updated_at', sa.DateTime(), server_default=sa.func.now()),
+    )
+    app_settings = sa.table(
+        'app_settings',
+        sa.column('key', sa.String()),
+        sa.column('value', sa.Text()),
+    )
+    op.bulk_insert(
+        app_settings,
+        [
+            {'key': 'mail.from.prework', 'value': 'certificates@kepner-tregoe.com'},
+            {'key': 'mail.from.certificates', 'value': 'certificates@kepner-tregoe.com'},
+            {'key': 'mail.from.clientsetup', 'value': 'certificates@kepner-tregoe.com'},
+        ],
+    )
+
+
+def downgrade():
+    op.drop_table('app_settings')


### PR DESCRIPTION
## Summary
- Add `app_settings` table with seeded mail From defaults
- Scaffold SMTP sender with environment fallback and `[MAIL-OUT]` logging
- Introduce admin-only Settings pages for mail configuration and test send

## Testing
- `python -m py_compile app/app.py app/emailer.py app/settings_bp.py migrations/versions/0003_create_app_settings_table.py`
- `flask --app manage.py db upgrade` *(fails: revision map error)*
- `DATABASE_URL=sqlite:// python - <<'PY' ... send_mail ... PY`

------
https://chatgpt.com/codex/tasks/task_e_68a4940d73a4832e80c6a0991fa89568