### PR TITLE
Add workshop type badges and badge downloads

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -358,3 +358,9 @@ Participant accounts provision with default password "KTRocks!" and flash summar
 - Manual account creation can set a password without it being overwritten by provisioning; provisioning keeps existing hashes and reports `kept_password`.
 - Forgot-password flow added with `/forgot-password` and `/reset-password` using 1-hour tokens; token shown on page when mail is stubbed.
 - SysAdmin/Admin interfaces allow setting passwords for Users and ParticipantAccounts with audit logging (`password_reset_admin`).
+
+## Latest update done by codex 09/01/2026
+- WorkshopType includes optional `badge` field with choices None, Foundations, Practitioner, Advanced, Expert, Coach, Facilitator, Program Leader.
+- Badge images served at `/badges/<slug>.webp` from repo or `/app/assets` fallback.
+- Certificate views show a **Download Badge** link when the session's workshop type has a badge.
+- Existing workshop types seeded to Foundations.

--- a/app/app.py
+++ b/app/app.py
@@ -195,6 +195,7 @@ def create_app():
     from .routes.users import bp as users_bp
     from .routes.clients import bp as clients_bp
     from .routes.accounts import bp as accounts_bp
+    from .routes.assets import bp as assets_bp
 
     app.register_blueprint(auth_bp)
     app.register_blueprint(settings_mail_bp)
@@ -206,6 +207,7 @@ def create_app():
     app.register_blueprint(users_bp)
     app.register_blueprint(clients_bp)
     app.register_blueprint(accounts_bp)
+    app.register_blueprint(assets_bp)
 
     @app.get("/verify/<int:cert_id>")
     def verify(cert_id: int):

--- a/app/constants.py
+++ b/app/constants.py
@@ -1,0 +1,10 @@
+BADGE_CHOICES = [
+    ("", "None"),
+    ("Foundations", "Foundations"),
+    ("Practitioner", "Practitioner"),
+    ("Advanced", "Advanced"),
+    ("Expert", "Expert"),
+    ("Coach", "Coach"),
+    ("Facilitator", "Facilitator"),
+    ("Program Leader", "Program Leader"),
+]

--- a/app/models.py
+++ b/app/models.py
@@ -132,6 +132,7 @@ class WorkshopType(db.Model):
     name = db.Column(db.String(255), nullable=False)
     status = db.Column(db.String(16), default="active")
     description = db.Column(db.Text)
+    badge = db.Column(db.String(50), nullable=True)  # one of allowed set; NULL means none
     created_at = db.Column(db.DateTime, server_default=db.func.now())
     __table_args__ = (
         db.Index("uix_workshop_types_code_upper", db.func.upper(code), unique=True),
@@ -325,6 +326,7 @@ class Certificate(db.Model):
             name="uix_certificate_session_participant",
         ),
     )
+    session = db.relationship("Session")
 
 
 class SessionFacilitator(db.Model):

--- a/app/routes/assets.py
+++ b/app/routes/assets.py
@@ -1,0 +1,28 @@
+from pathlib import Path
+from flask import Blueprint, abort, send_file
+
+bp = Blueprint("assets", __name__)
+
+_allowed = {
+    "foundations": "foundation.webp",
+    "practitioner": "practitioner.webp",
+    "advanced": "advanced.webp",
+    "expert": "expert.webp",
+    "coach": "coach.webp",
+    "facilitator": "facilitator.webp",
+    "program-leader": "program-leader.webp",
+}
+
+_repo_dir = Path(__file__).resolve().parents[1] / "assets" / "badges"
+_fallback_dir = Path("/app/assets")
+
+@bp.get("/badges/<slug>.webp")
+def badge(slug: str):
+    fname = _allowed.get(slug.lower())
+    if not fname:
+        abort(404)
+    for d in (_repo_dir, _fallback_dir):
+        p = d / fname
+        if p.exists():
+            return send_file(p, as_attachment=True, download_name=fname, mimetype="image/webp")
+    abort(404)

