### PR TITLE
Streamline materials order workflow and remove duplicate flashes

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -408,3 +408,9 @@ Participant accounts provision with default password "KTRocks!" and flash summar
 
 ## Latest update done by codex 01/15/2027
 - Fixed a stray endblock in `sessions/materials.html` that caused an internal server error when opening the Materials Order page.
+
+## Latest update done by codex 02/15/2027
+- Flash messages rendered only once via `base.html`, eliminating duplicated per-page blocks.
+- New Session form's save button now reads **Proceed to Material Order** and redirects to the materials order page.
+- Materials orders are auto-created for each session; Admin, SysAdmin, and CERM can edit while Delivery and Contractors have read-only access.
+- Removed the submit-to-materials step and the "Materials order not initialized" warning; shipments remain editable until delivered or the session is finalized.

--- a/app/routes/sessions.py
+++ b/app/routes/sessions.py
@@ -29,6 +29,7 @@ from ..models import (
     Certificate,
     WorkshopType,
     AuditLog,
+    SessionShipping,
 )
 from sqlalchemy import or_, func
 from ..utils.certificates import generate_for_session, remove_session_certificates
@@ -216,6 +217,7 @@ def new_session(current_user):
             sess.facilitators = User.query.filter(User.id.in_(add_ids)).all()
         db.session.add(sess)
         db.session.flush()
