### PR TITLE
Add languages registry and materials type selection

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -420,3 +420,9 @@ Participant accounts provision with default password "KTRocks!" and flash summar
 - Settings adds **Materials** management (Standard workshop, Modular, LDI, Bulk order, Simulation) limited to Admin/SysAdmin.
 - Options stored in `materials_options` (order_type, title, languages JSON[], formats JSON[], is_active).
 - Session Materials header now offers a Materials dropdown filtered by Order Type, storing `materials_option_id` on the shipment (`name` defaults to "Main Shipment").
+
+## Latest update done by codex 04/15/2027
+- Settings adds **Languages** management (Admin/SysAdmin only) with name, active flag, and sort order.
+- Materials options draw languages from this table via `materials_option_languages` and select multiple languages.
+- Session language dropdown lists active Languages but preserves legacy values.
+- Session Materials header now labels **Materials type**, filters options by Order type, and stores the chosen `materials_option_id` with a preview of its languages and formats.

--- a/app/constants.py
+++ b/app/constants.py
@@ -8,3 +8,13 @@ BADGE_CHOICES = [
     ("Facilitator", "Facilitator"),
     ("Program Leader", "Program Leader"),
 ]
+
+LANGUAGE_NAMES = [
+    "Chinese",
+    "Dutch",
+    "English",
+    "French",
+    "German",
+    "Japanese",
+    "Spanish",
+]

--- a/app/models.py
+++ b/app/models.py
@@ -7,17 +7,6 @@ from sqlalchemy.orm import validates
 from .app import db
 from .utils.passwords import hash_password, check_password
 
-# Language choices stored as human labels for now
-LANG_CHOICES = [
-    ("Chinese", "zh"),
-    ("Dutch", "nl"),
-    ("English", "en"),
-    ("French", "fr"),
-    ("German", "de"),
-    ("Japanese", "ja"),
-    ("Spanish", "es"),
-]
-
 
 class User(db.Model):
     __tablename__ = "users"
@@ -122,6 +111,16 @@ class Settings(db.Model):
             return data.decode()
         except Exception:
             return None
+
+
+class Language(db.Model):
+    __tablename__ = "languages"
+
+    id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.String(120), unique=True, nullable=False)
+    is_active = db.Column(db.Boolean, nullable=False, default=True)
+    sort_order = db.Column(db.SmallInteger, nullable=False, default=100)
+    created_at = db.Column(db.DateTime, server_default=db.func.now(), nullable=False)
 
 
 class WorkshopType(db.Model):
@@ -357,6 +356,23 @@ class Material(db.Model):
     description = db.Column(db.Text)
 
 
