### PR TITLE
Fix certificate generator storage import

### DIFF
--- a/app/certgen.py
+++ b/app/certgen.py
@@ -9,7 +9,7 @@ from PyPDF2 import PdfReader, PdfWriter
 from reportlab.lib.pagesizes import A4
 from reportlab.pdfgen import canvas
 
-from utils.storage import ensure_dir, write_atomic
+from app.utils.storage import ensure_dir, write_atomic
 
 
 _MM = 72 / 25.4

--- a/app/utils/storage.py
+++ b/app/utils/storage.py
@@ -1,0 +1,21 @@
+import os
+import tempfile
+
+
+def ensure_dir(path: str) -> None:
+    """Create directory if missing (mkdir -p equivalent)."""
+    os.makedirs(path, exist_ok=True)
+
+
+def write_atomic(path: str, data, mode: str = "wb") -> None:
+    """Write data to a temporary file then atomically rename to target path."""
+    dir_path = os.path.dirname(path)
+    ensure_dir(dir_path)
+    fd, tmp_path = tempfile.mkstemp(dir=dir_path)
+    try:
+        with os.fdopen(fd, mode) as f:
+            f.write(data)
+        os.replace(tmp_path, path)
+    finally:
+        if os.path.exists(tmp_path):
+            os.remove(tmp_path)


### PR DESCRIPTION
## Summary
- Add `ensure_dir` and `write_atomic` helpers under `app.utils.storage`
- Update certificate generation to use `app.utils.storage`

## Testing
- `python -m py_compile app/certgen.py app/utils/storage.py`
- `docker compose up --build --quiet-pull` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a4e5d1ae3c832eb875df248eb6c69e