### PR TITLE
Expose certificate PDFs and add staff certificates page

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -4,6 +4,9 @@ cbs.ktapps.net {
     handle_path /static/* {
         file_server
     }
+    handle_path /certificates/* {
+        file_server
+    }
     @health path /healthz
     reverse_proxy @health app:8000
     handle {

--- a/app/app.py
+++ b/app/app.py
@@ -268,10 +268,12 @@ def create_app():
     from .routes.settings_mail import bp as settings_mail_bp
     from .routes.sessions import bp as sessions_bp
     from .routes.learner import bp as learner_bp
+    from .routes.certificates import bp as certificates_bp
 
     app.register_blueprint(settings_mail_bp)
     app.register_blueprint(sessions_bp)
     app.register_blueprint(learner_bp)
+    app.register_blueprint(certificates_bp)
 
     @app.get("/verify/<int:cert_id>")
     def verify(cert_id: int):

--- a/app/routes/certificates.py
+++ b/app/routes/certificates.py
@@ -1,0 +1,11 @@
+from flask import Blueprint, render_template
+
+from .sessions import staff_required
+
+bp = Blueprint("certificates", __name__, url_prefix="/certificates")
+
+
+@bp.get("")
+@staff_required
+def index(current_user):
+    return render_template("certificates.html")

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -1,16 +1,44 @@
 <!doctype html>
-<title>{% block title %}CBS{% endblock %}</title>
+<html>
+<head>
+  <title>{% block title %}CBS{% endblock %}</title>
+  <style>
+    body {
+      margin:0;
+      font-family:"Segoe UI", Arial, sans-serif;
+      display:flex;
+      min-height:100vh;
+    }
+    .sidebar {
+      width:220px;
+      background:#f0f0f0;
+      padding:1rem;
+      flex-shrink:0;
+    }
+    .sidebar .logo {
+      max-width:100%;
+      margin-bottom:1rem;
+      display:block;
+    }
+    .sidebar a {
+      display:block;
+      margin:0.5rem 0;
+      text-decoration:none;
+      color:#4B2E83;
+    }
+    .content {
+      flex:1;
+      padding:1rem;
+    }
+  </style>
+</head>
 <body>
-<div class="sidebar">
-  {% include 'nav.html' %}
-</div>
-<div class="content">
-  {% block content %}{% endblock %}
-</div>
-<style>
-  body { margin:0; font-family:sans-serif; }
-  .sidebar { position:fixed; top:0; bottom:0; left:0; width:200px; background:#f0f0f0; padding:1rem; }
-  .content { margin-left:200px; padding:1rem; }
-  .sidebar a { display:block; margin:0.5rem 0; text-decoration:none; }
-</style>
+  <aside class="sidebar">
+    <img src="/static/kt-logo.png" alt="KT Logo" class="logo">
+    {% include 'nav.html' %}
+  </aside>
+  <main class="content">
+    {% block content %}{% endblock %}
+  </main>
 </body>
+</html>

--- a/app/templates/certificates.html
+++ b/app/templates/certificates.html
@@ -1,0 +1,7 @@
+{% extends 'base.html' %}
+
+{% block title %}Certificates{% endblock %}
+
+{% block content %}
+<h1>Certificates</h1>
+{% endblock %}

--- a/app/templates/nav.html
+++ b/app/templates/nav.html
@@ -1,9 +1,17 @@
 <nav>
   <!-- Navigation Freeze v1 -->
   <a href="{{ url_for('index') }}">Home</a>
+  {% if current_user and (
+    current_user.is_kt_admin or
+    current_user.is_kt_crm or
+    current_user.is_kt_delivery or
+    current_user.is_kt_staff
+  ) %}
   <a href="{{ url_for('sessions.list_sessions') }}">Sessions</a>
-  <a href="{{ url_for('learner.my_certs') }}">Certificates</a>
+  <a href="{{ url_for('certificates.index') }}">Certificates</a>
   <a href="/users">Users</a>
+  {% endif %}
+  <a href="{{ url_for('learner.my_certs') }}">My Certificates</a>
   {% if current_user and current_user.is_kt_admin %}
   <a href="{{ url_for('settings_mail.settings') }}">Mail Settings</a>
   {% endif %}


### PR DESCRIPTION
## Summary
- serve `/srv/certificates` at `/certificates/` in Caddy
- redesign base layout with KT branding and fixed sidebar
- add staff-only Certificates page and navigation

## Testing
- `python -m py_compile app/routes/certificates.py app/app.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a5dff570ec832ea676ddf72701ab5c