### PR TITLE
Add remaining tables from Excel and models

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -135,34 +135,39 @@ Notes: name/workshop/date placement per layout rules; uses session end date as c
 10.4 Pagination on lists (sessions, users)  
 10.5 Timezone handling for sessions
 
-## 11. Data and Security Rules
-11.1 One account per email across the entire system; enforce lower(email) unique in DB and app logic  
-11.2 Roles (boolean flags on user):  
+## 11. Database Completion
+11.1 All remaining tables from Excel added via migration [DONE]
+11.2 Idempotent guards and FK relationships documented [DONE]
+11.3 Next: wire Session Details to shipping/materials where needed
+
+## 12. Data and Security Rules
+12.1 One account per email across the entire system; enforce lower(email) unique in DB and app logic  
+12.2 Roles (boolean flags on user):  
  • Application Admin: can change Settings (section 7), manage users and roles  
  • Admin (information admin): manage sessions, participants, certificates; cannot change core Settings  
  • CRM, Delivery, Contractor, Staff as needed for access scopes  
  • Participant: access only to their own certificates  
-11.3 Staff‑only pages: `/importer`, `/cert-form`, `/issued`, `/users`  
-11.4 Learner page: `/my-certificates` shows only their own PDFs  
-11.5 Secrets policy: never commit secrets; use environment variables and GitHub secrets  
-11.6 Certificate completion date uses session end date
+12.3 Staff‑only pages: `/importer`, `/cert-form`, `/issued`, `/users`  
+12.4 Learner page: `/my-certificates` shows only their own PDFs  
+12.5 Secrets policy: never commit secrets; use environment variables and GitHub secrets  
+12.6 Certificate completion date uses session end date
 
-## 12. Current State Snapshot
-12.1 App, DB, Caddy running via Docker Compose on VPS  
-12.2 Domain: https://cbs.ktapps.net  
-12.3 Health check: `/healthz`  
-12.4 Migrations configured and working  
-12.5 Magic link login working  
-12.6 Password login working (bcrypt)  
-12.7 Admin user present: `cackermann@kepner-tregoe.com` (password set manually on VPS)  
-12.8 SMTP not yet configured in app; auth account is `ktbooks@kepner-tregoe.com` and From defaults to `certificates@kepner-tregoe.com` once wired
+## 13. Current State Snapshot
+13.1 App, DB, Caddy running via Docker Compose on VPS  
+13.2 Domain: https://cbs.ktapps.net  
+13.3 Health check: `/healthz`  
+13.4 Migrations configured and working  
+13.5 Magic link login working  
+13.6 Password login working (bcrypt)  
+13.7 Admin user present: `cackermann@kepner-tregoe.com` (password set manually on VPS)  
+13.8 SMTP not yet configured in app; auth account is `ktbooks@kepner-tregoe.com` and From defaults to `certificates@kepner-tregoe.com` once wired
 
-## 13. Reference Files in repo or project
-13.1 Process flow: `CBS Level1 Flow.pdf`  
-13.2 Import template: `SFC Participant Import Template.csv`  
-13.3 Data models: `CBS Data tables.xlsx`  
-13.4 Branding asset: `KT-KepnerTregoe-CMYK-wtag (trans).png`  
-13.5 Site map and access: `Site Map and access.xlsx`
+## 14. Reference Files in repo or project
+14.1 Process flow: `CBS Level1 Flow.pdf`  
+14.2 Import template: `SFC Participant Import Template.csv`  
+14.3 Data models: `CBS Data tables.xlsx`  
+14.4 Branding asset: `KT-KepnerTregoe-CMYK-wtag (trans).png`  
+14.5 Site map and access: `Site Map and access.xlsx`
 
 
 ## Latest update done by codex 08/19/2025 11:24 EST

--- a/app/models.py
+++ b/app/models.py
@@ -109,3 +109,80 @@ class Certificate(db.Model):
     workshop_date = db.Column(db.Date)
     pdf_path = db.Column(db.String(255))
     issued_at = db.Column(db.DateTime, server_default=db.func.now())
