### PR TITLE
Add user edit logging and seed safety

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -309,3 +309,6 @@ Participant accounts provision with default password "KTRocks!" and flash summar
 - Delivered checkbox performs a pre-check and alerts “This session cannot be marked as Delivered — the workshop End Date is in the future.” when end date is in the future.
 - Users require a Region (NA/EU/SEA/Other). Admin Sessions list defaults to the admin’s region with a “Show Global Sessions” toggle, and facilitator pickers default to in-region with an “Include out-of-region facilitators” override.
 
+## Latest update done by codex 03/15/2026
+- Users Edit supports Full name + Region; Email is immutable; audit log recorded.
+

--- a/app/models.py
+++ b/app/models.py
@@ -385,3 +385,18 @@ class AuditLog(db.Model):
     action = db.Column(db.String(255), nullable=False)
     details = db.Column(db.Text)
     created_at = db.Column(db.DateTime, server_default=db.func.now())
+
+
+class UserAuditLog(db.Model):
+    __tablename__ = "user_audit_logs"
+    id = db.Column(db.Integer, primary_key=True)
+    actor_user_id = db.Column(
+        db.Integer, db.ForeignKey("users.id", ondelete="RESTRICT"), nullable=False
+    )
+    target_user_id = db.Column(
+        db.Integer, db.ForeignKey("users.id", ondelete="RESTRICT"), nullable=False
+    )
+    field = db.Column(db.String(64), nullable=False)
+    old_value = db.Column(db.String(255))
+    new_value = db.Column(db.String(255))
+    changed_at = db.Column(db.DateTime, server_default=db.func.now())

--- a/app/templates/users/edit.html
+++ b/app/templates/users/edit.html
@@ -1,0 +1,24 @@
+{% extends 'base.html' %}
+{% block title %}Edit User{% endblock %}
+{% block content %}
+{% with msgs = get_flashed_messages(with_categories=true) %}
+  {% if msgs %}<ul class="flashes">{% for cat,msg in msgs %}<li class="{{cat}}">{{msg}}</li>{% endfor %}</ul>{% endif %}
+{% endwith %}
+<h1>Edit User</h1>
+<form method="post" action="{{ url_for('users.update_user', user_id=user.id) }}">
+  <p>Email: <input type="text" name="email" value="{{ user.email }}" readonly style="background:#eee"></p>
+  <p>Full name: <input type="text" name="full_name" value="{{ user.full_name }}" maxlength="120" required autocomplete="off"></p>
+  <p>Region:
+    <select name="region" required autocomplete="off">
+      <option value="NA" {% if user.region=='NA' %}selected{% endif %}>NA</option>
+      <option value="EU" {% if user.region=='EU' %}selected{% endif %}>EU</option>
+      <option value="SEA" {% if user.region=='SEA' %}selected{% endif %}>SEA</option>
+      <option value="Other" {% if user.region=='Other' %}selected{% endif %}>Other</option>
+    </select>
+  </p>
+  <p>
+    <button type="submit">Save</button>
+    <a href="{{ url_for('users.list_users') }}">Cancel</a>
+  </p>
+</form>
+{% endblock %}

--- a/app/templates/users/list.html
+++ b/app/templates/users/list.html
@@ -6,26 +6,43 @@
 {% endwith %}
 <h1>Users</h1>
 <p><a href="{{ url_for('users.new_user') }}">New User</a> | <a href="#" id="role-matrix-link">Role Matrix</a></p>
+
+<form method="get" action="{{ url_for('users.list_users') }}">
+  <input type="text" name="q" value="{{ q }}" placeholder="Search" autocomplete="off">
+  <select name="region" autocomplete="off">
+    <option value="" {% if not region %}selected{% endif %}>All Regions</option>
+    <option value="NA" {% if region=='NA' %}selected{% endif %}>NA</option>
+    <option value="EU" {% if region=='EU' %}selected{% endif %}>EU</option>
+    <option value="SEA" {% if region=='SEA' %}selected{% endif %}>SEA</option>
+    <option value="Other" {% if region=='Other' %}selected{% endif %}>Other</option>
+  </select>
+  <button type="submit">Filter</button>
+</form>
+
 <form method="post" action="{{ url_for('users.bulk_update') }}">
 <table>
   <tr>
     <th>Email</th>
     <th>Full Name</th>
+    <th>Region</th>
     <th>SysAdmin</th>
     <th>Administrator</th>
     <th>CRM</th>
     <th>KT Facilitator</th>
     <th>Contractor</th>