+materials_option_languages = db.Table(
+    "materials_option_languages",
+    db.Column(
+        "materials_option_id",
+        db.Integer,
+        db.ForeignKey("materials_options.id", ondelete="CASCADE"),
+        primary_key=True,
+    ),
+    db.Column(
+        "language_id",
+        db.Integer,
+        db.ForeignKey("languages.id", ondelete="RESTRICT"),
+        primary_key=True,
+    ),
+)
+
+
 class MaterialsOption(db.Model):
     __tablename__ = "materials_options"
     __table_args__ = (
@@ -374,10 +390,10 @@ class MaterialsOption(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     order_type = db.Column(db.Text, nullable=False)
     title = db.Column(db.String(160), nullable=False)
-    languages = db.Column(db.JSON, nullable=False, default=list)
     formats = db.Column(db.JSON, nullable=False, default=list)
     is_active = db.Column(db.Boolean, nullable=False, default=True)
     created_at = db.Column(db.DateTime, server_default=db.func.now(), nullable=False)
+    languages = db.relationship("Language", secondary="materials_option_languages")
 
 
 class SessionShipping(db.Model):

--- a/app/routes/settings_languages.py
+++ b/app/routes/settings_languages.py
@@ -1,0 +1,85 @@
+from flask import Blueprint, abort, flash, redirect, render_template, request, url_for
+
+from ..app import db
+from ..models import Language
+from ..utils.rbac import admin_required
+
+bp = Blueprint('settings_languages', __name__, url_prefix='/settings/languages')
+
+
+@bp.get('/')
+@admin_required
+def list_langs(current_user):
+    langs = Language.query.order_by(Language.sort_order, Language.name).all()
+    return render_template('settings_languages/list.html', langs=langs)
+
+
+@bp.get('/new')
+@admin_required
+def new_lang(current_user):
+    return render_template('settings_languages/form.html', lang=None)
+
+
+@bp.post('/new')
+@admin_required
+def create_lang(current_user):
+    name = (request.form.get('name') or '').strip()
+    sort_order = request.form.get('sort_order') or '100'
+    if not name:
+        flash('Name required', 'error')
+        return redirect(url_for('settings_languages.new_lang'))
+    existing = Language.query.filter(db.func.lower(Language.name) == name.lower()).first()
+    if existing:
+        flash('Name must be unique', 'error')
+        return redirect(url_for('settings_languages.new_lang'))
+    lang = Language(name=name, sort_order=int(sort_order))
+    db.session.add(lang)
+    db.session.commit()
+    flash('Language created', 'success')
+    return redirect(url_for('settings_languages.list_langs'))
+
+
+@bp.get('/<int:lang_id>/edit')
+@admin_required
+def edit_lang(lang_id: int, current_user):
+    lang = db.session.get(Language, lang_id)
+    if not lang:
+        abort(404)
+    return render_template('settings_languages/form.html', lang=lang)
+
+
+@bp.post('/<int:lang_id>/edit')
+@admin_required
+def update_lang(lang_id: int, current_user):
+    lang = db.session.get(Language, lang_id)
+    if not lang:
+        abort(404)
+    name = (request.form.get('name') or '').strip()
+    sort_order = request.form.get('sort_order') or '100'
+    if not name:
+        flash('Name required', 'error')
+        return redirect(url_for('settings_languages.edit_lang', lang_id=lang_id))
+    existing = Language.query.filter(
+        db.func.lower(Language.name) == name.lower(), Language.id != lang.id
+    ).first()
+    if existing:
+        flash('Name must be unique', 'error')
+        return redirect(url_for('settings_languages.edit_lang', lang_id=lang_id))
+    lang.name = name
+    lang.sort_order = int(sort_order)
+    lang.is_active = bool(request.form.get('is_active'))
+    db.session.commit()
+    flash('Language updated', 'success')
+    return redirect(url_for('settings_languages.list_langs'))
+
+
+@bp.post('/<int:lang_id>/toggle')
+@admin_required
+def toggle_lang(lang_id: int, current_user):
+    lang = db.session.get(Language, lang_id)
+    if not lang:
+        abort(404)
+    lang.is_active = not lang.is_active
+    db.session.commit()
+    flash('Language activated' if lang.is_active else 'Language deactivated', 'info')
+    return redirect(url_for('settings_languages.list_langs'))

--- a/app/templates/nav.html
+++ b/app/templates/nav.html
@@ -23,6 +23,7 @@
       {% if current_user and (current_user.is_app_admin or current_user.is_admin) %}
       <li><a href="{{ url_for('clients.list_clients') }}">Clients</a></li>
       <li><a href="{{ url_for('workshop_types.list_types') }}">Workshop Types</a></li>
+      <li><a href="{{ url_for('settings_languages.list_langs') }}">Languages</a></li>
       <li>
         <details>
           <summary>Materials</summary>

--- a/app/templates/sessions/form.html
+++ b/app/templates/sessions/form.html
@@ -48,9 +48,12 @@
     </label></div>
     <div><label>Language*
       <select name="language" required>
-        {% for label, code in LANG_CHOICES %}
-        <option value="{{ label }}" {% if (session and session.language==label) or (not session and label=='English') %}selected{% endif %}>{{ label }}</option>
+        {% for lang in languages %}
+        <option value="{{ lang.name }}" {% if session.language==lang.name %}selected{% endif %}>{{ lang.name }}</option>
         {% endfor %}
+        {% if extra_language %}
+        <option value="{{ extra_language }}" selected>{{ extra_language }}</option>
+        {% endif %}
       </select>
     </label></div>
     <div><label>Simulation Outline<br><textarea name="simulation_outline">{{ session.simulation_outline or '' }}</textarea></label></div>

--- a/app/templates/sessions/materials.html
+++ b/app/templates/sessions/materials.html
@@ -25,7 +25,7 @@
       </select>
     {% else %}{{ shipment.order_type|default('', true) }}{% endif %}
   </div>
-  <div>Materials:
+  <div>Materials type:
     {% if shipment.order_type %}
       {% if can_edit_materials_header('materials_option_id', current_user, shipment) and not readonly %}
         <select name="materials_option_id">
@@ -36,7 +36,7 @@
         </select>
       {% else %}{{ shipment.materials_option.title | default('', true) }}{% endif %}
       {% if selected_option %}
-      <div><small>{{ selected_option.title }}{% if selected_option.languages %} — {{ selected_option.languages|join(', ') }}{% endif %}{% if selected_option.formats %} ({{ selected_option.formats|join(', ') }}){% endif %}</small></div>
+      <div><small>{{ selected_option.title }}{% if selected_option.languages %} — {{ selected_option.languages | map(attribute='name') | join(', ') }}{% endif %}{% if selected_option.formats %} ({{ selected_option.formats|join(', ') }}){% endif %}</small></div>
       {% endif %}
     {% endif %}
   </div>

--- a/app/templates/settings_languages/form.html
+++ b/app/templates/settings_languages/form.html
@@ -1,0 +1,19 @@
+{% extends 'base.html' %}
+{% block title %}Languages{% endblock %}
+{% block content %}
+<h1>{{ 'Edit' if lang else 'New' }} Language</h1>
+<form method="post">
+  <div>Name:
+    <input type="text" name="name" value="{{ lang.name if lang else '' }}" maxlength="120">
+  </div>
+  <div>Sort order:
+    <input type="number" name="sort_order" value="{{ lang.sort_order if lang else 100 }}">
+  </div>
+  {% if lang %}
+  <div>Status:
+    <input type="checkbox" name="is_active" value="1" {% if lang.is_active %}checked{% endif %}>
+  </div>
+  {% endif %}
+  <button type="submit">Save</button>
+</form>
+{% endblock %}

--- a/app/templates/settings_languages/list.html
+++ b/app/templates/settings_languages/list.html
@@ -1,0 +1,22 @@
+{% extends 'base.html' %}
+{% block title %}Languages{% endblock %}
+{% block content %}
+<h1>Languages</h1>
+<p><a href="{{ url_for('settings_languages.new_lang') }}">New language</a></p>
+<table border="1" cellpadding="4" cellspacing="0">
+  <tr><th>Name</th><th>Sort Order</th><th>Status</th><th></th></tr>
+  {% for lang in langs %}
+  <tr>
+    <td>{{ lang.name }}</td>
+    <td>{{ lang.sort_order }}</td>
+    <td>{{ 'Active' if lang.is_active else 'Inactive' }}</td>
+    <td>
+      <a href="{{ url_for('settings_languages.edit_lang', lang_id=lang.id) }}">Edit</a>
+      <form method="post" action="{{ url_for('settings_languages.toggle_lang', lang_id=lang.id) }}" style="display:inline">
+        <button type="submit">{{ 'Deactivate' if lang.is_active else 'Activate' }}</button>
+      </form>
+    </td>
+  </tr>
+  {% endfor %}
+</table>
+{% endblock %}

--- a/app/templates/settings_materials/form.html
+++ b/app/templates/settings_materials/form.html
@@ -7,7 +7,11 @@
     <input type="text" name="title" value="{{ opt.title if opt else '' }}" maxlength="160">
   </div>
   <div>Languages:
-    <input type="text" name="languages" value="{{ opt.languages|join(', ') if opt else '' }}">
+    <select name="language_ids" multiple>
+      {% for lang in languages %}
+        <option value="{{ lang.id }}" {% if opt and lang in opt.languages %}selected{% endif %}>{{ lang.name }}</option>
+      {% endfor %}
+    </select>
   </div>
   <div>Formats:
     {% for fmt in format_choices %}

--- a/app/templates/settings_materials/list.html
+++ b/app/templates/settings_materials/list.html
@@ -8,7 +8,7 @@
   {% for opt in options %}
   <tr>
     <td>{{ opt.title }}</td>
-    <td>{{ opt.languages|join(', ') }}</td>
+    <td>{{ opt.languages | map(attribute='name') | join(', ') }}</td>
     <td>{{ opt.formats|join(', ') }}</td>
     <td>{{ 'Active' if opt.is_active else 'Inactive' }}</td>
     <td>

--- a/migrations/versions/0028_languages_bridge.py
+++ b/migrations/versions/0028_languages_bridge.py
@@ -1,0 +1,59 @@
+"""add languages table and materials_option_languages bridge"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = '0028_languages_bridge'
+down_revision = '0027_materials_options'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        'languages',
+        sa.Column('id', sa.Integer(), primary_key=True),
+        sa.Column('name', sa.String(length=120), nullable=False, unique=True),
+        sa.Column('is_active', sa.Boolean(), nullable=False, server_default=sa.text('true')),
+        sa.Column('sort_order', sa.SmallInteger(), nullable=False, server_default='100'),
+        sa.Column('created_at', sa.DateTime(), nullable=False, server_default=sa.text('now()')),
+    )
+    op.create_table(
+        'materials_option_languages',
+        sa.Column('materials_option_id', sa.Integer(), nullable=False),
+        sa.Column('language_id', sa.Integer(), nullable=False),
+        sa.ForeignKeyConstraint(['materials_option_id'], ['materials_options.id'], ondelete='CASCADE'),
+        sa.ForeignKeyConstraint(['language_id'], ['languages.id'], ondelete='RESTRICT'),
+        sa.PrimaryKeyConstraint('materials_option_id', 'language_id', name='pk_materials_option_languages'),
+    )
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+    if 'materials_options' in insp.get_table_names():
+        cols = [c['name'] for c in insp.get_columns('materials_options')]
+        if 'languages' in cols:
+            op.drop_column('materials_options', 'languages')
+    names = sorted([
+        'Chinese',
+        'Dutch',
+        'English',
+        'French',
+        'German',
+        'Japanese',
+        'Spanish',
+    ])
+    for n in names:
+        op.execute(
+            sa.text(
+                "INSERT INTO languages (name) VALUES (:name) ON CONFLICT (name) DO NOTHING"
+            ),
+            {"name": n},
+        )
+
+
+def downgrade() -> None:
+    op.add_column(
+        'materials_options',
+        sa.Column('languages', sa.JSON(), nullable=False, server_default='[]'),
+    )
+    op.drop_table('materials_option_languages')
+    op.drop_table('languages')


### PR DESCRIPTION
## Summary
- Introduce `languages` table and `materials_option_languages` bridge for materials options
- Add admin-only Languages settings with CRUD and integrate multi-select languages into Materials options
- Update session forms and materials order page to use language registry and a "Materials type" dropdown

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ae284c7234832ea4b0bacc919020b8