### PR TITLE
Add session region, delivery type, and facilitator selections

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -65,7 +65,7 @@ Environment variables (reference only, do not hardcode secrets in repo):
 Note: SMTP env surfaced in UI (read-only), emailer defaults and mock logging in place. Real send depends on env on VPS.
 
 ## 3. Session Management (with client self‑service)
-3.1 Create Session form (staff only): title, Workshop Type (dropdown by Code), date-only start/end, daily start/end times, timezone, location, delivery type, language, capacity, status, sponsor, notes, simulation outline, facilitators (multi-select from KT Delivery staff); session.code derives from selected Workshop Type
+3.1 Create Session form (staff only): title, Workshop Type (dropdown labeled by Code only), date-only start/end, daily start/end times, timezone, location, delivery type (Onsite, Virtual, Self-paced, Hybrid), region (NA, EU, SEA, Other), language, capacity, status, sponsor, notes, simulation outline, facilitators (multi-select from KT Delivery or Contractor users); session.code derives from selected Workshop Type
 3.2 Materials and shipping block on the Session:  
  • Shipping contact name, phone, email  
  • Shipping address lines, city, state, postal code, country  
@@ -95,7 +95,7 @@ Note: SMTP env surfaced in UI (read-only), emailer defaults and mock logging in 
     • Name Y from bottom 145 mm, Times-Italic, autoshrink 48→32 pt, centered.
     • Workshop Y 102 mm, start 56 pt and shrink to 40 pt if needed, centered.
     • Date Y 83 mm, format “d Month YYYY”, centered using session end date.
-    • Workshop text uses Workshop Type Name when available.
+    • Workshop text always uses Workshop Type Name.
 
 ## 6. UI and Navigation
 6.1 Left‑hand menu, persistent across pages, role aware  
@@ -237,6 +237,11 @@ Implemented app_admin_required RBAC decorator and guarded navigation link
 ## Latest update done by codex 10/20/2025
 Gated initial admin seeding behind users table presence and `FLASK_SKIP_SEED`
 Marked Users table and Users admin UI as complete in context
+## Latest update done by codex 10/30/2025
+Added region field and delivery type/region dropdowns to Session forms
+Workshop Type dropdown now shows Code only; session.code derives automatically
+Facilitators selectable from Delivery or Contractor users and saved via session_facilitators
+Documented Session field changes and WorkshopType Name usage for certificates
 ## Diagnostics 2025-08-19
 - Route exists: admin_test_mail GET /admin/test-mail
 - /healthz returns 200 OK

--- a/app/models.py
+++ b/app/models.py
@@ -120,7 +120,7 @@ class Session(db.Model):
 
     id = db.Column(db.Integer, primary_key=True)
     title = db.Column(db.String(255))
-    code = db.Column(db.String(50))
+    code = db.Column(db.String(64))
     description = db.Column(db.Text)
     client_owner = db.Column(db.String(255))
     start_date = db.Column(db.Date)
@@ -130,6 +130,7 @@ class Session(db.Model):
     timezone = db.Column(db.String(64))
     location = db.Column(db.String(255))
     delivery_type = db.Column(db.String(32))
+    region = db.Column(db.String(8))
     language = db.Column(db.String(8))
     capacity = db.Column(db.Integer)
     status = db.Column(db.String(16))

