### PR TITLE
Refine session lifecycle and profile name handling

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -330,3 +330,9 @@ Participant accounts provision with default password "KTRocks!" and flash summar
 - Delivered requires Ready for delivery and End Date not in the future; Finalized requires Delivered and locks participant edits.
 - Session pages flash saved changes and display Status and lifecycle flags.
 
+## Latest update done by codex 08/22/2025
+- Checkbox parsing consolidated with local `_cb` accepting y/yes/on/1 variants and treating missing fields as false.
+- Session forms drop Status and Confirmed-Ready fields; lifecycle flags only appear on Edit and drive a derived `computed_status`.
+- Profile page allows editing Full name and Certificate name; new participant accounts default certificate_name to full_name.
+- Sessions can be cancelled or finalized via detail page actions; cancelled sessions remove stored certificates and block generation.
+

--- a/app/models.py
+++ b/app/models.py
@@ -74,6 +74,7 @@ class ParticipantAccount(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     email = db.Column(db.String(255), nullable=False)
     password_hash = db.Column(db.String(255))
+    full_name = db.Column(db.String(200), default="")
     certificate_name = db.Column(db.String(200), default="")
     is_active = db.Column(db.Boolean, nullable=False, default=True)
     last_login = db.Column(db.DateTime)

--- a/app/templates/profile.html
+++ b/app/templates/profile.html
@@ -4,6 +4,7 @@
 <h1>My Profile</h1>
 <form method="post">
   <div><label>Email <input type="text" value="{{ email }}" readonly></label></div>
+  <div><label>Full name <input type="text" name="full_name" value="{{ full_name }}" maxlength="200" autocomplete="off"></label></div>
   <div><label>Certificate Name <input type="text" name="certificate_name" value="{{ certificate_name }}" maxlength="200" autocomplete="off"></label></div>
   <button type="submit">Save</button>
 </form>

--- a/app/templates/session_detail.html
+++ b/app/templates/session_detail.html
@@ -5,6 +5,7 @@
   {% if msgs %}<ul class="flashes">{% for cat,msg in msgs %}<li class="{{cat}}">{{msg}}</li>{% endfor %}</ul>{% endif %}
 {% endwith %}
 <h1>{{ session.title }}</h1>
+{% if session.cancelled %}<div class="banner">Session cancelled.</div>{% endif %}
 {% set start_time = session.daily_start_time.strftime('%H:%M') if session.daily_start_time else '' %}
 {% set end_time = session.daily_end_time.strftime('%H:%M') if session.daily_end_time else '' %}
 {% if csa_view %}
@@ -23,7 +24,6 @@
   Location: {{ session.location }}<br>
   Client: {% if session.client %}{{ session.client.name }}{% endif %}<br>
   CRM: {% if session.client and session.client.crm %}{{ session.client.crm.full_name or session.client.crm.email }}{% endif %}<br>
-  Confirmed-Ready: {{ 'Yes' if session.confirmed_ready else 'No' }}<br>
   Status: {{ session.computed_status }}<br>
   Materials ordered: {{ 'Yes' if session.materials_ordered else 'No' }}{% if session.materials_ordered_at %} ({{ session.materials_ordered_at }}){% endif %}<br>
   Ready for delivery: {{ 'Yes' if session.ready_for_delivery else 'No' }}{% if session.ready_at %} ({{ session.ready_at }}){% endif %}<br>
@@ -40,7 +40,6 @@
   Client: {% if session.client %}{{ session.client.name }}{% endif %}<br>
   CRM: {% if session.client and session.client.crm %}{{ session.client.crm.full_name or session.client.crm.email }}{% endif %}<br>
   Status: {{ session.computed_status }}<br>
-  Confirmed-Ready: {{ 'Yes' if session.confirmed_ready else 'No' }}<br>
   Materials ordered: {{ 'Yes' if session.materials_ordered else 'No' }}{% if session.materials_ordered_at %} ({{ session.materials_ordered_at }}){% endif %}<br>
   Ready for delivery: {{ 'Yes' if session.ready_for_delivery else 'No' }}{% if session.ready_at %} ({{ session.ready_at }}){% endif %}<br>
   Workshop info sent: {{ 'Yes' if session.info_sent else 'No' }}{% if session.info_sent_at %} ({{ session.info_sent_at }}){% endif %}<br>
@@ -49,7 +48,14 @@
 </div>
 {% endif %}
 {% if current_user %}
-<p><a href="{{ url_for('sessions.edit_session', session_id=session.id) }}">Edit</a></p>
+<p><a href="{{ url_for('sessions.edit_session', session_id=session.id) }}">Edit</a>
+{% if not session.cancelled %}
+<form action="{{ url_for('sessions.cancel_session', session_id=session.id) }}" method="post" style="display:inline" onsubmit="return confirm('Cancel session?');"><button type="submit">Cancel session</button></form>
+{% endif %}
+{% if session.delivered and not session.finalized and not session.cancelled %}
+<form action="{{ url_for('sessions.finalize_session', session_id=session.id) }}" method="post" style="display:inline" onsubmit="return confirm('Finalize session?');"><button type="submit">Finalize session</button></form>
+{% endif %}
+</p>
 <div>
   <h2>Client Session Admin</h2>
   {% if session.csa_account %}

--- a/app/templates/sessions/form.html
+++ b/app/templates/sessions/form.html
@@ -56,14 +56,7 @@
     </select>
   </label></div>
   <div><label>Capacity <input type="number" name="capacity" value="{{ session.capacity }}"></label></div>
-  <div><label>Status
-    <select name="status">
-      {% for opt in STATUS_CHOICES %}
-      <option value="{{ opt }}" {% if (session and session.status==opt) or (not session and opt=='New') %}selected{% endif %}>{{ opt }}</option>
-      {% endfor %}
-    </select>
-  </label></div>
-  <div><label>Confirmed-Ready <input type="checkbox" name="confirmed_ready" value="1" {{ 'checked' if session.confirmed_ready else '' }}></label></div>
+  {% if session.id %}
   <fieldset>
     <legend>Lifecycle</legend>
     <div><label><input type="checkbox" name="materials_ordered" value="1" {% if session.materials_ordered %}checked{% endif %}> Materials ordered</label></div>
@@ -73,6 +66,7 @@
     <div><label><input type="checkbox" name="finalized" value="1" {% if session.finalized %}checked{% endif %}> Finalized</label></div>
   </fieldset>
   <div>Status: {{ session.computed_status }}</div>
+  {% endif %}
   <div><label>Sponsor <input type="text" name="sponsor" value="{{ session.sponsor }}"></label></div>
   <div><label>Notes<br><textarea name="notes">{{ session.notes if session else '' }}</textarea></label></div>
   <div><label>Simulation Outline<br><textarea name="simulation_outline">{{ session.simulation_outline if session else '' }}</textarea></label></div>
@@ -114,52 +108,34 @@
   var delivered = document.querySelector('input[name="delivered"]');
   var ready = document.querySelector('input[name="ready_for_delivery"]');
   var finalized = document.querySelector('input[name="finalized"]');
-  var confirmed = document.querySelector('input[name="confirmed_ready"]');
-  function syncDelivered(){
-    if(delivered.checked){
-      confirmed.checked = true;
-      confirmed.disabled = true;
-    } else {
-      confirmed.disabled = false;
-    }
+  if(delivered){
+    delivered.addEventListener('change', function(){
+      if(delivered.checked){
+        var end = document.querySelector('input[name="end_date"]').value;
+        var today = new Date().toISOString().slice(0,10);
+        if(!ready.checked){
+          alert('Delivered requires "Ready for delivery" first.');
+          delivered.checked = false;
+          return;
+        }
+        if(end && end > today){
+          alert('Cannot mark Delivered before the end date.');
+          delivered.checked = false;
+          return;
+        }
+        if(!confirm('Mark this session Delivered? Certificates become available.')){
+          delivered.checked = false;
+          return;
+        }
+      }
+    });
+    finalized.addEventListener('change', function(){
+      if(finalized.checked && !delivered.checked){
+        alert('Finalized requires Delivered first.');
+        finalized.checked = false;
+      }
+    });
   }
-  delivered.addEventListener('change', function(){
-    if(delivered.checked){
-      var end = document.querySelector('input[name="end_date"]').value;
-      var today = new Date().toISOString().slice(0,10);
-      if(!ready.checked){
-        alert('Delivered requires "Ready for delivery" first.');
-        delivered.checked = false;
-        syncDelivered();
-        return;
-      }
-      if(end && end > today){
-        alert('Cannot mark Delivered before the end date.');
-        delivered.checked = false;
-        syncDelivered();
-        return;
-      }
-      if(!confirm('Mark this session Delivered? Certificates become available.')){
-        delivered.checked = false;
-        syncDelivered();
-        return;
-      }
-    }
-    syncDelivered();
-  });
-  finalized.addEventListener('change', function(){
-    if(finalized.checked && !delivered.checked){
-      alert('Finalized requires Delivered first.');
-      finalized.checked = false;
-    }
-  });
-  document.querySelector('form').addEventListener('submit', function(){
-    if(delivered.checked){
-      confirmed.disabled = false;
-      confirmed.checked = true;
-    }
-  });
-  syncDelivered();
   document.getElementById('add-fac').addEventListener('click', function(){
     var container = document.getElementById('additional-facilitators');
     var select = container.querySelector('select').cloneNode(true);

--- a/app/utils/provisioning.py
+++ b/app/utils/provisioning.py
@@ -27,7 +27,12 @@ def provision_for_session(session: Session) -> Dict[str, int]:
             func.lower(ParticipantAccount.email) == email
         ).first()
         if not account:
-            account = ParticipantAccount(email=email, is_active=True)
+            account = ParticipantAccount(
+                email=email,
+                full_name=participant.full_name or "",
+                certificate_name=participant.full_name or "",
+                is_active=True,
+            )
             account.set_password("KTRocks!")
             db.session.add(account)
             created += 1
@@ -37,6 +42,8 @@ def provision_for_session(session: Session) -> Dict[str, int]:
                 reactivated += 1
             else:
                 already_active += 1
+            if not account.certificate_name and account.full_name:
+                account.certificate_name = account.full_name
         if participant.account_id != account.id:
             participant.account_id = account.id
     db.session.commit()

--- a/migrations/versions/0023_participant_account_full_name.py
+++ b/migrations/versions/0023_participant_account_full_name.py
@@ -1,0 +1,15 @@
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = '0023_participant_account_full_name'
+down_revision = '0022_session_state_machine'
+branch_labels = None
+depends_on = None
+
+def upgrade() -> None:
+    op.add_column('participant_accounts', sa.Column('full_name', sa.String(length=200), nullable=False, server_default=''))
+    op.alter_column('participant_accounts', 'full_name', server_default=None)
+
+def downgrade() -> None:
+    op.drop_column('participant_accounts', 'full_name')

--- a/tests/test_lifecycle_profile.py
+++ b/tests/test_lifecycle_profile.py
@@ -1,0 +1,109 @@
+import os
+import sys
+from datetime import date, timedelta
+
+import pytest
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from app.app import create_app, db
+from app.models import (
+    User,
+    WorkshopType,
+    Session,
+    Participant,
+    SessionParticipant,
+    ParticipantAccount,
+)
+from app.routes.sessions import _cb
+from app.utils.provisioning import provision_participant_accounts_for_session
+
+
+@pytest.fixture
+def app():
+    os.environ["DATABASE_URL"] = "sqlite:///:memory:"
+    os.makedirs("/srv", exist_ok=True)
+    app = create_app()
+    with app.app_context():
+        db.create_all()
+        yield app
+        db.session.remove()
+
+
+def login_admin(client, admin_id):
+    with client.session_transaction() as sess:
+        sess["user_id"] = admin_id
+
+
+def test_cb_helper():
+    assert _cb("yes")
+    assert _cb("On")
+    assert not _cb("0")
+    assert not _cb(None)
+
+
+def test_delivered_gating(app):
+    with app.app_context():
+        admin = User(email="admin@example.com", is_app_admin=True)
+        admin.set_password("x")
+        wt = WorkshopType(code="WT", name="WT")
+        sess = Session(title="S1", workshop_type=wt, end_date=date.today() + timedelta(days=1))
+        db.session.add_all([admin, wt, sess])
+        db.session.commit()
+        admin_id = admin.id
+        session_id = sess.id
+    client = app.test_client()
+    login_admin(client, admin_id)
+    client.post(f"/sessions/{session_id}/edit", data={"delivered": "1"})
+    with app.app_context():
+        sess = db.session.get(Session, session_id)
+        assert not sess.delivered
+
+
+def test_finalize_gating(app):
+    with app.app_context():
+        admin = User(email="adm@example.com", is_app_admin=True)
+        admin.set_password("x")
+        wt = WorkshopType(code="WT", name="WT")
+        sess = Session(title="S1", workshop_type=wt, end_date=date.today())
+        db.session.add_all([admin, wt, sess])
+        db.session.commit()
+        admin_id = admin.id
+        session_id = sess.id
+    client = app.test_client()
+    login_admin(client, admin_id)
+    client.post(f"/sessions/{session_id}/finalize")
+    with app.app_context():
+        sess = db.session.get(Session, session_id)
+        assert not sess.finalized
+
+
+def test_lifecycle_hidden_on_new(app):
+    with app.app_context():
+        admin = User(email="admin@example.com", is_app_admin=True)
+        admin.set_password("x")
+        wt = WorkshopType(code="WT", name="WT")
+        db.session.add_all([admin, wt])
+        db.session.commit()
+        admin_id = admin.id
+    client = app.test_client()
+    login_admin(client, admin_id)
+    resp = client.get("/sessions/new")
+    assert b"Lifecycle" not in resp.data
+
+
+def test_certificate_name_defaults(app):
+    with app.app_context():
+        admin = User(email="admin@example.com", is_app_admin=True)
+        admin.set_password("x")
+        wt = WorkshopType(code="WT", name="WT")
+        sess = Session(title="S1", workshop_type=wt, end_date=date.today(), ready_for_delivery=True)
+        part = Participant(email="p@example.com", full_name="P One")
+        db.session.add_all([admin, wt, sess, part])
+        db.session.commit()
+        link = SessionParticipant(session_id=sess.id, participant_id=part.id)
+        db.session.add(link)
+        db.session.commit()
+        provision_participant_accounts_for_session(sess.id)
+        acct = ParticipantAccount.query.filter_by(email="p@example.com").one()
+        assert acct.certificate_name == "P One"


### PR DESCRIPTION
## Summary
- replace checkbox parsing with tolerant `_cb` and simplify session forms; add cancel/finalize actions
- allow full-name edits on Profile and default certificate names from full names
- add migration for participant account full names and adjust provisioning

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a8b63862bc832eb9dc9b6d19ec7b5d