### PR TITLE
feat: add session materials shipment management

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -394,3 +394,12 @@ Participant accounts provision with default password "KTRocks!" and flash summar
 - Lifecycle tweaks: Delivered auto-checks Materials ordered and Workshop info sent; Ready for delivery is required and retained if Delivered is undone; Finalized locks all lifecycle fields; cancelled or on-hold sessions disable lifecycle edits; status derives from flags including On Hold and Finalized.
 - Cancelled sessions may be deleted by Administrators or SysAdmin.
 - Certificates generate automatically on session finalization and are removed when a session is cancelled.
+
+## Latest update done by codex 12/15/2026
+- Sessions → Materials:
+  • Single-shipment model enforced with `session_shipping` unique per session.
+  • CSA can provide shipping location (contact, address, arrival date) before Submit; fields become read-only afterward.
+  • Staff manage line items, order type, and statuses: Submit, Shipped, Delivered.
+  • Marking Delivered sets `Session.materials_ordered = TRUE`.
+  • Submit requires `arrival_date` and at least one line item.
+  • Order Type uses fixed list: "KT-Run Standard materials", "KT-Run Modular materials", "KT-Run LDI materials", "Client-run Bulk order", "Simulation".

--- a/app/app.py
+++ b/app/app.py
@@ -206,6 +206,7 @@ def create_app():
     from .routes.users import bp as users_bp
     from .routes.clients import bp as clients_bp
     from .routes.accounts import bp as accounts_bp
+    from .routes.materials import bp as materials_bp
 
     app.register_blueprint(auth_bp)
     app.register_blueprint(settings_mail_bp)
@@ -217,6 +218,7 @@ def create_app():
     app.register_blueprint(users_bp)
     app.register_blueprint(clients_bp)
     app.register_blueprint(accounts_bp)
+    app.register_blueprint(materials_bp)
 
     @app.get("/materials")
     def materials():

--- a/app/models.py
+++ b/app/models.py
@@ -359,6 +359,10 @@ class Material(db.Model):
 
 class SessionShipping(db.Model):
     __tablename__ = "session_shipping"
+    __table_args__ = (
+        db.UniqueConstraint("session_id", name="uq_session_shipping_session_id"),
+    )
+
     id = db.Column(db.Integer, primary_key=True)
     session_id = db.Column(db.Integer, db.ForeignKey("sessions.id", ondelete="CASCADE"))
     created_by = db.Column(db.Integer, db.ForeignKey("users.id", ondelete="SET NULL"))
@@ -375,7 +379,14 @@ class SessionShipping(db.Model):
     tracking = db.Column(db.String(255))
     ship_date = db.Column(db.Date)
     special_instructions = db.Column(db.Text)
+    arrival_date = db.Column(db.Date)
+    order_type = db.Column(db.Text)
+    submitted_at = db.Column(db.DateTime)
+    delivered_at = db.Column(db.DateTime)
     created_at = db.Column(db.DateTime, server_default=db.func.now())
+    items = db.relationship(
+        "SessionShippingItem", backref="shipment", cascade="all, delete-orphan"
+    )
 
 
 class SessionShippingItem(db.Model):

