### PR TITLE
Adjust navigation and session listings

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -426,3 +426,8 @@ Participant accounts provision with default password "KTRocks!" and flash summar
 - Materials options draw languages from this table via `materials_option_languages` and select multiple languages.
 - Session language dropdown lists active Languages but preserves legacy values.
 - Session Materials header now labels **Materials type**, filters options by Order type, and stores the chosen `materials_option_id` with a preview of its languages and formats.
+
+## Latest update done by codex 05/30/2027
+- Settings navigation flattens Materials links to match other Settings items.
+- Left navigation moves My Sessions and My Certificates below Resources, Sessions, and Surveys.
+- Sessions and My Sessions tables now show Client and place Location between Title and Workshop Type.

--- a/app/templates/my_sessions.html
+++ b/app/templates/my_sessions.html
@@ -6,6 +6,7 @@
 <table border="1" cellpadding="4" cellspacing="0">
   <tr>
     <th>Title</th>
+    <th>Location</th>
     <th>Workshop Type</th>
     <th>Dates</th>
     <th>Client</th>
@@ -17,6 +18,7 @@
   {% for s in sessions %}
   <tr>
     <td>{{ s.title }}</td>
+    <td>{{ s.location }}</td>
     <td>{% if s.workshop_type %}{{ s.workshop_type.code }} / {{ s.workshop_type.name }}{% endif %}</td>
     <td>{{ s.start_date }} - {{ s.end_date }} {{ s.daily_start_time }}-{{ s.daily_end_time }}</td>
     <td>{% if s.client %}{{ s.client.name }}{% endif %}</td>

--- a/app/templates/nav.html
+++ b/app/templates/nav.html
@@ -2,10 +2,6 @@
   <!-- Navigation order updated -->
   <a href="/"><img src="{{ url_for('static', filename='ktlogo1.png') }}" onerror="this.onerror=null;this.src='/logo.png';" alt="KT Logo" style="max-height:48px;"></a>
   <a href="{{ url_for('home') }}">Home</a>
-  {% if current_user or is_csa %}
-  <a href="{{ url_for('my_sessions.list_my_sessions') }}">My Sessions</a>
-  {% endif %}
-  <a href="{{ url_for('learner.my_certs') }}">My Certificates</a>
   {% if current_user or session.get('participant_account_id') %}
   <a href="{{ url_for('resources') }}">Resources</a>
   {% endif %}
@@ -15,6 +11,10 @@
   {% if current_user or session.get('participant_account_id') %}
   <a href="{{ url_for('surveys') }}">Surveys</a>
   {% endif %}
+  {% if current_user or is_csa %}
+  <a href="{{ url_for('my_sessions.list_my_sessions') }}">My Sessions</a>
+  {% endif %}
+  <a href="{{ url_for('learner.my_certs') }}">My Certificates</a>
   <a href="{{ url_for('verify_form') }}">Verify Certificates</a>
   {% if current_user or session.get('participant_account_id') or is_csa %}
   <details class="settings">
@@ -24,18 +24,11 @@
       <li><a href="{{ url_for('clients.list_clients') }}">Clients</a></li>
       <li><a href="{{ url_for('workshop_types.list_types') }}">Workshop Types</a></li>
       <li><a href="{{ url_for('settings_languages.list_langs') }}">Languages</a></li>
-      <li>
-        <details>
-          <summary>Materials</summary>
-          <ul>
-            <li><a href="{{ url_for('settings_materials.list_options', slug='standard') }}">Standard workshop</a></li>
-            <li><a href="{{ url_for('settings_materials.list_options', slug='modular') }}">Modular</a></li>
-            <li><a href="{{ url_for('settings_materials.list_options', slug='ldi') }}">LDI</a></li>
-            <li><a href="{{ url_for('settings_materials.list_options', slug='bulk') }}">Bulk order</a></li>
-            <li><a href="{{ url_for('settings_materials.list_options', slug='simulation') }}">Simulation</a></li>
-          </ul>
-        </details>
-      </li>
+      <li><a href="{{ url_for('settings_materials.list_options', slug='standard') }}">Standard Materials</a></li>
+      <li><a href="{{ url_for('settings_materials.list_options', slug='modular') }}">Modular Materials</a></li>
+      <li><a href="{{ url_for('settings_materials.list_options', slug='ldi') }}">LDI Materials</a></li>
+      <li><a href="{{ url_for('settings_materials.list_options', slug='bulk') }}">Bulk order Materials</a></li>
+      <li><a href="{{ url_for('settings_materials.list_options', slug='simulation') }}">Simulation Materials</a></li>
       {% endif %}
       <li><a href="{{ url_for('learner.profile') }}">My Profile</a></li>
       {% if current_user and (current_user.is_app_admin or current_user.is_admin) %}

--- a/app/templates/sessions.html
+++ b/app/templates/sessions.html
@@ -9,14 +9,15 @@
 <p><a href="{{ url_for('sessions.list_sessions', global=1) }}">Show Global Sessions</a></p>
 {% endif %}
 <table border="1" cellpadding="4" cellspacing="0">
-  <tr><th>Title</th><th>Workshop Type</th><th>Start</th><th>End</th><th>Location</th><th>Status</th></tr>
+  <tr><th>Title</th><th>Location</th><th>Workshop Type</th><th>Start</th><th>End</th><th>Client</th><th>Status</th></tr>
   {% for s in sessions %}
   <tr>
     <td><a href="{{ url_for('sessions.session_detail', session_id=s.id) }}">{{ s.title }}</a></td>
+    <td>{{ s.location }}</td>
     <td>{% if s.workshop_type %}{{ s.workshop_type.code }} — {{ s.workshop_type.name }}{% endif %}</td>
     <td>{{ s.start_date }}</td>
     <td>{{ s.end_date }}</td>
-    <td>{{ s.location }}</td>
+    <td>{% if s.client %}{{ s.client.name }}{% endif %}</td>
     <td>{{ s.status }}</td>
   </tr>
   {% endfor %}


### PR DESCRIPTION
## Summary
- Reorder left navigation placing My Sessions and My Certificates after Resources, Sessions, and Surveys
- Make Settings > Materials links consistent with other Settings items
- Show Client and reposition Location in Sessions and My Sessions tables

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ae30ffec78832ebf231c27d9cfe855