### PR TITLE
Introduce participant accounts and session provisioning

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -45,6 +45,10 @@ The Certs and Badges System (CBS) is a standalone web application built to manag
 1.5 Role based access control (RBAC) middleware for routes [DONE]
 1.6 Session persistence and timeout configuration  
 1.7 Basic audit log for logins and role changes
+1.8 Two login surfaces:
+    • **Users** (staff) managed in Users admin.
+    • **ParticipantAccount** (learners) auto-provisioned via sessions; not shown in Users admin.
+    One email across system; provisioning skips any email that already exists in Users.
 
 ## 2. Email and Notifications
 2.1 Wire SMTP using Microsoft 365 auth account (authenticate as `ktbooks@kepner-tregoe.com`) [UI + backend working; real SMTP depends on env on VPS.]
@@ -65,15 +69,15 @@ Environment variables (reference only, do not hardcode secrets in repo):
 Note: SMTP env surfaced in UI (read-only), emailer defaults and mock logging in place. Real send depends on env on VPS.
 
 ## 3. Session Management (with client self‑service)
-3.1 Create Session form (staff only): title, Workshop Type (dropdown labeled by Code only), date-only start/end, daily start/end times, timezone, location, delivery type (Onsite, Virtual, Self-paced, Hybrid), region (NA, EU, SEA, Other), language (dropdown, default English), capacity, status, sponsor, notes, simulation outline, lead facilitator (single select) and additional facilitators (addable selects from KT Delivery or Contractor users); session.code derives from selected Workshop Type
-3.2 Materials and shipping block on the Session:  
+3.1 Create Session form (staff only): title, Workshop Type (dropdown labeled by Code only), date-only start/end, daily start/end times, timezone, location, delivery type (Onsite, Virtual, Self-paced, Hybrid), region (NA, EU, SEA, Other), language (dropdown, default English), capacity, status, sponsor, notes, simulation outline, lead facilitator (single select) and additional facilitators (addable selects from KT Delivery or Contractor users); session.code derives from selected Workshop Type. Defaults: daily times prefill 08:00–17:00; lead facilitator removed from additional facilitator options.
+3.2 Materials and shipping block on the Session:
  • Shipping contact name, phone, email  
  • Shipping address lines, city, state, postal code, country  
  • Special instructions, courier, tracking, ship date  
  • Materials list (simple initially: item name, qty, notes)  
 3.3 Participants tab on the Session: add/remove participants, mark attendance, completion date, edit/remove entries, CSV import (FullName,Email,Title) with sample download [DONE]
-3.4 Status fields: planned, ready to ship, shipped, delivered, completed  
-3.5 Client self‑service link for a Session (tokenized URL): client can edit participant list, confirm shipping details, confirm primary contact  
+3.4 Session Status + Confirmed-Ready gate: statuses `New`, `Confirmed`, `On Hold`, `Delivered`, `Closed`, `Cancelled`. Participant accounts are provisioned when Confirmed-Ready switches on. Advanced statuses allowed only after ready; cancelling or placing on hold deactivates accounts with no other active sessions.
+3.5 Client self‑service link for a Session (tokenized URL): client can edit participant list, confirm shipping details, confirm primary contact
 3.6 Session list and filters: upcoming, past, by facilitator, by client
 
 ## 4. Participant Management
@@ -187,6 +191,7 @@ Notes: name/workshop/date placement per layout rules; uses session end date as c
 12.6 Secrets policy: never commit secrets; use environment variables and GitHub secrets
 12.7 Certificate completion date uses session end date
 12.7 Users admin UI live with audit logging [DONE]
+12.8 Participant accounts are deactivated when all their sessions are Cancelled, Closed, or On Hold; provisioning another confirmed session reactivates them.
 
 ## 13. Current State Snapshot
 13.1 App, DB, Caddy running via Docker Compose on VPS  

--- a/app/templates/session_detail.html
+++ b/app/templates/session_detail.html
@@ -14,6 +14,7 @@ Region: {{ session.region }}<br>
 Language: {{ session.language }}<br>
 Capacity: {{ session.capacity }}<br>
 Status: {{ session.status }}<br>
+Confirmed-Ready: {{ 'Yes' if session.confirmed_ready else 'No' }}<br>
 Sponsor: {{ session.sponsor }}<br>
 Notes: {{ session.notes }}<br>
 Simulation Outline: {{ session.simulation_outline }}<br>

--- a/app/templates/sessions/form.html
+++ b/app/templates/sessions/form.html
@@ -14,8 +14,8 @@
   </label></div>
   <div><label>Start Date <input type="date" name="start_date" value="{{ session.start_date }}"></label></div>
   <div><label>End Date <input type="date" name="end_date" value="{{ session.end_date }}"></label></div>
-  <div><label>Daily Start Time <input type="time" name="daily_start_time" value="{{ session.daily_start_time }}"></label></div>
-  <div><label>Daily End Time <input type="time" name="daily_end_time" value="{{ session.daily_end_time }}"></label></div>
+  <div><label>Daily Start Time <input type="time" name="daily_start_time" value="{{ session.daily_start_time if session else '08:00' }}"></label></div>
+  <div><label>Daily End Time <input type="time" name="daily_end_time" value="{{ session.daily_end_time if session else '17:00' }}"></label></div>
   <div><label>Timezone <input type="text" name="timezone" value="{{ session.timezone }}"></label></div>
   <div><label>Location <input type="text" name="location" value="{{ session.location }}"></label></div>
   <div><label>Delivery Type