--- a/app/routes/materials.py
+++ b/app/routes/materials.py
@@ -1,0 +1,213 @@
+from __future__ import annotations
+
+from datetime import date, datetime
+from functools import wraps
+
+from flask import Blueprint, abort, flash, redirect, render_template, request, session as flask_session, url_for
+
+from ..app import db, User
+from ..models import Session, SessionShipping, SessionShippingItem, Material
+
+bp = Blueprint("materials", __name__, url_prefix="/sessions/<int:session_id>/materials")
+
+ORDER_TYPES = [
+    "KT-Run Standard materials",
+    "KT-Run Modular materials",
+    "KT-Run LDI materials",
+    "Client-run Bulk order",
+    "Simulation",
+]
+
+
+def _is_staff(user: User | None) -> bool:
+    return bool(
+        user
+        and (
+            user.is_app_admin
+            or user.is_admin
+            or getattr(user, "is_kcrm", False)
+            or getattr(user, "is_kt_delivery", False)
+            or getattr(user, "is_kt_staff", False)
+            or getattr(user, "is_kt_contractor", False)
+        )
+    )
+
+
+def materials_access(fn):
+    @wraps(fn)
+    def wrapper(session_id: int, *args, **kwargs):
+        sess = db.session.get(Session, session_id)
+        if not sess:
+            abort(404)
+        user = None
+        user_id = flask_session.get("user_id")
+        if user_id:
+            user = db.session.get(User, user_id)
+            if _is_staff(user):
+                return fn(session_id, *args, **kwargs, sess=sess, current_user=user, csa_view=False)
+        account_id = flask_session.get("participant_account_id")
+        if account_id and sess.csa_account_id == account_id:
+            return fn(session_id, *args, **kwargs, sess=sess, current_user=None, csa_view=True)
+        abort(403)
+
+    return wrapper
+
+
+CSA_FIELDS = {
+    "contact_name",
+    "contact_phone",
+    "contact_email",
+    "address_line1",
+    "address_line2",
+    "city",
+    "state",
+    "postal_code",
+    "country",
+    "arrival_date",
+}
+
+
+def can_edit_materials_header(field: str, user: User | None, shipment: SessionShipping | None) -> bool:
+    if _is_staff(user):
+        return True
+    if shipment and shipment.submitted_at:
+        return False
+    return field in CSA_FIELDS
+
+
+def _parse_date(val: str | None):
+    if not val:
+        return None
+    try:
+        return date.fromisoformat(val)
+    except ValueError:
+        return None
+
+
+@bp.route("", methods=["GET", "POST"])
+@materials_access
+def materials_view(session_id: int, sess: Session, current_user: User | None, csa_view: bool):
+    shipment = SessionShipping.query.filter_by(session_id=session_id).first()
+    if request.method == "POST":
+        action = request.form.get("action")
+        if action == "create":
+            if csa_view:
+                abort(403)
+            if shipment:
+                flash("Shipment already exists", "error")
+            else:
+                shipment = SessionShipping(session_id=session_id, created_by=current_user.id)
+                db.session.add(shipment)
+                db.session.commit()
+            return redirect(url_for("materials.materials_view", session_id=session_id))
+        if not shipment:
+            abort(404)
+        if action == "update_header":
+            unauthorized = False
+            fields = CSA_FIELDS | {
+                "courier",
+                "tracking",
+                "ship_date",
+                "special_instructions",
+                "order_type",
+            }
+            for field in fields:
+                val = request.form.get(field)
+                if not can_edit_materials_header(field, current_user, shipment):
+                    if csa_view and val:
+                        unauthorized = True
+                    continue
+                if field in {"ship_date", "arrival_date"}:
+                    setattr(shipment, field, _parse_date(val))
+                else:
+                    setattr(shipment, field, val or None)
+            if not csa_view and sess.client and not sess.client.sfc_link:
+                sfc_link = request.form.get("sfc_link")
+                if sfc_link:
+                    sess.client.sfc_link = sfc_link
+            db.session.commit()
+            if unauthorized:
+                flash("You can only provide shipping location details.", "error")
+            else:
+                flash("Saved", "info")
+            return redirect(url_for("materials.materials_view", session_id=session_id))
+        if action == "add_item" and not csa_view:
+            material_id = request.form.get("material_id")
+            qty = request.form.get("quantity")
+            notes = request.form.get("notes")
+            if material_id and qty and int(qty) >= 1:
+                item = SessionShippingItem(
+                    session_shipping_id=shipment.id,
+                    material_id=int(material_id),
+                    quantity=int(qty),
+                    notes=notes,
+                )
+                db.session.add(item)
+                db.session.commit()
+            else:
+                flash("Material and quantity required", "error")
+            return redirect(url_for("materials.materials_view", session_id=session_id))
+        if action == "update_item" and not csa_view:
+            item_id = request.form.get("item_id")
+            item = db.session.get(SessionShippingItem, int(item_id)) if item_id else None
+            if item and item.session_shipping_id == shipment.id:
+                material_id = request.form.get("material_id")
+                qty = request.form.get("quantity")
+                item.material_id = int(material_id) if material_id else None
+                item.quantity = int(qty) if qty else 0
+                item.notes = request.form.get("notes")
+                db.session.commit()
+            return redirect(url_for("materials.materials_view", session_id=session_id))
+        if action == "delete_item" and not csa_view:
+            item_id = request.form.get("item_id")
+            item = db.session.get(SessionShippingItem, int(item_id)) if item_id else None
+            if item and item.session_shipping_id == shipment.id:
+                db.session.delete(item)
+                db.session.commit()
+            return redirect(url_for("materials.materials_view", session_id=session_id))
+        if action == "submit" and not csa_view:
+            if not shipment.arrival_date or len(shipment.items) == 0:
+                flash("Arrival date and at least one line item required", "error")
+            else:
+                shipment.submitted_at = datetime.utcnow()
+                db.session.commit()
+            return redirect(url_for("materials.materials_view", session_id=session_id))
+        if action == "mark_shipped" and not csa_view:
+            if not shipment.ship_date:
+                shipment.ship_date = date.today()
+            db.session.commit()
+            return redirect(url_for("materials.materials_view", session_id=session_id))
+        if action == "mark_delivered" and not csa_view:
+            shipment.delivered_at = datetime.utcnow()
+            sess.materials_ordered = True
+            sess.materials_ordered_at = datetime.utcnow()
+            db.session.commit()
+            flash("Shipment delivered", "info")
+            return redirect(url_for("materials.materials_view", session_id=session_id))
+        if action == "delete" and not csa_view:
+            if shipment.submitted_at:
+                flash("Cannot delete after submit", "error")
+            else:
+                db.session.delete(shipment)
+                db.session.commit()
+            return redirect(url_for("materials.materials_view", session_id=session_id))
+    status = "Draft"
+    if shipment:
+        if shipment.delivered_at:
+            status = "Delivered"
+        elif shipment.ship_date:
+            status = "Shipped"
+        elif shipment.submitted_at:
+            status = "Submitted"
+    materials = Material.query.order_by(Material.name).all() if not csa_view else []
+    return render_template(
+        "sessions/materials.html",
+        sess=sess,
+        shipment=shipment,
+        status=status,
+        materials=materials,
+        order_types=ORDER_TYPES,
+        csa_view=csa_view,
+        current_user=current_user,
+        can_edit_materials_header=can_edit_materials_header,
+    )

