### PR TITLE
Fix badge download routing

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -385,3 +385,6 @@ Participant accounts provision with default password "KTRocks!" and flash summar
 - New Session form adds an **Add Client** button and a **Client Session Admin** email field; Edit Session also shows the CSA field.
 - Ready for delivery is disabled once Delivered is set, and Delivered remains disabled until Ready for delivery is checked.
 - Left navigation reordered: Home, My Sessions, My Certificates, Resources, Sessions, Materials, Surveys, Verify Certificates, Settings (Clients, Workshop Types, My Profile, Users, Mail Settings), Logout.
+
+## Latest update done by codex 10/15/2026
+- Badge downloads handled via Flask route serving from `/srv/badges` with fallback to bundled assets, fixing broken Download Badge links.

--- a/app/app.py
+++ b/app/app.py
@@ -47,6 +47,16 @@ def create_app():
             os.path.join(app.root_path, "static"), "ktlogo1.png"
         )
 
+    @app.get("/badges/<slug>.webp")
+    def badge_file(slug: str):
+        filename = f"{slug}.webp"
+        site_dir = "/srv/badges"
+        asset_dir = os.path.join(app.root_path, "assets", "badges")
+        site_path = os.path.join(site_dir, filename)
+        if os.path.isfile(site_path):
+            return send_from_directory(site_dir, filename, as_attachment=True)
+        return send_from_directory(asset_dir, filename, as_attachment=True)
+
     @app.context_processor
     def inject_user():
         user = None

--- a/tests/test_badges.py
+++ b/tests/test_badges.py
@@ -1,0 +1,26 @@
+import os
+import sys
+import pytest
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from app.app import create_app, db
+
+
+@pytest.fixture
+def app():
+    os.environ["DATABASE_URL"] = "sqlite:///:memory:"
+    os.makedirs("/srv", exist_ok=True)
+    app = create_app()
+    with app.app_context():
+        db.create_all()
+        yield app
+        db.session.remove()
+
+
+def test_download_badge(app):
+    client = app.test_client()
+    resp = client.get("/badges/foundations.webp")
+    assert resp.status_code == 200
+    assert resp.headers["Content-Type"] == "image/webp"
+    assert resp.data


### PR DESCRIPTION
## Summary
- serve `/badges/<slug>.webp` via Flask with fallback to bundled assets
- add regression test for badge downloads
- update context with badge download note

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68adef5f8d3c832ea9fb5e7f31299156