--- a/app/routes/learner.py
+++ b/app/routes/learner.py
@@ -17,9 +17,10 @@ from flask import (
 import os
 
 from sqlalchemy import func
+from sqlalchemy.orm import joinedload
 
 from ..app import db, User
-from ..models import Certificate, Participant, ParticipantAccount
+from ..models import Certificate, Participant, ParticipantAccount, Session
 
 bp = Blueprint("learner", __name__)
 
@@ -49,6 +50,7 @@ def my_certs():
         db.session.query(Certificate)
         .join(Participant, Certificate.participant_id == Participant.id)
         .filter(db.func.lower(Participant.email) == email)
+        .options(joinedload(Certificate.session).joinedload(Session.workshop_type))
         .all()
     )
     return render_template("my_certificates.html", certs=certs)

--- a/app/routes/sessions.py
+++ b/app/routes/sessions.py
@@ -25,6 +25,7 @@ from ..models import (
     Client,
     Session,
     SessionParticipant,
+    Certificate,
     WorkshopType,
     AuditLog,
 )
@@ -441,8 +442,13 @@ def session_detail(session_id: int, sess, current_user, csa_view):
     participants = []
     for link in links:
         participant = db.session.get(Participant, link.participant_id)
+        cert = (
+            db.session.query(Certificate)
+            .filter_by(session_id=session_id, participant_id=link.participant_id)
+            .one_or_none()
+        )
         if participant:
-            participants.append({"participant": participant, "link": link})
+            participants.append({"participant": participant, "link": link, "certificate": cert})
     import_errors = flask_session.pop("import_errors", None)
     return render_template(
         "session_detail.html",

--- a/app/routes/workshop_types.py
+++ b/app/routes/workshop_types.py
@@ -4,6 +4,7 @@ from flask import Blueprint, abort, flash, redirect, render_template, request, u
 
 from ..app import db, User
 from ..models import WorkshopType, AuditLog
+from ..constants import BADGE_CHOICES
 
 bp = Blueprint('workshop_types', __name__, url_prefix='/workshop-types')
 
@@ -35,7 +36,7 @@ def list_types(current_user):
 @bp.get('/new')
 @staff_required
 def new_type(current_user):
-    return render_template('workshop_types/form.html', wt=None)
+    return render_template('workshop_types/form.html', wt=None, badge_choices=BADGE_CHOICES)
 
 
 @bp.post('/new')
@@ -54,6 +55,7 @@ def create_type(current_user):
         name=name,
         status=request.form.get('status') or 'active',
         description=request.form.get('description') or None,
+        badge=request.form.get('badge') or None,
     )
     db.session.add(wt)
     db.session.flush()
@@ -75,7 +77,7 @@ def edit_type(type_id: int, current_user):
     wt = db.session.get(WorkshopType, type_id)
     if not wt:
         abort(404)
-    return render_template('workshop_types/form.html', wt=wt)
+    return render_template('workshop_types/form.html', wt=wt, badge_choices=BADGE_CHOICES)
 
 
 @bp.post('/<int:type_id>/edit')
@@ -87,6 +89,7 @@ def update_type(type_id: int, current_user):
     wt.name = request.form.get('name') or wt.name
     wt.status = request.form.get('status') or wt.status
     wt.description = request.form.get('description') or None
