### PR TITLE
Handle checkbox parsing for sessions

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -316,3 +316,6 @@ Participant accounts provision with default password "KTRocks!" and flash summar
 - Confirmed-Ready independent; Delivered requires Confirmed-Ready.
 - “My Profile” adds Certificate Name; certs use it; typography updated.
 
+## Latest update done by codex 05/01/2026
+- Checkboxes accept y/yes/on/1 and Confirmed-Ready persists independently of Delivered.
+

--- a/app/routes/sessions.py
+++ b/app/routes/sessions.py
@@ -43,8 +43,8 @@ FALSY = {"0", "off", "false", "f", "n", "no", "False", "FALSE", ""}
 
 def get_checkbox(form, name, default=None):
     if name not in form:
-        return default
-    v = form.get(name, "").strip()
+        return default  # missing field => leave as-is (read-only views)
+    v = (form.get(name) or "").strip()
     if v in TRUTHY:
         return True
     if v in FALSY:
@@ -294,7 +294,7 @@ def edit_session(session_id: int, current_user):
             )
         )
         db.session.commit()
-        if confirmed_ready and not old_confirmed:
+        if new_ready and not old_confirmed:
             summary = provision_participant_accounts_for_session(sess.id)
             total = summary["created"] + summary["reactivated"] + summary["already_active"]
             flash(

--- a/app/templates/sessions/form.html
+++ b/app/templates/sessions/form.html
@@ -62,7 +62,7 @@
     </select>
   </label></div>
   <div><label>Confirmed-Ready <input type="checkbox" name="confirmed_ready" value="1" {{ 'checked' if session.confirmed_ready else '' }}></label></div>
-  <div><label>Delivered <input type="checkbox" name="delivered" value="y" {% if session and session.delivered %}checked{% endif %}></label></div>
+  <div><label>Delivered <input type="checkbox" name="delivered" value="1" {% if session and session.delivered %}checked{% endif %}></label></div>
   <div><label>Sponsor <input type="text" name="sponsor" value="{{ session.sponsor }}"></label></div>
   <div><label>Notes<br><textarea name="notes">{{ session.notes if session else '' }}</textarea></label></div>
   <div><label>Simulation Outline<br><textarea name="simulation_outline">{{ session.simulation_outline if session else '' }}</textarea></label></div>


### PR DESCRIPTION
## Summary
- add robust get_checkbox helper for session forms
- parse confirmed_ready and delivered using get_checkbox, keeping confirmed_ready independent
- document checkbox truthy values and confirm Confirmed-Ready can persist independently

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a897017a88832e9c04d0ac52a4afb9