+
+
+class MaterialType(db.Model):
+    __tablename__ = "material_types"
+    id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.String(100), unique=True, nullable=False)
+
+
+class Material(db.Model):
+    __tablename__ = "materials"
+    id = db.Column(db.Integer, primary_key=True)
+    material_type_id = db.Column(
+        db.Integer, db.ForeignKey("material_types.id", ondelete="SET NULL")
+    )
+    name = db.Column(db.String(255), nullable=False)
+    description = db.Column(db.Text)
+
+
+class SessionShipping(db.Model):
+    __tablename__ = "session_shipping"
+    id = db.Column(db.Integer, primary_key=True)
+    session_id = db.Column(db.Integer, db.ForeignKey("sessions.id", ondelete="CASCADE"))
+    created_by = db.Column(db.Integer, db.ForeignKey("users.id", ondelete="SET NULL"))
+    contact_name = db.Column(db.String(255))
+    contact_phone = db.Column(db.String(50))
+    contact_email = db.Column(db.String(255))
+    address_line1 = db.Column(db.String(255))
+    address_line2 = db.Column(db.String(255))
+    city = db.Column(db.String(255))
+    state = db.Column(db.String(255))
+    postal_code = db.Column(db.String(50))
+    country = db.Column(db.String(100))
+    courier = db.Column(db.String(255))
+    tracking = db.Column(db.String(255))
+    ship_date = db.Column(db.Date)
+    special_instructions = db.Column(db.Text)
+    created_at = db.Column(db.DateTime, server_default=db.func.now())
+
+
+class SessionShippingItem(db.Model):
+    __tablename__ = "session_shipping_items"
+    id = db.Column(db.Integer, primary_key=True)
+    session_shipping_id = db.Column(
+        db.Integer, db.ForeignKey("session_shipping.id", ondelete="CASCADE")
+    )
+    material_id = db.Column(
+        db.Integer, db.ForeignKey("materials.id", ondelete="SET NULL")
+    )
+    quantity = db.Column(db.Integer, default=0)
+    notes = db.Column(db.Text)
+
+
+class Badge(db.Model):
+    __tablename__ = "badges"
+    id = db.Column(db.Integer, primary_key=True)
+    participant_id = db.Column(
+        db.Integer, db.ForeignKey("participants.id", ondelete="CASCADE")
+    )
+    name = db.Column(db.String(255), nullable=False)
+    issued_at = db.Column(db.DateTime, server_default=db.func.now())
+
+
+class AuditLog(db.Model):
+    __tablename__ = "audit_logs"
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(
+        db.Integer, db.ForeignKey("users.id", ondelete="SET NULL"), nullable=True
+    )
+    session_id = db.Column(
+        db.Integer, db.ForeignKey("sessions.id", ondelete="SET NULL"), nullable=True
+    )
+    participant_id = db.Column(
+        db.Integer, db.ForeignKey("participants.id", ondelete="SET NULL"), nullable=True
+    )
+    action = db.Column(db.String(255), nullable=False)
+    details = db.Column(db.Text)
+    created_at = db.Column(db.DateTime, server_default=db.func.now())