+    wt.badge = request.form.get('badge') or None
     db.session.add(
         AuditLog(
             user_id=current_user.id,

--- a/app/templates/my_certificates.html
+++ b/app/templates/my_certificates.html
@@ -4,7 +4,13 @@
 <h1>My Certificates</h1>
 <ul>
 {% for c in certs %}
-  <li><a href="{{ url_for('learner.download_certificate', cert_id=c.id) }}">{{ c.workshop_name }} - {{ c.workshop_date }}</a></li>
+  <li>
+    <a href="{{ url_for('learner.download_certificate', cert_id=c.id) }}">{{ c.workshop_name }} - {{ c.workshop_date }}</a>
+    {% if c.session and c.session.workshop_type and c.session.workshop_type.badge %}
+      {% set slug = c.session.workshop_type.badge.lower().replace(' ', '-') %}
+      - <a href="{{ url_for('assets.badge', slug=slug) }}">Download Badge</a>
+    {% endif %}
+  </li>
 {% endfor %}
 </ul>
 {% endblock %}

--- a/app/templates/session_detail.html
+++ b/app/templates/session_detail.html
@@ -119,7 +119,7 @@
 </table>
 {% else %}
 <table border="1" cellpadding="4" cellspacing="0">
-  <tr><th>Full Name</th><th>Email</th><th>Title</th><th>Completion Date</th><th>Actions</th></tr>
+  <tr><th>Full Name</th><th>Email</th><th>Title</th><th>Completion Date</th><th>Certificate</th><th>Actions</th></tr>
   {% for row in participants %}
   <tr>
     <td>{{ row.participant.full_name }}{% if row.participant.account and row.participant.account.certificate_name %} ({{ row.participant.account.certificate_name }}){% endif %}</td>
@@ -133,6 +133,15 @@
         <button type="submit" name="action" value="generate">Generate</button>
         {% endif %}
       </form>
+    </td>
+    <td>
+      {% if row.certificate %}
+      <a href="{{ url_for('learner.download_certificate', cert_id=row.certificate.id) }}">Download Certificate</a>
+      {% if session.workshop_type and session.workshop_type.badge %}
+        {% set slug = session.workshop_type.badge.lower().replace(' ', '-') %}
+        <a href="{{ url_for('assets.badge', slug=slug) }}">Download Badge</a>
+      {% endif %}
+      {% endif %}
     </td>
     <td>
       {% if not session.delivered and not session.participants_locked() %}

--- a/app/templates/workshop_types/form.html
+++ b/app/templates/workshop_types/form.html
@@ -10,6 +10,13 @@
   {% endif %}
   <div><label>Name <input type="text" name="name" value="{{ wt.name if wt else '' }}" required></label></div>
   <div><label>Status <input type="text" name="status" value="{{ wt.status if wt else 'active' }}"></label></div>
+  <div><label>Badge
+    <select name="badge">
+      {% for val,label in badge_choices %}
+      <option value="{{ val }}"{% if wt and wt.badge==val %} selected{% endif %}>{{ label }}</option>
+      {% endfor %}
+    </select>
+  </label></div>
   <div><label>Description<br><textarea name="description">{{ wt.description if wt else '' }}</textarea></label></div>
   <button type="submit">Save</button>
 </form>

--- a/app/templates/workshop_types/list.html
+++ b/app/templates/workshop_types/list.html
@@ -4,12 +4,13 @@
 <h1>Workshop Types</h1>
 <p><a href="{{ url_for('workshop_types.new_type') }}">New Workshop Type</a></p>
 <table border="1" cellpadding="4" cellspacing="0">
-  <tr><th>Code</th><th>Name</th><th>Status</th><th>Description</th><th></th></tr>
+  <tr><th>Code</th><th>Name</th><th>Status</th><th>Badge</th><th>Description</th><th></th></tr>
   {% for wt in types %}
   <tr>
     <td>{{ wt.code }}</td>
     <td>{{ wt.name }}</td>
     <td>{{ wt.status }}</td>
+    <td>{{ wt.badge or '—' }}</td>
     <td>{{ wt.description }}</td>
     <td><a href="{{ url_for('workshop_types.edit_type', type_id=wt.id) }}">Edit</a></td>
   </tr>

--- a/migrations/versions/0025_workshoptype_badge.py
+++ b/migrations/versions/0025_workshoptype_badge.py
@@ -1,0 +1,18 @@
+"""add badge to workshop types"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = '0025_workshoptype_badge'
+down_revision = '0024_add_on_hold_at'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column('workshop_types', sa.Column('badge', sa.String(length=50), nullable=True))
+    op.execute("UPDATE workshop_types SET badge='Foundations' WHERE badge IS NULL")
+
+
+def downgrade() -> None:
+    op.drop_column('workshop_types', 'badge')


### PR DESCRIPTION
## Summary
- add optional `badge` field on `WorkshopType` with migration and seed to "Foundations"
- serve badge images via new `/badges/<slug>.webp` asset route (expects `foundation.webp` for the Foundations badge)
- surface "Download Badge" links alongside certificates
- drop badge image assets from the PR since they are supplied separately

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68acacb9f9e0832eaab2aa4e53dd5253