+        db.session.add(SessionShipping(session_id=sess.id, created_by=current_user.id))
         db.session.add(
             AuditLog(
                 user_id=current_user.id,
@@ -264,7 +266,7 @@ def new_session(current_user):
         if changes:
             msg += ": " + ", ".join(changes)
         flash(msg, "success")
-        return redirect(url_for("sessions.session_detail", session_id=sess.id))
+        return redirect(url_for("materials.materials_view", session_id=sess.id))
     tz_map = {
         "NA": "America/New_York",
         "EU": "Europe/Paris",

--- a/app/templates/account_password.html
+++ b/app/templates/account_password.html
@@ -1,9 +1,6 @@
 {% extends 'base.html' %}
 {% block title %}Set Password{% endblock %}
 {% block content %}
-{% with msgs=get_flashed_messages(with_categories=true) %}
-  {% if msgs %}<ul class="flashes">{% for cat,msg in msgs %}<li class="{{cat}}">{{msg}}</li>{% endfor %}</ul>{% endif %}
-{% endwith %}
 <h1>Set password for {{ account.email }}</h1>
 <form method="post">
   <p>Password: <input type="password" name="password" autocomplete="new-password"></p>

--- a/app/templates/clients/form.html
+++ b/app/templates/clients/form.html
@@ -1,9 +1,6 @@
 {% extends 'base.html' %}
 {% block title %}{{ 'New Client' if not client else 'Edit Client' }}{% endblock %}
 {% block content %}
-{% with msgs = get_flashed_messages(with_categories=true) %}
-  {% if msgs %}<ul class="flashes">{% for cat,msg in msgs %}<li class="{{cat}}">{{msg}}</li>{% endfor %}</ul>{% endif %}
-{% endwith %}
 <h1>{{ 'New Client' if not client else 'Edit Client' }}</h1>
 <form method="post">
   <div><label>Name <input type="text" name="name" value="{{ client.name if client else '' }}" required></label></div>

--- a/app/templates/clients/list.html
+++ b/app/templates/clients/list.html
@@ -1,9 +1,6 @@
 {% extends 'base.html' %}
 {% block title %}Clients{% endblock %}
 {% block content %}
-{% with msgs = get_flashed_messages(with_categories=true) %}
-  {% if msgs %}<ul class="flashes">{% for cat,msg in msgs %}<li class="{{cat}}">{{msg}}</li>{% endfor %}</ul>{% endif %}
-{% endwith %}
 <h1>Clients</h1>
 <p><a href="{{ url_for('clients.new_client') }}">New Client</a></p>
 <table>

--- a/app/templates/forgot_password.html
+++ b/app/templates/forgot_password.html
@@ -1,9 +1,6 @@
 {% extends 'base.html' %}
 {% block title %}Forgot Password{% endblock %}
 {% block content %}
-{% with msgs=get_flashed_messages(with_categories=true) %}
-  {% if msgs %}<ul class="flashes">{% for cat,msg in msgs %}<li class="{{cat}}">{{msg}}</li>{% endfor %}</ul>{% endif %}
-{% endwith %}
 <h1>Forgot Password</h1>
 <form method="post">
   <p>Email: <input type="email" name="email" required></p>

--- a/app/templates/participant_edit.html
+++ b/app/templates/participant_edit.html
@@ -1,9 +1,6 @@
 {% extends 'base.html' %}
 {% block title %}Edit Participant{% endblock %}
 {% block content %}
-{% with msgs = get_flashed_messages(with_categories=true) %}
-  {% if msgs %}<ul class="flashes">{% for cat,msg in msgs %}<li class="{{cat}}">{{msg}}</li>{% endfor %}</ul>{% endif %}
-{% endwith %}
 <h1>Edit Participant</h1>
 <form method="post">
   <div><label>Email <input type="email" value="{{ participant.email }}" readonly></label></div>

--- a/app/templates/reset_password.html
+++ b/app/templates/reset_password.html
@@ -1,9 +1,6 @@
 {% extends 'base.html' %}
 {% block title %}Reset Password{% endblock %}
 {% block content %}
-{% with msgs=get_flashed_messages(with_categories=true) %}
-  {% if msgs %}<ul class="flashes">{% for cat,msg in msgs %}<li class="{{cat}}">{{msg}}</li>{% endfor %}</ul>{% endif %}
-{% endwith %}
 <h1>Reset Password</h1>
 <form method="post">
   <input type="hidden" name="token" value="{{ token }}">

--- a/app/templates/session_detail.html
+++ b/app/templates/session_detail.html
@@ -1,9 +1,6 @@
 {% extends 'base.html' %}
 {% block title %}Session {{ session.title }}{% endblock %}
 {% block content %}
-{% with msgs = get_flashed_messages(with_categories=true) %}
-  {% if msgs %}<ul class="flashes">{% for cat,msg in msgs %}<li class="{{cat}}">{{msg}}</li>{% endfor %}</ul>{% endif %}
-{% endwith %}
 <h1>{{ session.title }}</h1>
 {% if session.cancelled %}<div class="banner">Session cancelled.</div>{% endif %}
 {% set start_time = session.daily_start_time.strftime('%H:%M') if session.daily_start_time else '' %}

--- a/app/templates/sessions.html
+++ b/app/templates/sessions.html
@@ -1,9 +1,6 @@
 {% extends 'base.html' %}
 {% block title %}Sessions{% endblock %}
 {% block content %}
-{% with msgs = get_flashed_messages(with_categories=true) %}
-  {% if msgs %}<ul class="flashes">{% for cat,msg in msgs %}<li class="{{cat}}">{{msg}}</li>{% endfor %}</ul>{% endif %}
-{% endwith %}
 <h1>Sessions</h1>
 <p><a href="{{ url_for('sessions.new_session') }}">New Session</a></p>
 {% if show_global %}

--- a/app/templates/sessions/form.html
+++ b/app/templates/sessions/form.html
@@ -1,9 +1,6 @@
 {% extends 'base.html' %}
 {% block title %}{{ 'New Session' if not session or not session.id else 'Edit Session' }}{% endblock %}
 {% block content %}
-{% with msgs = get_flashed_messages(with_categories=true) %}
-  {% if msgs %}<ul class="flashes">{% for cat,msg in msgs %}<li class="{{cat}}">{{msg}}</li>{% endfor %}</ul>{% endif %}
-{% endwith %}
 <h1>{{ 'New Session' if not session or not session.id else 'Edit Session' }}</h1>
 <form method="post">
   <fieldset>
@@ -120,7 +117,7 @@
   </fieldset>
   <div>Status: <span class="badge">{{ session.computed_status }}</span></div>
   {% endif %}
-  <button type="submit">Save</button>
+  <button type="submit">{{ 'Proceed to Material Order' if not session or not session.id else 'Save' }}</button>
 </form>
 <script>
   var delivered = document.querySelector('input[name="delivered"]');

--- a/app/templates/sessions/materials.html
+++ b/app/templates/sessions/materials.html
@@ -1,9 +1,6 @@
 {% extends 'base.html' %}
 {% block title %}Materials Order{% endblock %}
 {% block content %}
-{% with msgs = get_flashed_messages(with_categories=true) %}
-  {% if msgs %}<ul class="flashes">{% for cat,msg in msgs %}<li class="{{cat}}">{{msg}}</li>{% endfor %}</ul>{% endif %}
-{% endwith %}
 <h1>Materials Order for {{ sess.title }}</h1>
 <p>Status: {{ status }}</p>
 <form method="post">
@@ -152,10 +149,6 @@
   <button type="submit">Add</button>
 </form>
 <form method="post">
-  <input type="hidden" name="action" value="submit">
-  <button type="submit">Submit to Materials Team</button>
-</form>
-<form method="post">
   <input type="hidden" name="action" value="mark_shipped">
   <button type="submit">Mark Shipped</button>
 </form>
@@ -166,7 +159,7 @@
   <button type="submit">Mark Delivered</button>
 </form>
 {% endif %}
-{% if can_manage and not shipment.submitted_at %}
+{% if can_manage and not shipment.delivered_at %}
 <form method="post" onsubmit="return confirm('Delete shipment?');">
   <input type="hidden" name="action" value="delete">
   <button type="submit">Delete Shipment</button>

--- a/app/templates/settings_mail.html
+++ b/app/templates/settings_mail.html
@@ -1,11 +1,6 @@
 {% extends "base.html" %}
 {% block title %}Mail Settings{% endblock %}
 {% block content %}
-{% with messages = get_flashed_messages() %}
-  {% for message in messages %}
-    <p>{{ message }}</p>
-  {% endfor %}
-{% endwith %}
 <h2>SMTP Settings</h2>
 <p>Updated: {{ settings.updated_at }}</p>
 <form method="post">

--- a/app/templates/users/edit.html
+++ b/app/templates/users/edit.html
@@ -1,9 +1,6 @@
 {% extends 'base.html' %}
 {% block title %}Edit User{% endblock %}
 {% block content %}
-{% with msgs = get_flashed_messages(with_categories=true) %}
-  {% if msgs %}<ul class="flashes">{% for cat,msg in msgs %}<li class="{{cat}}">{{msg}}</li>{% endfor %}</ul>{% endif %}
-{% endwith %}
 <h1>Edit User</h1>
 <form method="post" action="{{ url_for('users.update_user', user_id=user.id) }}">
   <p>Email: <input type="text" name="email" value="{{ user.email }}" readonly style="background:#eee"></p>

--- a/app/templates/users/form.html
+++ b/app/templates/users/form.html
@@ -1,9 +1,6 @@
 {% extends 'base.html' %}
 {% block title %}{{ 'New User' if not user else 'Edit User' }}{% endblock %}
 {% block content %}
-{% with msgs = get_flashed_messages(with_categories=true) %}
-  {% if msgs %}<ul class="flashes">{% for cat,msg in msgs %}<li class="{{cat}}">{{msg}}</li>{% endfor %}</ul>{% endif %}
-{% endwith %}
 <h1>{{ 'New User' if not user else 'Edit User' }}</h1>
 <form method="post" autocomplete="off">
   <input type="text" style="display:none">

--- a/app/templates/users/list.html
+++ b/app/templates/users/list.html
@@ -1,9 +1,6 @@
 {% extends 'base.html' %}
 {% block title %}Users{% endblock %}
 {% block content %}
-{% with msgs = get_flashed_messages(with_categories=true) %}
-  {% if msgs %}<ul class="flashes">{% for cat,msg in msgs %}<li class="{{cat}}">{{msg}}</li>{% endfor %}</ul>{% endif %}
-{% endwith %}
 <h1>Users</h1>
 <p><a href="{{ url_for('users.new_user') }}">New User</a> | <a href="#" id="role-matrix-link">Role Matrix</a></p>
 


### PR DESCRIPTION
## Summary
- Render flash messages only once via base template
- Redirect new sessions directly to materials order with auto-created shipments
- Simplify materials order flow by removing submit step and initialization warning

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ae18ac2af0832e819d50aef8e80fb4