### PR TITLE
Group material settings under submenu

### DIFF
--- a/app/templates/nav.html
+++ b/app/templates/nav.html
@@ -21,16 +21,23 @@
     <summary class="nav-link">Settings</summary>
     <ul>
       {% if current_user and (current_user.is_app_admin or current_user.is_admin) %}
-      <li><a href="{{ url_for('clients.list_clients') }}">Clients</a></li>
-      <li><a href="{{ url_for('workshop_types.list_types') }}">Workshop Types</a></li>
-      <li><a href="{{ url_for('settings_languages.list_langs') }}">Languages</a></li>
-      <li><a href="{{ url_for('settings_materials.list_options', slug='standard') }}">Standard Materials</a></li>
-      <li><a href="{{ url_for('settings_materials.list_options', slug='modular') }}">Modular Materials</a></li>
-      <li><a href="{{ url_for('settings_materials.list_options', slug='ldi') }}">LDI Materials</a></li>
-      <li><a href="{{ url_for('settings_materials.list_options', slug='bulk') }}">Bulk order Materials</a></li>
-      <li><a href="{{ url_for('settings_materials.list_options', slug='simulation') }}">Simulation Materials</a></li>
-      {% endif %}
-      <li><a href="{{ url_for('learner.profile') }}">My Profile</a></li>
+        <li><a href="{{ url_for('clients.list_clients') }}">Clients</a></li>
+        <li><a href="{{ url_for('workshop_types.list_types') }}">Workshop Types</a></li>
+        <li><a href="{{ url_for('settings_languages.list_langs') }}">Languages</a></li>
+        <li>
+          <details>
+            <summary class="nav-link">Material settings</summary>
+            <ul>
+              <li><a href="{{ url_for('settings_materials.list_options', slug='standard') }}">Standard</a></li>
+              <li><a href="{{ url_for('settings_materials.list_options', slug='modular') }}">Modular</a></li>
+              <li><a href="{{ url_for('settings_materials.list_options', slug='ldi') }}">LDI</a></li>
+              <li><a href="{{ url_for('settings_materials.list_options', slug='bulk') }}">Bulk Order</a></li>
+              <li><a href="{{ url_for('settings_materials.list_options', slug='simulation') }}">Simulation</a></li>
+            </ul>
+          </details>
+        </li>
+        {% endif %}
+        <li><a href="{{ url_for('learner.profile') }}">My Profile</a></li>
       {% if current_user and (current_user.is_app_admin or current_user.is_admin) %}
       <li><a href="{{ url_for('users.list_users') }}">Users</a></li>
       {% if current_user.is_app_admin %}


### PR DESCRIPTION
## Summary
- Nest materials pages within a Material settings submenu under Settings
- Shorten material menu link labels

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ae33a6f3bc832e83d7d398e4daaff5