--- a/app/routes/sessions.py
+++ b/app/routes/sessions.py
@@ -15,6 +15,7 @@ from flask import (
 
 from ..app import db, User
 from ..models import Participant, Session, SessionParticipant, WorkshopType, AuditLog
+from sqlalchemy import or_
 from ..utils.certificates import generate_for_session
 
 bp = Blueprint("sessions", __name__, url_prefix="/sessions")
@@ -45,7 +46,9 @@ def list_sessions(current_user):
 @staff_required
 def new_session(current_user):
     workshop_types = WorkshopType.query.order_by(WorkshopType.code).all()
-    facilitators = User.query.filter_by(is_kt_delivery=True).all()
+    facilitators = User.query.filter(
+        or_(User.is_kt_delivery == True, User.is_kt_contractor == True)
+    ).all()
     if request.method == "POST":
         wt_id = request.form.get("workshop_type_id")
         if not wt_id:
@@ -61,6 +64,7 @@ def new_session(current_user):
             timezone=request.form.get("timezone") or None,
             location=request.form.get("location") or None,
             delivery_type=request.form.get("delivery_type") or None,
+            region=request.form.get("region") or None,
             language=request.form.get("language") or None,
             capacity=request.form.get("capacity") or None,
             status=request.form.get("status") or None,
@@ -99,7 +103,9 @@ def edit_session(session_id: int, current_user):
     if not sess:
         abort(404)
     workshop_types = WorkshopType.query.order_by(WorkshopType.code).all()
-    facilitators = User.query.filter_by(is_kt_delivery=True).all()
+    facilitators = User.query.filter(
+        or_(User.is_kt_delivery == True, User.is_kt_contractor == True)
+    ).all()
     if request.method == "POST":
         wt_id = request.form.get("workshop_type_id")
         if wt_id:
@@ -112,6 +118,7 @@ def edit_session(session_id: int, current_user):
         sess.timezone = request.form.get("timezone") or None
         sess.location = request.form.get("location") or None
         sess.delivery_type = request.form.get("delivery_type") or None
+        sess.region = request.form.get("region") or None
         sess.language = request.form.get("language") or None
         sess.capacity = request.form.get("capacity") or None
         sess.status = request.form.get("status") or None

--- a/app/templates/session_detail.html
+++ b/app/templates/session_detail.html
@@ -10,6 +10,7 @@ Daily: {{ session.daily_start_time }} - {{ session.daily_end_time }}<br>
 Timezone: {{ session.timezone }}<br>
 Location: {{ session.location }}<br>
 Delivery Type: {{ session.delivery_type }}<br>
+Region: {{ session.region }}<br>
 Language: {{ session.language }}<br>
 Capacity: {{ session.capacity }}<br>
 Status: {{ session.status }}<br>

--- a/app/templates/sessions/form.html
+++ b/app/templates/sessions/form.html
@@ -8,18 +8,32 @@
     <select name="workshop_type_id" required>
       <option value="">--Select--</option>
       {% for wt in workshop_types %}
-      <option value="{{ wt.id }}" {% if session and session.workshop_type_id==wt.id %}selected{% endif %}>{{ wt.code }} — {{ wt.name }}</option>
+      <option value="{{ wt.id }}" {% if session and session.workshop_type_id==wt.id %}selected{% endif %}>{{ wt.code }}</option>
       {% endfor %}
     </select>
   </label></div>
-  <div><label>Code <input type="text" name="code" value="{{ session.code if session else '' }}" readonly></label></div>
   <div><label>Start Date <input type="date" name="start_date" value="{{ session.start_date }}"></label></div>
   <div><label>End Date <input type="date" name="end_date" value="{{ session.end_date }}"></label></div>
   <div><label>Daily Start Time <input type="time" name="daily_start_time" value="{{ session.daily_start_time }}"></label></div>
   <div><label>Daily End Time <input type="time" name="daily_end_time" value="{{ session.daily_end_time }}"></label></div>
   <div><label>Timezone <input type="text" name="timezone" value="{{ session.timezone }}"></label></div>
   <div><label>Location <input type="text" name="location" value="{{ session.location }}"></label></div>
-  <div><label>Delivery Type <input type="text" name="delivery_type" value="{{ session.delivery_type }}"></label></div>
+  <div><label>Delivery Type
+    <select name="delivery_type">
+      <option value="">--Select--</option>
+      {% for opt in ['Onsite','Virtual','Self-paced','Hybrid'] %}
+      <option value="{{ opt }}" {% if session and session.delivery_type==opt %}selected{% endif %}>{{ opt }}</option>
+      {% endfor %}
+    </select>
+  </label></div>
+  <div><label>Region
+    <select name="region">
+      <option value="">--Select--</option>
+      {% for opt in ['NA','EU','SEA','Other'] %}
+      <option value="{{ opt }}" {% if session and session.region==opt %}selected{% endif %}>{{ opt }}</option>
+      {% endfor %}
+    </select>
+  </label></div>
   <div><label>Language <input type="text" name="language" value="{{ session.language }}"></label></div>
   <div><label>Capacity <input type="number" name="capacity" value="{{ session.capacity }}"></label></div>
   <div><label>Status <input type="text" name="status" value="{{ session.status }}"></label></div>

--- a/migrations/versions/0014_sessions_fields_fix.py
+++ b/migrations/versions/0014_sessions_fields_fix.py
@@ -1,0 +1,54 @@
+from alembic import op
+import sqlalchemy as sa
+
+revision = '0014_sessions_fields_fix'
+down_revision = '0013_workshop_types_and_session_fields'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+
+    if 'sessions' in insp.get_table_names():
+        cols = {c['name'] for c in insp.get_columns('sessions')}
+        if 'daily_start_time' not in cols:
+            op.add_column('sessions', sa.Column('daily_start_time', sa.Time()))
+        if 'daily_end_time' not in cols:
+            op.add_column('sessions', sa.Column('daily_end_time', sa.Time()))
+        if 'delivery_type' not in cols:
+            op.add_column('sessions', sa.Column('delivery_type', sa.String(length=32)))
+        if 'region' not in cols:
+            op.add_column('sessions', sa.Column('region', sa.String(length=8)))
+        if 'code' in cols:
+            op.alter_column('sessions', 'code', type_=sa.String(length=64))
+
+    if 'session_facilitators' not in insp.get_table_names():
+        op.create_table(
+            'session_facilitators',
+            sa.Column('id', sa.Integer, primary_key=True),
+            sa.Column('session_id', sa.Integer, sa.ForeignKey('sessions.id', ondelete='CASCADE')),
+            sa.Column('user_id', sa.Integer, sa.ForeignKey('users.id', ondelete='CASCADE')),
+        )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+
+    if 'session_facilitators' in insp.get_table_names():
+        op.drop_table('session_facilitators')
+
+    if 'sessions' in insp.get_table_names():
+        cols = {c['name'] for c in insp.get_columns('sessions')}
+        if 'region' in cols:
+            op.drop_column('sessions', 'region')
+        if 'delivery_type' in cols:
+            op.drop_column('sessions', 'delivery_type')
+        if 'daily_end_time' in cols:
+            op.drop_column('sessions', 'daily_end_time')
+        if 'daily_start_time' in cols:
+            op.drop_column('sessions', 'daily_start_time')
+        if 'code' in cols:
+            op.alter_column('sessions', 'code', type_=sa.String(length=50))


### PR DESCRIPTION
## Summary
- Widen Session code field and add region column
- Derive session codes from WorkshopType and allow facilitator multi-select from Delivery or Contractor users
- Add idempotent migration to ensure session timing fields, delivery type, region, and facilitator table exist

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a74bd2fc74832eb36f8b572cd665ea