### PR TITLE
Implement user roles and admin management UI

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -42,7 +42,7 @@ The Certs and Badges System (CBS) is a standalone web application built to manag
 1.2 Password login with bcrypt hashing [DONE]  
 1.3 Logout route and session clear [DONE]  
 1.4 Password reset flow (request, email token, reset form)  
-1.5 Role based access control (RBAC) middleware for routes  
+1.5 Role based access control (RBAC) middleware for routes [DONE]
 1.6 Session persistence and timeout configuration  
 1.7 Basic audit log for logins and role changes
 
@@ -220,6 +220,10 @@ Added helpers to read and write app_settings with safe upserts
 Mail Settings page saves without 500s and emailer pulls SMTP/From values from settings with env fallback
 ## Latest update done by codex 09/30/2025
 Mailer logs [MAIL-OUT] lines to stdout and /admin/test-mail logs route results for easier debugging
+## Latest update done by codex 10/10/2025
+Introduced a dedicated User model with role flags and bcrypt helpers
+Added admin-only Users management pages with create/edit and audit logging
+Implemented app_admin_required RBAC decorator and guarded navigation link
 ## Diagnostics 2025-08-19
 - Route exists: admin_test_mail GET /admin/test-mail
 - /healthz returns 200 OK

--- a/app/routes/learner.py
+++ b/app/routes/learner.py
@@ -45,9 +45,11 @@ def download_certificate(cert_id: int):
     user_id = flask_session.get("user_id")
     user = db.session.get(User, user_id)
     if cert.user_id != user_id and not (
-        user.is_kt_admin
-        or user.is_kt_crm
+        user.is_app_admin
+        or user.is_admin
+        or user.is_kcrm
         or user.is_kt_delivery
+        or user.is_kt_contractor
         or user.is_kt_staff
     ):
         abort(403)

--- a/app/routes/sessions.py
+++ b/app/routes/sessions.py
@@ -34,9 +34,11 @@ def staff_required(fn):
             return redirect(url_for("login"))
         user = db.session.get(User, user_id)
         if not user or not (
-            user.is_kt_admin
-            or user.is_kt_crm
+            user.is_app_admin
+            or user.is_admin
+            or user.is_kcrm
             or user.is_kt_delivery
+            or user.is_kt_contractor
             or user.is_kt_staff
         ):
             abort(403)

--- a/app/routes/settings_mail.py
+++ b/app/routes/settings_mail.py
@@ -1,31 +1,18 @@
 import os
 from functools import wraps
 
-from flask import Blueprint, flash, redirect, render_template, request, session, url_for
+from flask import Blueprint, flash, redirect, render_template, request, url_for
 
-from ..app import db, User
+from ..app import db
 from ..models import Settings
+from ..utils.rbac import app_admin_required
 
 bp = Blueprint("settings_mail", __name__, url_prefix="/admin")
 
 
-def require_admin(fn):
-    @wraps(fn)
-    def wrapper(*args, **kwargs):
-        user_id = session.get("user_id")
-        if not user_id:
-            return redirect(url_for("login"))
-        user = db.session.get(User, user_id)
-        if not user or not user.is_kt_admin:
-            return redirect(url_for("dashboard"))
-        return fn(*args, **kwargs)
-
-    return wrapper
-
-
 @bp.route("/settings/mail", methods=["GET", "POST"])
