### PR TITLE
Add settings nav and reinforce session delivered gating

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -269,3 +269,9 @@ Participant accounts provision with default password "KTRocks!" and flash summar
 - Delivered cannot be set before session End Date and forces Confirmed-Ready on.
 - Saving with Confirmed-Ready on runs provisioning, sets status to Confirmed, and flashes provisioning counts.
 - Certificate generation remains blocked until a session is marked Delivered.
+
+## Latest update done by codex 11/25/2025
+- Sign-in now lands on Home and "/dashboard" redirects to "/".
+- Left nav adds a Settings accordion for SysAdmin or Administrator with Users, Workshop Types, Clients, and Mail Settings (SysAdmin only); placeholder Certificates link removed.
+- Users list includes a Role Matrix modal.
+- Delivered cannot be set before End Date. Saving with Delivered forces Confirmed-Ready on and locks it.

--- a/app/app.py
+++ b/app/app.py
@@ -126,7 +126,7 @@ def create_app():
                 if user and user.check_password(password):
                     session["user_id"] = user.id
                     session["user_email"] = user.email
-                    return redirect(url_for("dashboard"))
+                    return redirect(url_for("index"))
                 account = ParticipantAccount.query.filter_by(email=email).first()
                 if (
                     account
@@ -170,7 +170,7 @@ def create_app():
         if user:
             session["user_id"] = user.id
             session["user_email"] = user.email
-            return redirect(url_for("dashboard"))
+            return redirect(url_for("index"))
         account = ParticipantAccount.query.filter_by(email=email).first()
         if account and account.is_active:
             session["participant_account_id"] = account.id
@@ -188,7 +188,7 @@ def create_app():
     @app.get("/dashboard")
     @login_required
     def dashboard():
-        return render_template("dashboard.html", email=session.get("user_email"))
+        return redirect(url_for("index"))
 
     @app.route("/settings/password", methods=["GET", "POST"])
     @login_required
@@ -203,7 +203,7 @@ def create_app():
                 user.set_password(password)
                 db.session.commit()
                 flash("Password updated.")
-                return redirect(url_for("dashboard"))
+                return redirect(url_for("index"))
         return render_template("password.html", error=error)
 
 

--- a/app/routes/sessions.py
+++ b/app/routes/sessions.py
@@ -82,7 +82,7 @@ def new_session(current_user):
         confirmed_ready = bool(request.form.get("confirmed_ready"))
         delivered = bool(request.form.get("delivered"))
         if delivered and end_date_val and end_date_val > date.today():
-            flash("Cannot mark Delivered before End Date. Adjust End Date.", "error")
+            flash("Cannot mark Delivered before End Date. Adjust End Date first.", "error")
             delivered = False
         if delivered and not confirmed_ready:
             flash("Delivered requires Confirmed-Ready; forcing on.", "info")
@@ -156,6 +156,8 @@ def new_session(current_user):
                 )
             )
             db.session.commit()
+        if sess.delivered:
+            flash("Session marked Delivered", "success")
         return redirect(url_for("sessions.session_detail", session_id=sess.id))
     return render_template(
         "sessions/form.html",
@@ -201,7 +203,7 @@ def edit_session(session_id: int, current_user):
         confirmed_ready = bool(request.form.get("confirmed_ready"))
         delivered = bool(request.form.get("delivered"))
         if not old_delivered and delivered and sess.end_date and sess.end_date > date.today():
-            flash("Cannot mark Delivered before End Date. Adjust End Date.", "error")
+            flash("Cannot mark Delivered before End Date. Adjust End Date first.", "error")
             delivered = False
         if delivered and not confirmed_ready:
             flash("Delivered requires Confirmed-Ready; forcing on.", "info")
@@ -264,6 +266,8 @@ def edit_session(session_id: int, current_user):
                 )
             )
             db.session.commit()
+        if delivered and not old_delivered:
+            flash("Session marked Delivered", "success")
         if sess.status in ["Cancelled", "On Hold"]:
             deactivated = deactivate_orphan_accounts_for_session(sess.id)
             if deactivated:

--- a/app/routes/settings_mail.py
+++ b/app/routes/settings_mail.py
@@ -7,10 +7,10 @@ from ..app import db
 from ..models import Settings
 from ..utils.rbac import app_admin_required
 
-bp = Blueprint("settings_mail", __name__, url_prefix="/admin")
+bp = Blueprint("settings_mail", __name__)
 
 
-@bp.route("/settings/mail", methods=["GET", "POST"])
+@bp.route("/mail-settings", methods=["GET", "POST"])
 @app_admin_required
 def settings(current_user):
     settings = Settings.get()

--- a/app/templates/nav.html
+++ b/app/templates/nav.html
@@ -3,15 +3,24 @@
   <a href="{{ url_for('index') }}">Home</a>
   {% if current_user and (current_user.is_app_admin or current_user.is_admin) %}
   <a href="{{ url_for('sessions.list_sessions') }}">Sessions</a>
-  <a href="{{ url_for('certificates.index') }}">Certificates</a>
-  <a href="{{ url_for('workshop_types.list_types') }}">Workshop Types</a>
-  {% if current_user.is_app_admin %}
-  <a href="{{ url_for('users.list_users') }}">Users</a>
-  {% endif %}
+  <details>
+    <summary>Settings</summary>
+    <ul>
+      {% if current_user.is_app_admin or current_user.is_admin %}
+      <li><a href="{{ url_for('users.list_users') }}">Users</a></li>
+      {% endif %}
+      {% if current_user.is_app_admin or current_user.is_admin %}
+      <li><a href="{{ url_for('workshop_types.list_types') }}">Workshop Types</a></li>
+      {% endif %}
+      {% if current_user.is_app_admin %}
+      <li><a href="{{ url_for('settings_mail.settings') }}">Mail Settings</a></li>
+      {% endif %}
+      {% if current_user.is_app_admin or current_user.is_admin %}
+      <li><a href="/clients">Clients</a></li>
+      {% endif %}
+    </ul>
+  </details>
   {% endif %}
   <a href="{{ url_for('learner.my_certs') }}">My Certificates</a>
-  {% if current_user and current_user.is_app_admin %}
-  <a href="{{ url_for('settings_mail.settings') }}">Mail Settings</a>
-  {% endif %}
   <a href="{{ url_for('logout') }}">Logout</a>
 </nav>

--- a/app/templates/sessions/form.html
+++ b/app/templates/sessions/form.html
@@ -52,7 +52,7 @@
       {% endfor %}
     </select>
   </label></div>
-  <div><label>Confirmed-Ready <input type="checkbox" name="confirmed_ready" value="y" {% if session and session.confirmed_ready %}checked{% endif %}></label></div>
+  <div><label>Confirmed-Ready <input type="checkbox" name="confirmed_ready" value="y" {% if session and session.confirmed_ready %}checked{% endif %} {% if session and session.delivered %}disabled{% endif %}></label></div>
   <div><label>Delivered <input type="checkbox" name="delivered" value="y" {% if session and session.delivered %}checked{% endif %}></label></div>
   <div><label>Sponsor <input type="text" name="sponsor" value="{{ session.sponsor }}"></label></div>
   <div><label>Notes<br><textarea name="notes">{{ session.notes if session else '' }}</textarea></label></div>

--- a/app/templates/users/list.html
+++ b/app/templates/users/list.html
@@ -5,7 +5,7 @@
   {% if msgs %}<ul class="flashes">{% for cat,msg in msgs %}<li class="{{cat}}">{{msg}}</li>{% endfor %}</ul>{% endif %}
 {% endwith %}
 <h1>Users</h1>
-<p><a href="{{ url_for('users.new_user') }}">New User</a></p>
+<p><a href="{{ url_for('users.new_user') }}">New User</a> | <a href="#" id="role-matrix-link">Role Matrix</a></p>
 <form method="post" action="{{ url_for('users.bulk_update') }}">
 <table>
   <tr>