@@ -42,7 +42,14 @@
     </select>
   </label></div>
   <div><label>Capacity <input type="number" name="capacity" value="{{ session.capacity }}"></label></div>
-  <div><label>Status <input type="text" name="status" value="{{ session.status }}"></label></div>
+  <div><label>Status
+    <select name="status">
+      {% for opt in STATUS_CHOICES %}
+      <option value="{{ opt }}" {% if (session and session.status==opt) or (not session and opt=='New') %}selected{% endif %}>{{ opt }}</option>
+      {% endfor %}
+    </select>
+  </label></div>
+  <div><label>Confirmed-Ready <input type="checkbox" name="confirmed_ready" value="y" {% if session and session.confirmed_ready %}checked{% endif %}></label></div>
   <div><label>Sponsor <input type="text" name="sponsor" value="{{ session.sponsor }}"></label></div>
   <div><label>Notes<br><textarea name="notes">{{ session.notes if session else '' }}</textarea></label></div>
   <div><label>Simulation Outline<br><textarea name="simulation_outline">{{ session.simulation_outline if session else '' }}</textarea></label></div>
@@ -85,6 +92,22 @@
     var select = container.querySelector('select').cloneNode(true);
     select.value='';
     container.appendChild(select);
+    refreshFacOptions();
   });
+  function refreshFacOptions(){
+    var lead = document.querySelector('select[name="lead_facilitator_id"]').value;
+    document.querySelectorAll('#additional-facilitators select').forEach(function(sel){
+      sel.querySelectorAll('option').forEach(function(opt){
+        if(opt.value === lead){
+          opt.style.display='none';
+          if(sel.value === lead){ sel.value=''; }
+        } else {
+          opt.style.display='';
+        }
+      });
+    });
+  }
+  document.querySelector('select[name="lead_facilitator_id"]').addEventListener('change', refreshFacOptions);
+  refreshFacOptions();
 </script>
 {% endblock %}

--- a/migrations/versions/0016_participant_accounts_and_session_status.py
+++ b/migrations/versions/0016_participant_accounts_and_session_status.py
@@ -1,0 +1,78 @@
+import sqlalchemy as sa
+from alembic import op
+
+revision = '0016_participant_accounts_and_session_status'
+down_revision = '0015_sessions_facilitators_language_participant_title'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+
+    if 'participant_accounts' not in insp.get_table_names():
+        op.create_table(
+            'participant_accounts',
+            sa.Column('id', sa.Integer, primary_key=True),
+            sa.Column('email', sa.String(length=255), nullable=False),
+            sa.Column('password_hash', sa.String(length=255)),
+            sa.Column('is_active', sa.Boolean, nullable=False, server_default=sa.text('true')),
+            sa.Column('last_login', sa.DateTime),
+            sa.Column('created_at', sa.DateTime, server_default=sa.func.now()),
+        )
+        op.execute(
+            "CREATE UNIQUE INDEX IF NOT EXISTS ix_participant_accounts_email_lower ON participant_accounts (LOWER(email))"
+        )
+
+    if 'participants' in insp.get_table_names():
+        cols = {c['name'] for c in insp.get_columns('participants')}
+        if 'account_id' not in cols:
+            op.add_column(
+                'participants',
+                sa.Column(
+                    'account_id',
+                    sa.Integer,
+                    sa.ForeignKey('participant_accounts.id', ondelete='SET NULL'),
+                ),
+            )
+
+    if 'sessions' in insp.get_table_names():
+        cols = {c['name']: c for c in insp.get_columns('sessions')}
+        if 'status' not in cols:
+            op.add_column(
+                'sessions',
+                sa.Column('status', sa.String(length=16), nullable=False, server_default='New'),
+            )
+        if 'confirmed_ready' not in cols:
+            op.add_column(
+                'sessions',
+                sa.Column(
+                    'confirmed_ready',
+                    sa.Boolean,
+                    nullable=False,
+                    server_default=sa.text('false'),
+                ),
+            )
+        if 'daily_start_time' in cols and not cols['daily_start_time'].get('default'):
+            op.alter_column('sessions', 'daily_start_time', server_default='08:00:00')
+        if 'daily_end_time' in cols and not cols['daily_end_time'].get('default'):
+            op.alter_column('sessions', 'daily_end_time', server_default='17:00:00')
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+
+    if 'sessions' in insp.get_table_names():
+        cols = {c['name'] for c in insp.get_columns('sessions')}
+        if 'confirmed_ready' in cols:
+            op.drop_column('sessions', 'confirmed_ready')
+        if 'status' in cols:
+            op.drop_column('sessions', 'status')
+    if 'participants' in insp.get_table_names():
+        cols = {c['name'] for c in insp.get_columns('participants')}
+        if 'account_id' in cols:
+            op.drop_column('participants', 'account_id')
+    if 'participant_accounts' in insp.get_table_names():
+        op.drop_table('participant_accounts')


### PR DESCRIPTION
## Summary
- Add dedicated ParticipantAccount model and link to Participants
- Implement session status and Confirmed-Ready gate with automatic account provisioning
- Default session times to 08:00–17:00 and prevent lead facilitator duplication

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a775cc2528832ebb558cab9e341ef9