--- a/migrations/versions/0010_full_db_from_excel.py
+++ b/migrations/versions/0010_full_db_from_excel.py
@@ -1,0 +1,164 @@
+"""add remaining tables from Excel"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0010_full_db_from_excel"
+down_revision = "0009_core_schema"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+
+    # material_types table
+    if not inspector.has_table("material_types"):
+        op.create_table(
+            "material_types",
+            sa.Column("id", sa.Integer, primary_key=True),
+            sa.Column("name", sa.String(100), nullable=False, unique=True, comment="Material type name from Excel"),
+        )
+
+    # materials table
+    if not inspector.has_table("materials"):
+        op.create_table(
+            "materials",
+            sa.Column("id", sa.Integer, primary_key=True),
+            sa.Column("material_type_id", sa.Integer, sa.ForeignKey("material_types.id", ondelete="SET NULL")),
+            sa.Column("name", sa.String(255), nullable=False),
+            sa.Column("description", sa.Text),
+        )
+        op.create_index(
+            "ix_materials_material_type_id",
+            "materials",
+            ["material_type_id"],
+        )
+
+    # session_shipping table
+    if not inspector.has_table("session_shipping"):
+        op.create_table(
+            "session_shipping",
+            sa.Column("id", sa.Integer, primary_key=True),
+            sa.Column("session_id", sa.Integer, sa.ForeignKey("sessions.id", ondelete="CASCADE")),
+            sa.Column("created_by", sa.Integer, sa.ForeignKey("users.id", ondelete="SET NULL")),
+            sa.Column("contact_name", sa.String(255)),
+            sa.Column("contact_phone", sa.String(50)),
+            sa.Column("contact_email", sa.String(255)),
+            sa.Column("address_line1", sa.String(255)),
+            sa.Column("address_line2", sa.String(255)),
+            sa.Column("city", sa.String(255)),
+            sa.Column("state", sa.String(255)),
+            sa.Column("postal_code", sa.String(50)),
+            sa.Column("country", sa.String(100)),
+            sa.Column("courier", sa.String(255)),
+            sa.Column("tracking", sa.String(255)),
+            sa.Column("ship_date", sa.Date),
+            sa.Column("special_instructions", sa.Text),
+            sa.Column("created_at", sa.DateTime, server_default=sa.func.now()),
+        )
+        op.create_index(
+            "ix_session_shipping_session_id",
+            "session_shipping",
+            ["session_id"],
+        )
+        op.create_index(
+            "ix_session_shipping_created_by",
+            "session_shipping",
+            ["created_by"],
+        )
+
+    # session_shipping_items table
+    if not inspector.has_table("session_shipping_items"):
+        op.create_table(
+            "session_shipping_items",
+            sa.Column("id", sa.Integer, primary_key=True),
+            sa.Column("session_shipping_id", sa.Integer, sa.ForeignKey("session_shipping.id", ondelete="CASCADE")),
+            sa.Column("material_id", sa.Integer, sa.ForeignKey("materials.id", ondelete="SET NULL")),
+            sa.Column("quantity", sa.Integer, nullable=False, server_default="0"),
+            sa.Column("notes", sa.Text),
+        )
+        op.create_index(
+            "ix_session_shipping_items_session_shipping_id",
+            "session_shipping_items",
+            ["session_shipping_id"],
+        )
+        op.create_index(
+            "ix_session_shipping_items_material_id",
+            "session_shipping_items",
+            ["material_id"],
+        )
+
+    # badges table
+    if not inspector.has_table("badges"):
+        op.create_table(
+            "badges",
+            sa.Column("id", sa.Integer, primary_key=True),
+            sa.Column("participant_id", sa.Integer, sa.ForeignKey("participants.id", ondelete="CASCADE")),
+            sa.Column("name", sa.String(255), nullable=False, comment="Badge name/type"),
+            sa.Column("issued_at", sa.DateTime, server_default=sa.func.now()),
+        )
+        op.create_index(
+            "ix_badges_participant_id",
+            "badges",
+            ["participant_id"],
+        )
+
+    # audit_logs table
+    if not inspector.has_table("audit_logs"):
+        op.create_table(
+            "audit_logs",
+            sa.Column("id", sa.Integer, primary_key=True),
+            sa.Column("user_id", sa.Integer, sa.ForeignKey("users.id", ondelete="SET NULL"), nullable=True),
+            sa.Column("session_id", sa.Integer, sa.ForeignKey("sessions.id", ondelete="SET NULL"), nullable=True),
+            sa.Column("participant_id", sa.Integer, sa.ForeignKey("participants.id", ondelete="SET NULL"), nullable=True),
+            sa.Column("action", sa.String(255), nullable=False),
+            sa.Column("details", sa.Text),
+            sa.Column("created_at", sa.DateTime, server_default=sa.func.now()),
+        )
+        op.create_index(
+            "ix_audit_logs_user_id",
+            "audit_logs",
+            ["user_id"],
+        )
+        op.create_index(
+            "ix_audit_logs_session_id",
+            "audit_logs",
+            ["session_id"],
+        )
+        op.create_index(
+            "ix_audit_logs_participant_id",
+            "audit_logs",
+            ["participant_id"],
+        )
+
+    # optional seed for material_types
+    if inspector.has_table("material_types"):
+        op.execute(
+            sa.text(
+                """
+                INSERT INTO material_types (name) VALUES
+                    ('book'),
+                    ('kit'),
+                    ('badge')
+                ON CONFLICT (name) DO NOTHING
+                """
+            )
+        )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+
+    for table in [
+        "audit_logs",
+        "badges",
+        "session_shipping_items",
+        "session_shipping",
+        "materials",
+        "material_types",
+    ]:
+        if inspector.has_table(table):
+            op.drop_table(table)


### PR DESCRIPTION
## Summary
- add Alembic migration creating material_types, materials, session shipping, badges and audit log tables
- seed material_types with basic entries
- add SQLAlchemy models for new tables
- update CONTEXT.md with database completion notes

## Testing
- `flask --app manage.py db upgrade` *(fails: could not translate host name "db")*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a4f3ef0094832e95f11c635f1f67a0