### PR TITLE
Fix materials order page internal error

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -405,3 +405,6 @@ Participant accounts provision with default password "KTRocks!" and flash summar
   • Order Type uses fixed list: "KT-Run Standard materials", "KT-Run Modular materials", "KT-Run LDI materials", "Client-run Bulk order", "Simulation".
   • Permissions: Admin or CRM may create and edit shipments; only Admin may mark Delivered. KT Delivery and Contractors have view-only access. CSA cannot modify shipments.
   • Materials page auto-creates a shipment only for Admin/CRM; others see read-only if absent.
+
+## Latest update done by codex 01/15/2027
+- Fixed a stray endblock in `sessions/materials.html` that caused an internal server error when opening the Materials Order page.

--- a/app/templates/sessions/materials.html
+++ b/app/templates/sessions/materials.html
@@ -173,5 +173,4 @@
 </form>
 {% endif %}
 {% endblock %}
-{% endblock %}
 

--- a/tests/test_materials.py
+++ b/tests/test_materials.py
@@ -1,0 +1,39 @@
+import os
+from datetime import date
+import pytest
+
+from app.app import create_app, db
+from app.models import User, WorkshopType, Session, MaterialType, Material
+
+
+@pytest.fixture
+def app():
+    os.environ["DATABASE_URL"] = "sqlite:///:memory:"
+    os.makedirs("/srv", exist_ok=True)
+    app = create_app()
+    with app.app_context():
+        db.create_all()
+        yield app
+        db.session.remove()
+
+
+def test_materials_page_loads(app):
+    with app.app_context():
+        admin = User(email="admin@example.com", is_app_admin=True, is_admin=True)
+        admin.set_password("x")
+        wt = WorkshopType(code="WT", name="WT")
+        mt = MaterialType(name="Kit")
+        db.session.add_all([admin, wt, mt])
+        db.session.commit()
+        mat = Material(material_type_id=mt.id, name="Sample Kit")
+        sess = Session(title="S1", workshop_type=wt, start_date=date.today(), end_date=date.today())
+        db.session.add_all([mat, sess])
+        db.session.commit()
+        admin_id = admin.id
+        session_id = sess.id
+    client = app.test_client()
+    with client.session_transaction() as sess_tx:
+        sess_tx["user_id"] = admin_id
+    resp = client.get(f"/sessions/{session_id}/materials")
+    assert resp.status_code == 200
+    assert b"Materials Order for" in resp.data


### PR DESCRIPTION
## Summary
- remove stray endblock from materials order template to stop 500 errors
- add regression test covering materials order route
- document fix in CONTEXT

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ae15e28f54832e859b50d8d316f993