-@require_admin
-def settings():
+@app_admin_required
+def settings(current_user):
     settings = Settings.get()
     if not settings:
         settings = Settings(

--- a/app/routes/users.py
+++ b/app/routes/users.py
@@ -1,0 +1,121 @@
+from flask import (
+    Blueprint,
+    abort,
+    flash,
+    redirect,
+    render_template,
+    request,
+    url_for,
+)
+
+from ..app import db, User
+from ..models import AuditLog
+from ..utils.rbac import app_admin_required
+
+
+bp = Blueprint("users", __name__, url_prefix="/users")
+
+
+def _roles_str(user: User) -> str:
+    roles: list[str] = []
+    if user.is_app_admin:
+        roles.append("app_admin")
+    if user.is_admin:
+        roles.append("admin")
+    if user.is_kcrm:
+        roles.append("kcrm")
+    if user.is_kt_delivery:
+        roles.append("kt_delivery")
+    if user.is_kt_contractor:
+        roles.append("kt_contractor")
+    if user.is_kt_staff:
+        roles.append("kt_staff")
+    return ",".join(roles)
+
+
+@bp.get("/")
+@app_admin_required
+def list_users(current_user):
+    users = User.query.order_by(User.created_at.desc()).all()
+    return render_template("users/list.html", users=users)
+
+
+@bp.get("/new")
+@app_admin_required
+def new_user(current_user):
+    return render_template("users/form.html", user=None)
+
+
+@bp.post("/new")
+@app_admin_required
+def create_user(current_user):
+    email = (request.form.get("email") or "").lower()
+    if not email:
+        flash("Email required", "error")
+        return redirect(url_for("users.new_user"))
+    if User.query.filter(db.func.lower(User.email) == email).first():
+        flash("Email already exists", "error")
+        return redirect(url_for("users.new_user"))
+    user = User(
+        email=email,
+        full_name=request.form.get("full_name"),
+        is_app_admin=bool(request.form.get("is_app_admin")),
+        is_admin=bool(request.form.get("is_admin")),
+        is_kcrm=bool(request.form.get("is_kcrm")),
+        is_kt_delivery=bool(request.form.get("is_kt_delivery")),
+        is_kt_contractor=bool(request.form.get("is_kt_contractor")),
+        is_kt_staff=bool(request.form.get("is_kt_staff")),
+    )
+    pwd = request.form.get("password") or ""
+    if pwd:
+        user.set_password(pwd)
+    db.session.add(user)
+    db.session.flush()
+    db.session.add(
+        AuditLog(
+            user_id=current_user.id,
+            action="user_create",
+            details=f"email={user.email} roles={_roles_str(user)}",
+        )
+    )
+    db.session.commit()
+    flash("User created", "success")
+    return redirect(url_for("users.list_users"))
+
+
+@bp.get("/<int:user_id>/edit")
+@app_admin_required
+def edit_user(user_id: int, current_user):
+    user = db.session.get(User, user_id)
+    if not user:
+        abort(404)
+    return render_template("users/form.html", user=user)
+
+
+@bp.post("/<int:user_id>/edit")
+@app_admin_required
+def update_user(user_id: int, current_user):
+    user = db.session.get(User, user_id)
+    if not user:
+        abort(404)
+    user.full_name = request.form.get("full_name")
+    user.is_app_admin = bool(request.form.get("is_app_admin"))
+    user.is_admin = bool(request.form.get("is_admin"))
+    user.is_kcrm = bool(request.form.get("is_kcrm"))
+    user.is_kt_delivery = bool(request.form.get("is_kt_delivery"))
+    user.is_kt_contractor = bool(request.form.get("is_kt_contractor"))
+    user.is_kt_staff = bool(request.form.get("is_kt_staff"))
+    pwd = request.form.get("password") or ""
+    if pwd:
+        user.set_password(pwd)
+    db.session.add(
+        AuditLog(
+            user_id=current_user.id,
+            action="user_update",
+            details=f"user_id={user.id} roles={_roles_str(user)}",
+        )
+    )
+    db.session.commit()
+    flash("User updated", "success")
+    return redirect(url_for("users.list_users"))
+

--- a/app/templates/nav.html
+++ b/app/templates/nav.html
@@ -2,17 +2,21 @@
   <!-- Navigation Freeze v1 -->
   <a href="{{ url_for('index') }}">Home</a>
   {% if current_user and (
-    current_user.is_kt_admin or
-    current_user.is_kt_crm or
+    current_user.is_app_admin or
+    current_user.is_admin or
+    current_user.is_kcrm or
     current_user.is_kt_delivery or
+    current_user.is_kt_contractor or
     current_user.is_kt_staff
   ) %}
   <a href="{{ url_for('sessions.list_sessions') }}">Sessions</a>
   <a href="{{ url_for('certificates.index') }}">Certificates</a>
-  <a href="/users">Users</a>
+  {% if current_user.is_app_admin %}
+  <a href="{{ url_for('users.list_users') }}">Users</a>
+  {% endif %}
   {% endif %}
   <a href="{{ url_for('learner.my_certs') }}">My Certificates</a>
-  {% if current_user and current_user.is_kt_admin %}
+  {% if current_user and current_user.is_app_admin %}
   <a href="{{ url_for('settings_mail.settings') }}">Mail Settings</a>
   {% endif %}
   <a href="{{ url_for('logout') }}">Logout</a>

--- a/app/templates/users/form.html
+++ b/app/templates/users/form.html
@@ -1,0 +1,24 @@
+{% extends 'base.html' %}
+{% block title %}{{ 'New User' if not user else 'Edit User' }}{% endblock %}
+{% block content %}
+<h1>{{ 'New User' if not user else 'Edit User' }}</h1>
+<form method="post">
+  {% if not user %}
+  <div><label>Email <input type="email" name="email" required></label></div>
+  {% else %}
+  <div><label>Email <input type="email" name="email" value="{{ user.email }}" readonly></label></div>
+  {% endif %}
+  <div><label>Full Name <input type="text" name="full_name" value="{{ user.full_name if user else '' }}"></label></div>
+  <div><label>New Password <input type="password" name="password"></label></div>
+  <div>
+    <label><input type="checkbox" name="is_app_admin" {% if user and user.is_app_admin %}checked{% endif %}> Application Admin</label><br>
+    <label><input type="checkbox" name="is_admin" {% if user and user.is_admin %}checked{% endif %}> Admin</label><br>
+    <label><input type="checkbox" name="is_kcrm" {% if user and user.is_kcrm %}checked{% endif %}> KCRM</label><br>
+    <label><input type="checkbox" name="is_kt_delivery" {% if user and user.is_kt_delivery %}checked{% endif %}> KT Delivery</label><br>
+    <label><input type="checkbox" name="is_kt_contractor" {% if user and user.is_kt_contractor %}checked{% endif %}> KT Contractor</label><br>
+    <label><input type="checkbox" name="is_kt_staff" {% if user and user.is_kt_staff %}checked{% endif %}> KT Staff</label><br>
+  </div>
+  <button type="submit">Save</button>
+</form>
+{% endblock %}
+

--- a/app/templates/users/list.html
+++ b/app/templates/users/list.html
@@ -1,0 +1,34 @@
+{% extends 'base.html' %}
+{% block title %}Users{% endblock %}
+{% block content %}
+<h1>Users</h1>
+<p><a href="{{ url_for('users.new_user') }}">New User</a></p>
+<table>
+  <tr>
+    <th>Email</th>
+    <th>Full Name</th>
+    <th>Roles</th>
+    <th>Created</th>
+    <th></th>
+  </tr>
+  {% for u in users %}
+  <tr>
+    <td>{{ u.email }}</td>
+    <td>{{ u.full_name }}</td>
+    <td>
+      {% set roles = [] %}
+      {% if u.is_app_admin %}{% set _ = roles.append('App Admin') %}{% endif %}
+      {% if u.is_admin %}{% set _ = roles.append('Admin') %}{% endif %}
+      {% if u.is_kcrm %}{% set _ = roles.append('KCRM') %}{% endif %}
+      {% if u.is_kt_delivery %}{% set _ = roles.append('KT Delivery') %}{% endif %}
+      {% if u.is_kt_contractor %}{% set _ = roles.append('KT Contractor') %}{% endif %}
+      {% if u.is_kt_staff %}{% set _ = roles.append('KT Staff') %}{% endif %}
+      {{ roles|join(', ') }}
+    </td>
+    <td>{{ u.created_at.strftime('%Y-%m-%d') if u.created_at }}</td>
+    <td><a href="{{ url_for('users.edit_user', user_id=u.id) }}">Edit</a></td>
+  </tr>
+  {% endfor %}
+</table>
+{% endblock %}
+

--- a/app/utils/rbac.py
+++ b/app/utils/rbac.py
@@ -1,0 +1,20 @@
+from functools import wraps
+
+from flask import abort, redirect, session, url_for
+
+from ..app import db, User
+
+
+def app_admin_required(fn):
+    @wraps(fn)
+    def wrapper(*args, **kwargs):
+        user_id = session.get("user_id")
+        if not user_id:
+            return redirect(url_for("login"))
+        user = db.session.get(User, user_id)
+        if not user or not user.is_app_admin:
+            abort(403)
+        return fn(*args, **kwargs, current_user=user)
+
+    return wrapper
+

--- a/migrations/versions/0011_user_roles_and_unique_email.py
+++ b/migrations/versions/0011_user_roles_and_unique_email.py
@@ -1,0 +1,75 @@
+"""ensure users table with roles and lower email unique"""
+
+from alembic import op
+
+
+revision = "0011_user_roles_and_unique_email"
+down_revision = "0010_full_db_from_excel"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute(
+        """
+        CREATE TABLE IF NOT EXISTS users (
+            id INTEGER PRIMARY KEY,
+            email VARCHAR(255) NOT NULL,
+            password_hash VARCHAR(255),
+            full_name VARCHAR(255),
+            is_app_admin BOOLEAN DEFAULT FALSE,
+            is_admin BOOLEAN DEFAULT FALSE,
+            is_kcrm BOOLEAN DEFAULT FALSE,
+            is_kt_delivery BOOLEAN DEFAULT FALSE,
+            is_kt_contractor BOOLEAN DEFAULT FALSE,
+            is_kt_staff BOOLEAN DEFAULT FALSE,
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+        )
+        """
+    )
+    op.execute(
+        "ALTER TABLE users RENAME COLUMN IF EXISTS name TO full_name"
+    )
+    op.execute(
+        "ALTER TABLE users RENAME COLUMN IF EXISTS is_kt_admin TO is_admin"
+    )
+    op.execute(
+        "ALTER TABLE users RENAME COLUMN IF EXISTS is_kt_crm TO is_kcrm"
+    )
+    op.execute(
+        "ALTER TABLE users ADD COLUMN IF NOT EXISTS password_hash VARCHAR(255)"
+    )
+    op.execute(
+        "ALTER TABLE users ADD COLUMN IF NOT EXISTS full_name VARCHAR(255)"
+    )
+    op.execute(
+        "ALTER TABLE users ADD COLUMN IF NOT EXISTS is_app_admin BOOLEAN DEFAULT FALSE"
+    )
+    op.execute(
+        "ALTER TABLE users ADD COLUMN IF NOT EXISTS is_admin BOOLEAN DEFAULT FALSE"
+    )
+    op.execute(
+        "ALTER TABLE users ADD COLUMN IF NOT EXISTS is_kcrm BOOLEAN DEFAULT FALSE"
+    )
+    op.execute(
+        "ALTER TABLE users ADD COLUMN IF NOT EXISTS is_kt_delivery BOOLEAN DEFAULT FALSE"
+    )
+    op.execute(
+        "ALTER TABLE users ADD COLUMN IF NOT EXISTS is_kt_contractor BOOLEAN DEFAULT FALSE"
+    )
+    op.execute(
+        "ALTER TABLE users ADD COLUMN IF NOT EXISTS is_kt_staff BOOLEAN DEFAULT FALSE"
+    )
+    op.execute(
+        "ALTER TABLE users ADD COLUMN IF NOT EXISTS created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP"
+    )
+    op.execute("DROP INDEX IF EXISTS ix_users_email")
+    op.execute(
+        "CREATE UNIQUE INDEX IF NOT EXISTS ix_users_email_lower ON users (lower(email))"
+    )
+
+
+def downgrade():
+    op.execute("DROP INDEX IF EXISTS ix_users_email_lower")
+    op.execute("DROP TABLE IF EXISTS users")
+


### PR DESCRIPTION
## Summary
- add dedicated `User` model with role flags, bcrypt helpers, and lowercased unique email
- create Application Admin users management views with audit logging
- require Application Admin role via shared `app_admin_required` decorator and show Users link only to authorized users

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a5ffe52634832eb33ebbcfc2f4fce2