### PR TITLE
docs: record diagnostics for admin test mail

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -163,3 +163,8 @@ Context items 2.1–2.3 and 7.2 noted as UI + backend working; real SMTP depends
 Fixed seed migration to upsert SMTP defaults using a bound connection
 Added helpers to read and write app_settings with safe upserts
 Mail Settings page saves without 500s and emailer pulls SMTP/From values from settings with env fallback
+## Diagnostics 2025-08-19
+- Route exists: admin_test_mail GET /admin/test-mail
+- /healthz returns 200 OK
+- Unauthenticated curl showed no headers, likely redirect to login
+- Next step: confirm HTTP status with verbose curl and follow redirects; verify admin-only access with a logged-in request


### PR DESCRIPTION
## Summary
- record diagnostics for `/admin/test-mail` and related auth

## Testing
- `python manage.py routes` *(fails: could not translate host name "db" to address)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a4cb04f2a0832eb0f098f6fd2be9b6