### PR TITLE
Restrict materials shipment actions by role

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -403,4 +403,5 @@ Participant accounts provision with default password "KTRocks!" and flash summar
   • Marking Delivered sets `Session.materials_ordered = TRUE`.
   • Submit requires `arrival_date` and at least one line item.
   • Order Type uses fixed list: "KT-Run Standard materials", "KT-Run Modular materials", "KT-Run LDI materials", "Client-run Bulk order", "Simulation".
-  • Materials page opens directly to the edit form; shipment is auto-created for staff if absent; CSA sees read-only until staff initializes.
+  • Permissions: Admin or CRM may create and edit shipments; only Admin may mark Delivered. KT Delivery and Contractors have view-only access. CSA cannot modify shipments.
+  • Materials page auto-creates a shipment only for Admin/CRM; others see read-only if absent.

--- a/app/routes/materials.py
+++ b/app/routes/materials.py
@@ -19,16 +19,26 @@ ORDER_TYPES = [
 ]
 
 
-def _is_staff(user: User | None) -> bool:
+def can_manage_shipment(user: User | None) -> bool:
     return bool(
         user
         and (
-            user.is_app_admin
-            or user.is_admin
-            or getattr(user, "is_kcrm", False)
-            or getattr(user, "is_kt_delivery", False)
-            or getattr(user, "is_kt_staff", False)
+            user.is_app_admin or user.is_admin or getattr(user, "is_kcrm", False)
+        )
+    )
+
+
+def can_mark_delivered(user: User | None) -> bool:
+    return bool(user and (user.is_app_admin or user.is_admin))
+
+
+def is_view_only(user: User | None) -> bool:
+    return bool(
+        user
+        and (
+            getattr(user, "is_kt_delivery", False)
             or getattr(user, "is_kt_contractor", False)
+            or getattr(user, "is_kt_staff", False)
         )
     )
 
@@ -43,11 +53,27 @@ def materials_access(fn):
         user_id = flask_session.get("user_id")
         if user_id:
             user = db.session.get(User, user_id)
-            if _is_staff(user):
-                return fn(session_id, *args, **kwargs, sess=sess, current_user=user, csa_view=False)
+            if can_manage_shipment(user) or is_view_only(user):
+                return fn(
+                    session_id,
+                    *args,
+                    **kwargs,
+                    sess=sess,
+                    current_user=user,
+                    csa_view=False,
+                    view_only=is_view_only(user),
+                )
         account_id = flask_session.get("participant_account_id")
         if account_id and sess.csa_account_id == account_id:
-            return fn(session_id, *args, **kwargs, sess=sess, current_user=None, csa_view=True)
+            return fn(
+                session_id,
+                *args,
+                **kwargs,
+                sess=sess,
+                current_user=None,
+                csa_view=True,
+                view_only=True,
+            )
         abort(403)
 
     return wrapper
@@ -67,8 +93,10 @@ CSA_FIELDS = {
 }
 
 
-def can_edit_materials_header(field: str, user: User | None, shipment: SessionShipping | None) -> bool:
-    if _is_staff(user):
+def can_edit_materials_header(
+    field: str, user: User | None, shipment: SessionShipping | None
+) -> bool:
+    if can_manage_shipment(user):
         return True
     if shipment and shipment.submitted_at:
         return False
@@ -86,11 +114,17 @@ def _parse_date(val: str | None):
 
 @bp.route("", methods=["GET", "POST"])
 @materials_access
-def materials_view(session_id: int, sess: Session, current_user: User | None, csa_view: bool):
+def materials_view(
+    session_id: int,
+    sess: Session,
+    current_user: User | None,
+    csa_view: bool,
+    view_only: bool,
+):
     shipment = SessionShipping.query.filter_by(session_id=session_id).first()
-    readonly = False
+    readonly = view_only
     if not shipment:
-        if not csa_view and current_user:
+        if not readonly and not csa_view:
             shipment = SessionShipping(session_id=session_id, created_by=current_user.id)
             db.session.add(shipment)
             db.session.commit()