--- a/app/templates/session_detail.html
+++ b/app/templates/session_detail.html
@@ -57,6 +57,7 @@
 {% if session.delivered and not session.finalized and not session.cancelled %}
 <form action="{{ url_for('sessions.finalize_session', session_id=session.id) }}" method="post" style="display:inline" onsubmit="return confirm('Finalize session?');"><button type="submit">Finalize session</button></form>
 {% endif %}
+ | <a href="{{ url_for('materials.materials_view', session_id=session.id) }}">Materials</a>
 </p>
 <div>
   <h2>Client Session Admin</h2>

--- a/app/templates/sessions/materials.html
+++ b/app/templates/sessions/materials.html
@@ -1,0 +1,175 @@
+{% extends 'base.html' %}
+{% block title %}Materials{% endblock %}
+{% block content %}
+{% with msgs = get_flashed_messages(with_categories=true) %}
+  {% if msgs %}<ul class="flashes">{% for cat,msg in msgs %}<li class="{{cat}}">{{msg}}</li>{% endfor %}</ul>{% endif %}
+{% endwith %}
+<h1>Materials for {{ sess.title }}</h1>
+{% if not shipment %}
+  <p>No shipment yet.</p>
+  {% if not csa_view %}
+  <form method="post">
+    <input type="hidden" name="action" value="create">
+    <button type="submit">Create shipment</button>
+  </form>
+  {% endif %}
+{% else %}
+  <p>Status: {{ status }}</p>
+  <form method="post">
+    <input type="hidden" name="action" value="update_header">
+    <div>Client: {% if sess.client %}{{ sess.client.name }}{% endif %}</div>
+    <div>Delivery region: {{ sess.region }}</div>
+    <div>Workshop start date: {{ sess.start_date }}</div>
+    <div>SFC Project link:
+      {% if sess.client and sess.client.sfc_link %}
+        {{ sess.client.sfc_link }}
+      {% elif not csa_view %}
+        <input type="url" name="sfc_link">
+      {% endif %}
+    </div>
+    <div>Order type:
+      {% if can_edit_materials_header('order_type', current_user, shipment) %}
+        <select name="order_type">
+          <option value=""></option>
+          {% for ot in order_types %}
+            <option value="{{ ot }}" {% if shipment.order_type==ot %}selected{% endif %}>{{ ot }}</option>
+          {% endfor %}
+        </select>
+      {% else %}{{ shipment.order_type }}{% endif %}
+    </div>
+    <div>Arrival date:
+      {% if can_edit_materials_header('arrival_date', current_user, shipment) %}
+        <input type="date" name="arrival_date" value="{{ shipment.arrival_date }}">
+      {% else %}{{ shipment.arrival_date }}{% endif %}
+    </div>
+    <div>Contact name:
+      {% if can_edit_materials_header('contact_name', current_user, shipment) %}
+        <input type="text" name="contact_name" value="{{ shipment.contact_name }}">
+      {% else %}{{ shipment.contact_name }}{% endif %}
+    </div>
+    <div>Contact phone:
+      {% if can_edit_materials_header('contact_phone', current_user, shipment) %}
+        <input type="text" name="contact_phone" value="{{ shipment.contact_phone }}">
+      {% else %}{{ shipment.contact_phone }}{% endif %}
+    </div>
+    <div>Contact email:
+      {% if can_edit_materials_header('contact_email', current_user, shipment) %}
+        <input type="email" name="contact_email" value="{{ shipment.contact_email }}">
+      {% else %}{{ shipment.contact_email }}{% endif %}
+    </div>
+    <div>Address line1:
+      {% if can_edit_materials_header('address_line1', current_user, shipment) %}
+        <input type="text" name="address_line1" value="{{ shipment.address_line1 }}">
+      {% else %}{{ shipment.address_line1 }}{% endif %}
+    </div>
+    <div>Address line2:
+      {% if can_edit_materials_header('address_line2', current_user, shipment) %}
+        <input type="text" name="address_line2" value="{{ shipment.address_line2 }}">
+      {% else %}{{ shipment.address_line2 }}{% endif %}
+    </div>
+    <div>City:
+      {% if can_edit_materials_header('city', current_user, shipment) %}
+        <input type="text" name="city" value="{{ shipment.city }}">
+      {% else %}{{ shipment.city }}{% endif %}
+    </div>
+    <div>State:
+      {% if can_edit_materials_header('state', current_user, shipment) %}
+        <input type="text" name="state" value="{{ shipment.state }}">
+      {% else %}{{ shipment.state }}{% endif %}
+    </div>
+    <div>Postal code:
+      {% if can_edit_materials_header('postal_code', current_user, shipment) %}
+        <input type="text" name="postal_code" value="{{ shipment.postal_code }}">
+      {% else %}{{ shipment.postal_code }}{% endif %}
+    </div>
+    <div>Country:
+      {% if can_edit_materials_header('country', current_user, shipment) %}
+        <input type="text" name="country" value="{{ shipment.country }}">
+      {% else %}{{ shipment.country }}{% endif %}
+    </div>
+    <div>Courier:
+      {% if can_edit_materials_header('courier', current_user, shipment) %}
+        <input type="text" name="courier" value="{{ shipment.courier }}">
+      {% else %}{{ shipment.courier }}{% endif %}
+    </div>
+    <div>Tracking:
+      {% if can_edit_materials_header('tracking', current_user, shipment) %}
+        <input type="text" name="tracking" value="{{ shipment.tracking }}">
+      {% else %}{{ shipment.tracking }}{% endif %}
+    </div>
+    <div>Ship date:
+      {% if can_edit_materials_header('ship_date', current_user, shipment) %}
+        <input type="date" name="ship_date" value="{{ shipment.ship_date }}">
+      {% else %}{{ shipment.ship_date }}{% endif %}
+    </div>
+    <div>Special instructions:
+      {% if can_edit_materials_header('special_instructions', current_user, shipment) %}
+        <textarea name="special_instructions">{{ shipment.special_instructions }}</textarea>
+      {% else %}{{ shipment.special_instructions }}{% endif %}
+    </div>
+    <button type="submit">Save</button>
+  </form>
+  {% if not csa_view %}
+  <h3>Items</h3>
+  <table border="1" cellpadding="4" cellspacing="0">
+    <tr><th>Material</th><th>Qty</th><th>Notes</th><th></th></tr>
+    {% for item in shipment.items %}
+    <tr>
+      <form method="post">
+        <input type="hidden" name="action" value="update_item">
+        <input type="hidden" name="item_id" value="{{ item.id }}">
+        <td>
+          <select name="material_id">
+            {% for m in materials %}
+              <option value="{{ m.id }}" {% if item.material_id==m.id %}selected{% endif %}>{{ m.name }}</option>
+            {% endfor %}
+          </select>
+        </td>
+        <td><input type="number" name="quantity" min="1" value="{{ item.quantity }}"></td>
+        <td><input type="text" name="notes" value="{{ item.notes }}"></td>
+        <td>
+          <button type="submit">Update</button>
+      </form>
+      <form method="post" style="display:inline">
+        <input type="hidden" name="action" value="delete_item">
+        <input type="hidden" name="item_id" value="{{ item.id }}">
+        <button type="submit">Delete</button>
+      </form>
+        </td>
+    </tr>
+    {% endfor %}
+  </table>
+  <h4>Add item</h4>
+  <form method="post">
+    <input type="hidden" name="action" value="add_item">
+    <select name="material_id">
+      <option value=""></option>
+      {% for m in materials %}
+        <option value="{{ m.id }}">{{ m.name }}</option>
+      {% endfor %}
+    </select>
+    <input type="number" name="quantity" min="1">
+    <input type="text" name="notes">
+    <button type="submit">Add</button>
+  </form>
+  <form method="post">
+    <input type="hidden" name="action" value="submit">
+    <button type="submit">Submit to Materials Team</button>
+  </form>
+  <form method="post">
+    <input type="hidden" name="action" value="mark_shipped">
+    <button type="submit">Mark Shipped</button>
+  </form>
+  <form method="post">
+    <input type="hidden" name="action" value="mark_delivered">
+    <button type="submit">Mark Delivered</button>
+  </form>
+  {% if not shipment.submitted_at %}
+  <form method="post" onsubmit="return confirm('Delete shipment?');">
+    <input type="hidden" name="action" value="delete">
+    <button type="submit">Delete Shipment</button>
+  </form>
+  {% endif %}
+  {% endif %}
+{% endif %}
+{% endblock %}