+    <th>Edit</th>
   </tr>
   {% for u in users %}
   <tr>
     <td>{{ u.email }}</td>
     <td>{{ u.full_name }}</td>
+    <td>{{ u.region }}</td>
     <td><input type="checkbox" name="is_app_admin_{{ u.id }}" {% if u.is_app_admin %}checked{% endif %} {% if not current_user.is_app_admin %}disabled{% endif %}></td>
     <td><input type="checkbox" name="is_admin_{{ u.id }}" {% if u.is_admin %}checked{% endif %}></td>
     <td><input type="checkbox" name="is_kcrm_{{ u.id }}" {% if u.is_kcrm %}checked{% endif %}></td>
     <td><input type="checkbox" name="is_kt_delivery_{{ u.id }}" {% if u.is_kt_delivery %}checked{% endif %}></td>
     <td><input type="checkbox" name="is_kt_contractor_{{ u.id }}" {% if u.is_kt_contractor %}checked{% endif %}></td>
+    <td><a href="{{ url_for('users.edit_user', user_id=u.id) }}">Edit</a></td>
   </tr>
   {% endfor %}
 </table>

--- a/migrations/versions/0020_user_edit_audit.py
+++ b/migrations/versions/0020_user_edit_audit.py
@@ -1,0 +1,37 @@
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0020_user_edit_audit"
+down_revision = "0019_user_region"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+    if "user_audit_logs" not in insp.get_table_names():
+        op.create_table(
+            "user_audit_logs",
+            sa.Column("id", sa.Integer, primary_key=True),
+            sa.Column(
+                "actor_user_id",
+                sa.Integer,
+                sa.ForeignKey("users.id", ondelete="RESTRICT"),
+                nullable=False,
+            ),
+            sa.Column(
+                "target_user_id",
+                sa.Integer,
+                sa.ForeignKey("users.id", ondelete="RESTRICT"),
+                nullable=False,
+            ),
+            sa.Column("field", sa.String(64), nullable=False),
+            sa.Column("old_value", sa.String(255)),
+            sa.Column("new_value", sa.String(255)),
+            sa.Column("changed_at", sa.DateTime, server_default=sa.func.now()),
+        )
+
+
+def downgrade():
+    pass

--- a/tests/test_user_edit.py
+++ b/tests/test_user_edit.py
@@ -1,0 +1,66 @@
+import os
+import pytest
+
+import os
+import pytest
+
+from app.app import create_app, db
+from app.models import User, UserAuditLog
+
+
+@pytest.fixture
+def app():
+    os.environ["DATABASE_URL"] = "sqlite:///:memory:"
+    os.makedirs("/srv", exist_ok=True)
+    app = create_app()
+    with app.app_context():
+        db.create_all()
+        yield app
+        db.session.remove()
+
+
+def login(client, user_id):
+    with client.session_transaction() as sess_tx:
+        sess_tx["user_id"] = user_id
+
+
+def test_edit_user_name_region(app):
+    with app.app_context():
+        admin = User(email="admin@example.com", is_app_admin=True, full_name="Admin", region="NA")
+        admin.set_password("x")
+        target = User(email="user@example.com", full_name="User", region="EU")
+        db.session.add_all([admin, target])
+        db.session.commit()
+        admin_id = admin.id
+        target_id = target.id
+    client = app.test_client()
+    login(client, admin_id)
+    resp = client.post(
+        f"/users/{target_id}/edit",
+        data={"email": "hax@example.com", "full_name": "User2", "region": "SEA"},
+        follow_redirects=True,
+    )
+    assert b"User updated." in resp.data
+    with app.app_context():
+        user = db.session.get(User, target_id)
+        assert user.email == "user@example.com"
+        assert user.full_name == "User2"
+        assert user.region == "SEA"
+        logs = db.session.query(UserAuditLog).filter_by(target_user_id=target_id).all()
+        assert len(logs) == 2
+        fields = {l.field for l in logs}
+        assert fields == {"full_name", "region"}
+
+
+def test_edit_user_forbidden(app):
+    with app.app_context():
+        u1 = User(email="u1@example.com")
+        u2 = User(email="u2@example.com")
+        db.session.add_all([u1, u2])
+        db.session.commit()
+        u1_id = u1.id
+        u2_id = u2.id
+    client = app.test_client()
+    login(client, u1_id)
+    resp = client.get(f"/users/{u2_id}/edit")
+    assert resp.status_code == 403


### PR DESCRIPTION
## Summary
- add UserAuditLog model and migration
- allow admins to edit user full name and region with per-field audit logging
- harden initial admin seeding against missing columns

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a883516048832e8219e02eaf0ca479