@@ -102,9 +136,18 @@ def materials_view(session_id: int, sess: Session, current_user: User | None, cs
         if readonly:
             abort(403)
         action = request.form.get("action")
-        if action == "create":
-            if csa_view:
+        if action == "mark_delivered":
+            if not can_mark_delivered(current_user):
                 abort(403)
+            shipment.delivered_at = datetime.utcnow()
+            sess.materials_ordered = True
+            sess.materials_ordered_at = datetime.utcnow()
+            db.session.commit()
+            flash("Shipment delivered", "info")
+            return redirect(url_for("materials.materials_view", session_id=session_id))
+        if not can_manage_shipment(current_user):
+            abort(403)
+        if action == "create":
             if shipment:
                 flash("Shipment already exists", "error")
             else:
@@ -115,7 +158,6 @@ def materials_view(session_id: int, sess: Session, current_user: User | None, cs
         if not shipment:
             abort(404)
         if action == "update_header":
-            unauthorized = False
             fields = CSA_FIELDS | {
                 "courier",
                 "tracking",
@@ -126,24 +168,19 @@ def materials_view(session_id: int, sess: Session, current_user: User | None, cs
             for field in fields:
                 val = request.form.get(field)
                 if not can_edit_materials_header(field, current_user, shipment):
-                    if csa_view and val:
-                        unauthorized = True
                     continue
                 if field in {"ship_date", "arrival_date"}:
                     setattr(shipment, field, _parse_date(val))
                 else:
                     setattr(shipment, field, val or None)
-            if not csa_view and sess.client and not sess.client.sfc_link:
+            if sess.client and not sess.client.sfc_link:
                 sfc_link = request.form.get("sfc_link")
                 if sfc_link:
                     sess.client.sfc_link = sfc_link
             db.session.commit()
-            if unauthorized:
-                flash("You can only provide shipping location details.", "error")
-            else:
-                flash("Saved", "info")
+            flash("Saved", "info")
             return redirect(url_for("materials.materials_view", session_id=session_id))
-        if action == "add_item" and not csa_view:
+        if action == "add_item":
             material_id = request.form.get("material_id")
             qty = request.form.get("quantity")
             notes = request.form.get("notes")
@@ -159,7 +196,7 @@ def materials_view(session_id: int, sess: Session, current_user: User | None, cs
             else:
                 flash("Material and quantity required", "error")
             return redirect(url_for("materials.materials_view", session_id=session_id))
-        if action == "update_item" and not csa_view:
+        if action == "update_item":
             item_id = request.form.get("item_id")
             item = db.session.get(SessionShippingItem, int(item_id)) if item_id else None
             if item and item.session_shipping_id == shipment.id:
@@ -170,33 +207,26 @@ def materials_view(session_id: int, sess: Session, current_user: User | None, cs
                 item.notes = request.form.get("notes")
                 db.session.commit()
             return redirect(url_for("materials.materials_view", session_id=session_id))
-        if action == "delete_item" and not csa_view:
+        if action == "delete_item":
             item_id = request.form.get("item_id")
             item = db.session.get(SessionShippingItem, int(item_id)) if item_id else None
             if item and item.session_shipping_id == shipment.id:
                 db.session.delete(item)
                 db.session.commit()
             return redirect(url_for("materials.materials_view", session_id=session_id))
-        if action == "submit" and not csa_view:
+        if action == "submit":
             if not shipment.arrival_date or len(shipment.items) == 0:
                 flash("Arrival date and at least one line item required", "error")
             else:
                 shipment.submitted_at = datetime.utcnow()
                 db.session.commit()
             return redirect(url_for("materials.materials_view", session_id=session_id))
-        if action == "mark_shipped" and not csa_view:
+        if action == "mark_shipped":
             if not shipment.ship_date:
                 shipment.ship_date = date.today()
             db.session.commit()
             return redirect(url_for("materials.materials_view", session_id=session_id))
-        if action == "mark_delivered" and not csa_view:
-            shipment.delivered_at = datetime.utcnow()
-            sess.materials_ordered = True
-            sess.materials_ordered_at = datetime.utcnow()
-            db.session.commit()
-            flash("Shipment delivered", "info")
-            return redirect(url_for("materials.materials_view", session_id=session_id))
-        if action == "delete" and not csa_view:
+        if action == "delete":
             if shipment.submitted_at:
                 flash("Cannot delete after submit", "error")
             else:
@@ -211,7 +241,7 @@ def materials_view(session_id: int, sess: Session, current_user: User | None, cs
             status = "Shipped"
         elif shipment.submitted_at:
             status = "Submitted"
-    materials = Material.query.order_by(Material.name).all() if not csa_view else []
+    materials = Material.query.order_by(Material.name).all() if not view_only else []
     return render_template(
         "sessions/materials.html",
         sess=sess,
@@ -223,4 +253,6 @@ def materials_view(session_id: int, sess: Session, current_user: User | None, cs
         readonly=readonly,
         current_user=current_user,
         can_edit_materials_header=can_edit_materials_header,
+        can_manage=can_manage_shipment(current_user),
+        can_mark_delivered=can_mark_delivered(current_user),
     )

--- a/app/templates/sessions/materials.html
+++ b/app/templates/sessions/materials.html
@@ -100,12 +100,12 @@
   </div>
   <button type="submit" {% if readonly %}disabled{% endif %}>Save</button>
 </form>
-{% if not csa_view %}
 <h3>Items</h3>
 <table border="1" cellpadding="4" cellspacing="0">
-  <tr><th>Material</th><th>Qty</th><th>Notes</th><th></th></tr>
+  <tr><th>Material</th><th>Qty</th><th>Notes</th>{% if can_manage %}<th></th>{% endif %}</tr>
   {% for item in shipment.items %}
   <tr>
+    {% if can_manage %}
     <form method="post">
       <input type="hidden" name="action" value="update_item">
       <input type="hidden" name="item_id" value="{{ item.id }}">
@@ -128,9 +128,16 @@
       <button type="submit">Delete</button>
     </form>
       </td>
+    {% else %}
+      <td>{{ item.material.name if item.material else '' }}</td>
+      <td>{{ item.quantity }}</td>
+      <td>{{ item.notes or '' }}</td>
+      {% if can_manage %}<td></td>{% endif %}
+    {% endif %}
   </tr>
   {% endfor %}
 </table>
+{% if can_manage %}
 <h4>Add item</h4>
 <form method="post">
   <input type="hidden" name="action" value="add_item">
@@ -152,16 +159,19 @@
   <input type="hidden" name="action" value="mark_shipped">
   <button type="submit">Mark Shipped</button>
 </form>
+{% endif %}
+{% if can_mark_delivered %}
 <form method="post">
   <input type="hidden" name="action" value="mark_delivered">
   <button type="submit">Mark Delivered</button>
 </form>
-{% if not shipment.submitted_at %}
+{% endif %}
+{% if can_manage and not shipment.submitted_at %}
 <form method="post" onsubmit="return confirm('Delete shipment?');">
   <input type="hidden" name="action" value="delete">
   <button type="submit">Delete Shipment</button>
 </form>
 {% endif %}
-{% endif %}
+{% endblock %}
 {% endblock %}
 


### PR DESCRIPTION
## Summary
- Enforce role-specific permissions for materials shipments
- Hide shipment editing UI for view-only roles
- Update context docs for new materials permission matrix

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ae137cd4f4832e909c8ccb7fb05cd1