--- a/migrations/versions/0026_session_shipping_fields.py
+++ b/migrations/versions/0026_session_shipping_fields.py
@@ -1,0 +1,25 @@
+"""add fields to session shipping"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = '0026_session_shipping_fields'
+down_revision = '0025_workshoptype_badge'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column('session_shipping', sa.Column('arrival_date', sa.Date(), nullable=True))
+    op.add_column('session_shipping', sa.Column('order_type', sa.Text(), nullable=True))
+    op.add_column('session_shipping', sa.Column('submitted_at', sa.DateTime(), nullable=True))
+    op.add_column('session_shipping', sa.Column('delivered_at', sa.DateTime(), nullable=True))
+    op.create_unique_constraint('uq_session_shipping_session_id', 'session_shipping', ['session_id'])
+
+
+def downgrade() -> None:
+    op.drop_constraint('uq_session_shipping_session_id', 'session_shipping', type_='unique')
+    op.drop_column('session_shipping', 'delivered_at')
+    op.drop_column('session_shipping', 'submitted_at')
+    op.drop_column('session_shipping', 'order_type')
+    op.drop_column('session_shipping', 'arrival_date')


### PR DESCRIPTION
## Summary
- support single materials shipment per session with arrival date, order type, and delivery tracking
- add materials page for sessions where staff manage items and statuses while CSA can only provide shipping location
- mark sessions as materials_ordered when shipment delivered

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ae0bb9b43c832ea5fc17ecdf956ec2