### PR TITLE
Log mailer output and report test-mail results

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -91,6 +91,8 @@ Note: SMTP env surfaced in UI (read-only), emailer defaults and mock logging in 
 7.2 Mail settings form save/reload [DONE]
 7.3 Emailer env fallback and safe stub [DONE]
 7.4 Test send route and log proof [DONE]
+    • Mailer logs [MAIL-OUT] lines to stdout and test route logs its result.
+    • Example: `docker compose logs app | grep '\[MAIL-OUT\]'`
 Note: Settings row is singleton id=1 with env fallback on first load
 
 ## 8. Salesforce Integration (later phase)
@@ -163,6 +165,8 @@ Context items 2.1–2.3 and 7.2 noted as UI + backend working; real SMTP depends
 Fixed seed migration to upsert SMTP defaults using a bound connection
 Added helpers to read and write app_settings with safe upserts
 Mail Settings page saves without 500s and emailer pulls SMTP/From values from settings with env fallback
+## Latest update done by codex 09/30/2025
+Mailer logs [MAIL-OUT] lines to stdout and /admin/test-mail logs route results for easier debugging
 ## Diagnostics 2025-08-19
 - Route exists: admin_test_mail GET /admin/test-mail
 - /healthz returns 200 OK

--- a/app/app.py
+++ b/app/app.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import smtplib
 from email.message import EmailMessage
@@ -214,12 +215,16 @@ def create_app():
     @admin_required
     def admin_test_mail():
         from . import emailer
+        mailer_logger = logging.getLogger("cbs.mailer")
 
         current_user = db.session.get(User, session.get("user_id"))
         result = emailer.send(
             current_user.email,
             "CBS test mail",
             "This is a test from CBS",
+        )
+        mailer_logger.info(
+            f"[MAIL-OUT] route_result={result['ok']}/{result['detail']}"
         )
         return jsonify(result)
 

--- a/app/emailer.py
+++ b/app/emailer.py
@@ -1,9 +1,14 @@
 import logging
 import os
 import smtplib
+import sys
 from email.message import EmailMessage
 
 logger = logging.getLogger("cbs.mailer")
+if not logger.handlers:
+    handler = logging.StreamHandler(sys.stdout)
+    logger.addHandler(handler)
+logger.setLevel(logging.INFO)
 
 
 def send(to_addr: str, subject: str, body: str):
@@ -17,14 +22,13 @@ def send(to_addr: str, subject: str, body: str):
     mode = "real"
     if not host or not port or not from_addr:
         mode = "stub"
-        logger.info(
-            f"[MAIL-OUT] to={to_addr} subject=\"{subject}\" host={host} mode=stub"
-        )
-        return {"ok": False, "detail": "stub: missing config"}
 
     logger.info(
-        f"[MAIL-OUT] to={to_addr} subject=\"{subject}\" host={host} mode=real"
+        f"[MAIL-OUT] mode={mode} to={to_addr} subject=\"{subject}\" host={host}"
     )
+
+    if mode == "stub":
+        return {"ok": False, "detail": "stub: missing config"}
 
     try:
         with smtplib.SMTP(host, int(port)) as server:


### PR DESCRIPTION
## Summary
- ensure `cbs.mailer` logger writes to stdout and notes mode/to/subject/host on each send
- log `/admin/test-mail` result so each request leaves a `[MAIL-OUT]` trail
- document new logging behavior and how to grep for it

## Testing
- `python -m py_compile app/emailer.py app/app.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a4d2dc6750832eb1fe14300e49beb8