### PR TITLE
Fix languages migration execute usage

### DIFF
--- a/migrations/versions/0028_languages_bridge.py
+++ b/migrations/versions/0028_languages_bridge.py
@@ -42,7 +42,7 @@ def upgrade() -> None:
         'Spanish',
     ])
     for n in names:
-        op.execute(
+        bind.execute(
             sa.text(
                 "INSERT INTO languages (name) VALUES (:name) ON CONFLICT (name) DO NOTHING"
             ),


### PR DESCRIPTION
## Summary
- fix TypeError in 0028_languages_bridge migration by executing seeded language inserts via DB connection

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ae2d56b940832eb6d5606a328cdfcd