@@ -31,5 +31,37 @@
 </table>
 <p><button type="submit">Save changes</button></p>
 </form>
+
+<div id="role-matrix-modal" style="display:none;position:fixed;top:0;left:0;width:100%;height:100%;background:rgba(0,0,0,0.5);">
+  <div class="modal-content" style="background:#fff;margin:10% auto;padding:1rem;max-width:800px;overflow:auto;">
+    <button id="role-matrix-close" style="float:right;">Close</button>
+    <h2>Role Matrix</h2>
+    <table border="1" cellpadding="4" cellspacing="0">
+      <tr><th>Action</th><th>SysAdmin</th><th>Administrator</th><th>CRM</th><th>KT Facilitator</th><th>Contractor</th><th>CSA*</th></tr>
+      <tr><td>System Settings (SMTP, etc)</td><td>&#10003;</td><td>&ndash;</td><td>&ndash;</td><td>&ndash;</td><td>&ndash;</td><td>&ndash;</td></tr>
+      <tr><td>Manage Users (create/edit/remove)</td><td>&#10003;</td><td>&#10003;</td><td>&ndash;</td><td>&ndash;</td><td>&ndash;</td><td>&ndash;</td></tr>
+      <tr><td>Toggle SysAdmin</td><td>&#10003;</td><td>&ndash;</td><td>&ndash;</td><td>&ndash;</td><td>&ndash;</td><td>&ndash;</td></tr>
+      <tr><td>Workshop Types CRUD</td><td>&#10003;</td><td>&#10003;</td><td>&ndash;</td><td>&ndash;</td><td>&ndash;</td><td>&ndash;</td></tr>
+      <tr><td>Clients CRUD</td><td>&#10003;</td><td>&#10003;</td><td>&ndash;</td><td>&ndash;</td><td>&ndash;</td><td>&ndash;</td></tr>
+      <tr><td>Sessions Create</td><td>&#10003;</td><td>&#10003;</td><td>&#10003;</td><td>&ndash;</td><td>&ndash;</td><td>&ndash;</td></tr>
+      <tr><td>Sessions Edit</td><td>&#10003;</td><td>&#10003;</td><td>&#10003;</td><td>&#10003;</td><td>&#10003;</td><td>&ndash;</td></tr>
+      <tr><td>Sessions Delete</td><td>&#10003;</td><td>&#10003;</td><td>&ndash;</td><td>&ndash;</td><td>&ndash;</td><td>&ndash;</td></tr>
+      <tr><td>Participants Add/Edit/Remove</td><td>&#10003;</td><td>&#10003;</td><td>&#10003;</td><td>&#10003;</td><td>&#10003;</td><td>&#10003; (assigned sessions only)</td></tr>
+      <tr><td>Confirm Delivery Complete</td><td>&#10003;</td><td>&#10003;</td><td>&#10003;</td><td>&#10003;</td><td>&#10003;</td><td>&ndash;</td></tr>
+      <tr><td>Generate Certificates**</td><td>&#10003;</td><td>&#10003;</td><td>&#10003;</td><td>&#10003;</td><td>&#10003;</td><td>&ndash;</td></tr>
+    </table>
+    <p>*CSA is per-session, assigned on the Session page.<br>**Only when “Delivered” is checked.</p>
+  </div>
+</div>
+
+<script>
+document.getElementById('role-matrix-link').addEventListener('click', function(ev){
+  ev.preventDefault();
+  document.getElementById('role-matrix-modal').style.display = 'block';
+});
+document.getElementById('role-matrix-close').addEventListener('click', function(){
+  document.getElementById('role-matrix-modal').style.display = 'none';
+});
+</script>
 {% endblock %}
 


### PR DESCRIPTION
## Summary
- Redirect sign-in to Home and keep /dashboard as a redirect
- Replace Certificates link with a role-gated Settings accordion and add Clients stub
- Add Role Matrix modal on Users page
- Prevent Delivered before session end date and force Confirmed-Ready with success flashes

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a78bfe77f4832ea1a7e73976709eb9