### PR TITLE
Manage client locations via edit page with session deep links

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -64,7 +64,7 @@ Passwords are hashed via a shared bcrypt helper. When manually creating Users or
 2.4 Message templates stored in DB with simple placeholders (name, session, date)  
 2.5 Test mail endpoint in Settings to send a one‑off test to an address
 2.6 Delivery logging table (to, subject, status, error text)
-2.7 Clients: manage client records (Name unique case-insensitive, SFC Link, CRM (User), Data Region NA/EU/SEA/Other, Status active/inactive). SysAdmin or Administrator can CRUD under Settings.
+2.7 Clients: manage client records (Name unique case-insensitive, SFC Link, CRM (User), Data Region NA/EU/SEA/Other, Status active/inactive). SysAdmin or Administrator can CRUD under Settings. Client edit also manages per‑client Workshop and Shipping Locations with inline create/edit forms.
 2.8 SMTP test button uses saved settings and flashes success or error.
 
 Environment variables (reference only, do not hardcode secrets in repo):  
@@ -73,11 +73,11 @@ Environment variables (reference only, do not hardcode secrets in repo):
 Note: SMTP env surfaced in UI (read-only), emailer defaults and mock logging in place. Real send depends on env on VPS.
 
 ## 3. Session Management (with client self‑service)
-3.1 Create Session form (staff only): title, Workshop Type (dropdown labeled by Code only), date-only start/end, daily start/end times, timezone, **Workshop Location** and **Shipping Location** dropdowns (per-client; workshop may be virtual), delivery type (Onsite, Virtual, Self-paced, Hybrid), region (NA, EU, SEA, Other), language (dropdown, default English), capacity, status, sponsor, notes, simulation outline, lead facilitator (single select) and additional facilitators (addable selects from KT Delivery or Contractor users); session.code derives from selected Workshop Type. Defaults: daily times prefill 08:00-17:00; lead facilitator removed from additional facilitator options. “Include out-of-region facilitators” toggle preserves current inputs.
+3.1 Create Session form (staff only): title, Workshop Type (dropdown labeled by Code only), date-only start/end, daily start/end times, timezone, **Workshop Location** and **Shipping Location** dropdowns (per-client; workshop may be virtual) with blank default and links to Client → Edit to add new locations returning via `next=`, delivery type (Onsite, Virtual, Self-paced, Hybrid), region (NA, EU, SEA, Other), language (dropdown, default English), capacity, status, sponsor, notes, simulation outline, lead facilitator (single select) and additional facilitators (addable selects from KT Delivery or Contractor users); session.code derives from selected Workshop Type. Defaults: daily times prefill 08:00-17:00; lead facilitator removed from additional facilitator options. “Include out-of-region facilitators” toggle preserves current inputs.
 3.2 Materials and shipping block on the Session:
  • Order Type select and Materials dropdown (filtered by type) storing `materials_option_id`
  • Materials list (item name, qty, notes)
- • Uses Session’s Shipping Location for address/contact (read-only on Materials page)
+ • Uses Session’s Shipping Location for address/contact (read-only on Materials page with small “Edit session” link)
 3.3 Participants tab on the Session: add/remove participants, mark attendance, completion date, edit/remove entries, CSV import (FullName,Email,Title) with sample download [DONE]
 3.4 Session lifecycle and status:
    - Flags: materials_ordered, ready_for_delivery, info_sent, delivered, finalized, on_hold_at, cancelled_at.

--- a/app/routes/clients.py
+++ b/app/routes/clients.py
@@ -10,6 +10,7 @@ from flask import (
     session as flask_session,
     url_for,
 )
+from urllib.parse import urlparse
 
 from ..app import db, User
 from ..models import (
@@ -17,10 +18,40 @@ from ..models import (
     Session,
     ClientWorkshopLocation,
     ClientShippingLocation,
+    ParticipantAccount,
     ensure_virtual_workshop_locations,
 )
 
 bp = Blueprint("clients", __name__, url_prefix="/clients")
+
+
+def _safe_next(url: str | None) -> str | None:
+    if not url:
+        return None
+    parsed = urlparse(url)
+    if parsed.scheme or parsed.netloc or not url.startswith("/"):
+        return None
+    return url
+
+
+def client_edit_required(fn):
+    @wraps(fn)
+    def wrapper(*args, **kwargs):
+        user_id = flask_session.get("user_id")
+        account_id = flask_session.get("participant_account_id")
+        if user_id:
+            user = db.session.get(User, user_id)
+            if not user or not (user.is_app_admin or user.is_admin or user.is_kcrm):
+                abort(403)
+            return fn(*args, **kwargs, current_user=user, csa_account=None)
+        if account_id:
+            account = db.session.get(ParticipantAccount, account_id)
+            if not account:
+                abort(403)
+            return fn(*args, **kwargs, current_user=None, csa_account=account)
+        return redirect(url_for("auth.login"))
+
+    return wrapper
 
 
 def admin_required(fn):
@@ -76,33 +107,126 @@ def new_client(current_user):
 
 
 @bp.route("/<int:client_id>/edit", methods=["GET", "POST"])
-@admin_required
-def edit_client(client_id, current_user):
+@client_edit_required
+def edit_client(client_id, current_user, csa_account):
     client = db.session.get(Client, client_id)
     if not client:
         abort(404)
+    section = request.values.get("section") or "workshop"
+    loc_id = request.values.get("loc_id")
+    next_url = _safe_next(request.values.get("next"))
     users = User.query.order_by(User.email).all()
+    can_toggle = bool(current_user and (current_user.is_app_admin or current_user.is_admin or current_user.is_kcrm))
     if request.method == "POST":
-        name = (request.form.get("name") or "").strip()
-        if not name:
-            flash("Name required", "error")
-            return redirect(url_for("clients.edit_client", client_id=client_id))
-        exists = (
-            db.session.query(Client)
-            .filter(db.func.lower(Client.name) == name.lower(), Client.id != client.id)
-            .first()
-        )
-        if exists:
-            flash("Client name must be unique", "error")
-            return redirect(url_for("clients.edit_client", client_id=client_id))
-        client.name = name
-        client.sfc_link = request.form.get("sfc_link") or None
-        client.crm_user_id = request.form.get("crm_user_id") or None
-        client.data_region = request.form.get("data_region") or None
-        client.status = request.form.get("status") or "active"
-        db.session.commit()
-        return redirect(url_for("clients.list_clients"))
-    return render_template("clients/form.html", client=client, users=users)
+        form = request.form.get("form")
+        if form == "client":
+            name = (request.form.get("name") or "").strip()
+            if not name:
+                flash("Name required", "error")
+                return redirect(url_for("clients.edit_client", client_id=client_id))
+            exists = (
+                db.session.query(Client)
+                .filter(db.func.lower(Client.name) == name.lower(), Client.id != client.id)
+                .first()
+            )
+            if exists:
+                flash("Client name must be unique", "error")
+                return redirect(url_for("clients.edit_client", client_id=client_id))
+            client.name = name
+            client.sfc_link = request.form.get("sfc_link") or None
+            client.crm_user_id = request.form.get("crm_user_id") or None
+            client.data_region = request.form.get("data_region") or None
+            client.status = request.form.get("status") or "active"
+            db.session.commit()
+            flash("Client saved", "success")
+            redirect_url = next_url or url_for("clients.edit_client", client_id=client_id)
+            return redirect(redirect_url)
+        elif form == "workshop":
+            if loc_id:
+                loc = db.session.get(ClientWorkshopLocation, int(loc_id))
+                if not loc or loc.client_id != client_id:
+                    abort(404)
+            else:
+                loc = ClientWorkshopLocation(client_id=client_id)
+            loc.label = (request.form.get("label") or "").strip()
+            loc.is_virtual = request.form.get("is_virtual") in {"1", "on", "true"}
+            loc.platform = request.form.get("platform") or None
+            loc.address_line1 = request.form.get("address_line1") or None
+            loc.address_line2 = request.form.get("address_line2") or None
+            loc.city = request.form.get("city") or None
+            loc.state = request.form.get("state") or None
+            loc.postal_code = request.form.get("postal_code") or None
+            loc.country = request.form.get("country") or None
+            if can_toggle and "is_active" in request.form:
+                loc.is_active = request.form.get("is_active") in {"1", "on", "true"}
+            db.session.add(loc)
+            db.session.commit()
+            flash("Workshop location saved", "success")
+        elif form == "shipping":
+            if loc_id:
+                loc = db.session.get(ClientShippingLocation, int(loc_id))
+                if not loc or loc.client_id != client_id:
+                    abort(404)
+            else:
+                loc = ClientShippingLocation(client_id=client_id)
+            loc.contact_name = request.form.get("contact_name") or None
+            loc.contact_phone = request.form.get("contact_phone") or None
+            loc.contact_email = request.form.get("contact_email") or None
+            loc.address_line1 = request.form.get("address_line1") or None
+            loc.address_line2 = request.form.get("address_line2") or None
+            loc.city = request.form.get("city") or None
+            loc.state = request.form.get("state") or None
+            loc.postal_code = request.form.get("postal_code") or None
+            loc.country = request.form.get("country") or None
+            if can_toggle and "is_active" in request.form:
+                loc.is_active = request.form.get("is_active") in {"1", "on", "true"}
+            db.session.add(loc)
+            db.session.commit()
+            flash("Shipping location saved", "success")
+        elif form == "workshop_deactivate" and can_toggle:
+            loc = db.session.get(ClientWorkshopLocation, int(loc_id))
+            if loc and loc.client_id == client_id:
+                loc.is_active = False
+                db.session.commit()
+                flash("Workshop location deactivated", "success")
+        elif form == "shipping_deactivate" and can_toggle:
+            loc = db.session.get(ClientShippingLocation, int(loc_id))
+            if loc and loc.client_id == client_id:
+                loc.is_active = False
+                db.session.commit()
+                flash("Shipping location deactivated", "success")
+        redirect_url = next_url or url_for("clients.edit_client", client_id=client_id, section=section)
+        if next_url:
+            return redirect(redirect_url)
+        return redirect(redirect_url)
+    workshop_locations = (
+        ClientWorkshopLocation.query.filter_by(client_id=client_id)
+        .order_by(ClientWorkshopLocation.label)
+        .all()
+    )
+    shipping_locations = (
+        ClientShippingLocation.query.filter_by(client_id=client_id)
+        .order_by(ClientShippingLocation.id)
+        .all()
+    )
+    edit_wl = None
+    edit_sl = None
+    if section == "workshop" and loc_id:
+        edit_wl = db.session.get(ClientWorkshopLocation, int(loc_id))
+    if section == "shipping" and loc_id:
+        edit_sl = db.session.get(ClientShippingLocation, int(loc_id))
+    return render_template(
+        "clients/edit.html",
+        client=client,
+        users=users,
+        section=section,
+        next_url=next_url,
+        workshop_locations=workshop_locations,
+        shipping_locations=shipping_locations,
+        edit_wl=edit_wl,
+        edit_sl=edit_sl,
+        can_toggle=can_toggle,
+    )
 
 
 @bp.post("/<int:client_id>/delete")
@@ -117,54 +241,3 @@ def delete_client(client_id, current_user):
     db.session.delete(client)
     db.session.commit()
     return redirect(url_for("clients.list_clients"))
-
-
-@bp.post("/<int:client_id>/workshop-locations/inline")
-@admin_required
-def workshop_location_inline(client_id, current_user):
-    client = db.session.get(Client, client_id)
-    if not client:
-        abort(404)
-    label = request.form.get("label") or ""
-    is_virtual = request.form.get("is_virtual", "1") not in {"0", "false", ""}
-    platform = request.form.get("platform") or None
-    loc = ClientWorkshopLocation(
-        client_id=client_id,
-        label=label,
-        is_virtual=is_virtual,
-        platform=platform,
-        address_line1=request.form.get("address_line1") or None,
-        address_line2=request.form.get("address_line2") or None,
-        city=request.form.get("city") or None,
-        state=request.form.get("state") or None,
-        postal_code=request.form.get("postal_code") or None,
-        country=request.form.get("country") or None,
-    )
-    db.session.add(loc)
-    db.session.commit()
-    return f"<option value='{loc.id}' selected>{loc.label}</option>"
-
-
-@bp.post("/<int:client_id>/shipping-locations/inline")
-@admin_required
-def shipping_location_inline(client_id, current_user):
-    client = db.session.get(Client, client_id)
-    if not client:
-        abort(404)
-    loc = ClientShippingLocation(
-        client_id=client_id,
-        contact_name=request.form.get("contact_name") or None,
-        contact_phone=request.form.get("contact_phone") or None,
-        contact_email=request.form.get("contact_email") or None,
-        address_line1=request.form.get("address_line1") or None,
-        address_line2=request.form.get("address_line2") or None,
-        city=request.form.get("city") or None,
-        state=request.form.get("state") or None,
-        postal_code=request.form.get("postal_code") or None,
-        country=request.form.get("country") or None,
-    )
-    db.session.add(loc)
-    db.session.commit()
-    return (
-        f"<option value='{loc.id}' selected>{loc.display_name()}</option>"
-    )

--- a/app/templates/clients/edit.html
+++ b/app/templates/clients/edit.html
@@ -1,0 +1,121 @@
+{% extends 'base.html' %}
+{% block title %}Edit Client{% endblock %}
+{% block content %}
+<h1>Edit Client</h1>
+<form method="post">
+  <input type="hidden" name="form" value="client">
+  <div><label>Name <input type="text" name="name" value="{{ client.name }}" required></label></div>
+  <div><label>SFC Link <input type="url" name="sfc_link" value="{{ client.sfc_link or '' }}"></label></div>
+  <div><label>CRM
+    <select name="crm_user_id">
+      <option value=""></option>
+      {% for u in users %}
+      <option value="{{ u.id }}" {% if client.crm_user_id==u.id %}selected{% endif %}>{{ u.full_name or u.email }}</option>
+      {% endfor %}
+    </select>
+  </label></div>
+  <div><label>Data Region
+    <select name="data_region">
+      <option value=""></option>
+      {% for opt in ['NA','EU','SEA','Other'] %}
+      <option value="{{ opt }}" {% if client.data_region==opt %}selected{% endif %}>{{ opt }}</option>
+      {% endfor %}
+    </select>
+  </label></div>
+  <div><label>Status
+    <select name="status">
+      {% for opt in ['active','inactive'] %}
+      <option value="{{ opt }}" {% if client.status==opt %}selected{% endif %}>{{ opt }}</option>
+      {% endfor %}
+    </select>
+  </label></div>
+  {% if next_url %}<input type="hidden" name="next" value="{{ next_url }}">{% endif %}
+  <button type="submit">Save</button>
+</form>
+<hr>
+<h2 id="workshop-section">Workshop Locations</h2>
+<table border="1" cellpadding="4" cellspacing="0">
+  <tr><th>Label</th><th>Virtual/Platform</th><th>Address</th><th>Active</th><th>Actions</th></tr>
+  {% for loc in workshop_locations %}
+  <tr>
+    <td>{{ loc.label }}</td>
+    <td>{% if loc.is_virtual %}{{ loc.platform or 'Virtual' }}{% endif %}</td>
+    <td>{{ loc.address_line1|default('', true) }} {{ loc.city|default('', true) }} {{ loc.country|default('', true) }}</td>
+    <td>{{ 'Yes' if loc.is_active else 'No' }}</td>
+    <td>
+      <a href="{{ url_for('clients.edit_client', client_id=client.id, section='workshop', loc_id=loc.id, next=next_url) }}">Edit</a>
+      {% if can_toggle %}
+      <form method="post" style="display:inline">
+        <input type="hidden" name="form" value="workshop_deactivate">
+        <input type="hidden" name="loc_id" value="{{ loc.id }}">
+        {% if next_url %}<input type="hidden" name="next" value="{{ next_url }}">{% endif %}
+        <button type="submit">Deactivate</button>
+      </form>
+      {% endif %}
+    </td>
+  </tr>
+  {% endfor %}
+</table>
+<h3>{{ 'Edit' if edit_wl else 'New' }} Workshop Location</h3>
+<form method="post">
+  <input type="hidden" name="form" value="workshop">
+  {% if edit_wl %}<input type="hidden" name="loc_id" value="{{ edit_wl.id }}">{% endif %}
+  {% if next_url %}<input type="hidden" name="next" value="{{ next_url }}">{% endif %}
+  <div><label>Label <input type="text" name="label" value="{{ edit_wl.label if edit_wl else '' }}" required></label></div>
+  <div><label>Virtual <input type="checkbox" name="is_virtual" value="1" {% if edit_wl and edit_wl.is_virtual %}checked{% endif %}></label></div>
+  <div><label>Platform <input type="text" name="platform" value="{{ edit_wl.platform if edit_wl else '' }}"></label></div>
+  <div><label>Address line 1 <input type="text" name="address_line1" value="{{ edit_wl.address_line1 if edit_wl else '' }}"></label></div>
+  <div><label>Address line 2 <input type="text" name="address_line2" value="{{ edit_wl.address_line2 if edit_wl else '' }}"></label></div>
+  <div><label>City <input type="text" name="city" value="{{ edit_wl.city if edit_wl else '' }}"></label></div>
+  <div><label>State <input type="text" name="state" value="{{ edit_wl.state if edit_wl else '' }}"></label></div>
+  <div><label>Postal Code <input type="text" name="postal_code" value="{{ edit_wl.postal_code if edit_wl else '' }}"></label></div>
+  <div><label>Country <input type="text" name="country" value="{{ edit_wl.country if edit_wl else '' }}"></label></div>
+  {% if can_toggle %}
+  <div><label>Active <input type="checkbox" name="is_active" value="1" {% if not edit_wl or edit_wl.is_active %}checked{% endif %}></label></div>
+  {% endif %}
+  <button type="submit">Save</button>
+</form>
+<hr>
+<h2 id="shipping-section">Shipping Locations</h2>
+<table border="1" cellpadding="4" cellspacing="0">
+  <tr><th>Contact</th><th>Email/Phone</th><th>Address</th><th>Active</th><th>Actions</th></tr>
+  {% for loc in shipping_locations %}
+  <tr>
+    <td>{{ loc.contact_name|default('', true) }}</td>
+    <td>{{ loc.contact_email|default('', true) }} {{ loc.contact_phone|default('', true) }}</td>
+    <td>{{ loc.address_line1|default('', true) }} {{ loc.city|default('', true) }} {{ loc.country|default('', true) }}</td>
+    <td>{{ 'Yes' if loc.is_active else 'No' }}</td>
+    <td>
+      <a href="{{ url_for('clients.edit_client', client_id=client.id, section='shipping', loc_id=loc.id, next=next_url) }}">Edit</a>
+      {% if can_toggle %}
+      <form method="post" style="display:inline">
+        <input type="hidden" name="form" value="shipping_deactivate">
+        <input type="hidden" name="loc_id" value="{{ loc.id }}">
+        {% if next_url %}<input type="hidden" name="next" value="{{ next_url }}">{% endif %}
+        <button type="submit">Deactivate</button>
+      </form>
+      {% endif %}
+    </td>
+  </tr>
+  {% endfor %}
+</table>
+<h3>{{ 'Edit' if edit_sl else 'New' }} Shipping Location</h3>
+<form method="post">
+  <input type="hidden" name="form" value="shipping">
+  {% if edit_sl %}<input type="hidden" name="loc_id" value="{{ edit_sl.id }}">{% endif %}
+  {% if next_url %}<input type="hidden" name="next" value="{{ next_url }}">{% endif %}
+  <div><label>Contact Name <input type="text" name="contact_name" value="{{ edit_sl.contact_name if edit_sl else '' }}"></label></div>
+  <div><label>Contact Phone <input type="text" name="contact_phone" value="{{ edit_sl.contact_phone if edit_sl else '' }}"></label></div>
+  <div><label>Contact Email <input type="email" name="contact_email" value="{{ edit_sl.contact_email if edit_sl else '' }}"></label></div>
+  <div><label>Address line 1 <input type="text" name="address_line1" value="{{ edit_sl.address_line1 if edit_sl else '' }}"></label></div>
+  <div><label>Address line 2 <input type="text" name="address_line2" value="{{ edit_sl.address_line2 if edit_sl else '' }}"></label></div>
+  <div><label>City <input type="text" name="city" value="{{ edit_sl.city if edit_sl else '' }}"></label></div>
+  <div><label>State <input type="text" name="state" value="{{ edit_sl.state if edit_sl else '' }}"></label></div>
+  <div><label>Postal Code <input type="text" name="postal_code" value="{{ edit_sl.postal_code if edit_sl else '' }}"></label></div>
+  <div><label>Country <input type="text" name="country" value="{{ edit_sl.country if edit_sl else '' }}"></label></div>
+  {% if can_toggle %}
+  <div><label>Active <input type="checkbox" name="is_active" value="1" {% if not edit_sl or edit_sl.is_active %}checked{% endif %}></label></div>
+  {% endif %}
+  <button type="submit">Save</button>
+</form>
+{% endblock %}

--- a/app/templates/sessions/form.html
+++ b/app/templates/sessions/form.html
@@ -28,21 +28,21 @@
     <div><label>Client Session Admin <input type="email" name="csa_email" value="{{ session.csa_account.email if session and session.csa_account else '' }}"></label></div>
     <div><label>Workshop Location
       <select name="workshop_location_id" id="workshop-location-select">
-        <option value="">--Select--</option>
+        <option value=""></option>
         {% for loc in workshop_locations %}
         <option value="{{ loc.id }}" {% if session.workshop_location_id==loc.id %}selected{% endif %}>{{ loc.label }}</option>
         {% endfor %}
       </select>
-      <button type="button" id="add-workshop-location">Add</button>
+      <a href="#" id="add-workshop-location">Add</a>
     </label></div>
     <div><label>Shipping Location
       <select name="shipping_location_id" id="shipping-location-select">
-        <option value="">--Select--</option>
+        <option value=""></option>
         {% for loc in shipping_locations %}
         <option value="{{ loc.id }}" {% if session.shipping_location_id==loc.id %}selected{% endif %}>{{ loc.display_name() }}</option>
         {% endfor %}
       </select>
-      <button type="button" id="add-shipping-location">Add</button>
+      <a href="#" id="add-shipping-location">Add</a>
     </label></div>
   </fieldset>
   <fieldset>
@@ -240,35 +240,25 @@
     else{ url.searchParams.delete('include_all_facilitators'); }
     window.location = url.toString();
   });
-  document.getElementById('add-workshop-location').addEventListener('click', function(){
+  function nextUrl(){
+    {% if session.id %}
+    return '/sessions/{{ session.id }}/edit';
+    {% else %}
+    var cid = document.getElementById('client-select').value;
+    return '/sessions/new?client_id='+cid;
+    {% endif %}
+  }
+  document.getElementById('add-workshop-location').addEventListener('click', function(e){
+    e.preventDefault();
     var cid = document.getElementById('client-select').value;
     if(!cid){ alert('Select client first'); return; }
-    var label = prompt('Location label');
-    if(!label) return;
-    fetch('/clients/'+cid+'/workshop-locations/inline', {
-      method:'POST',
-      headers:{'Content-Type':'application/x-www-form-urlencoded'},
-      body:'label='+encodeURIComponent(label)+'&is_virtual=1'
-    }).then(r=>r.text()).then(function(opt){
-      document.getElementById('workshop-location-select').insertAdjacentHTML('beforeend', opt);
-    });
+    window.location = '/clients/'+cid+'/edit?section=workshop&next='+encodeURIComponent(nextUrl());
   });
-  document.getElementById('add-shipping-location').addEventListener('click', function(){
+  document.getElementById('add-shipping-location').addEventListener('click', function(e){
+    e.preventDefault();
     var cid = document.getElementById('client-select').value;
     if(!cid){ alert('Select client first'); return; }
-    var line1 = prompt('Address line 1');
-    if(!line1) return;
-    var city = prompt('City') || '';
-    var postal = prompt('Postal code') || '';
-    var country = prompt('Country') || '';
-    var params = new URLSearchParams({address_line1:line1, city:city, postal_code:postal, country:country});
-    fetch('/clients/'+cid+'/shipping-locations/inline', {
-      method:'POST',
-      headers:{'Content-Type':'application/x-www-form-urlencoded'},
-      body:params.toString()
-    }).then(r=>r.text()).then(function(opt){
-      document.getElementById('shipping-location-select').insertAdjacentHTML('beforeend', opt);
-    });
+    window.location = '/clients/'+cid+'/edit?section=shipping&next='+encodeURIComponent(nextUrl());
   });
 </script>
 <script src="{{ url_for('static', filename='js/form_state.js') }}"></script>

--- a/app/templates/sessions/materials.html
+++ b/app/templates/sessions/materials.html
@@ -22,7 +22,7 @@
       {{ sess.shipping_location.city|default('', true) }} {{ sess.shipping_location.state|default('', true) }} {{ sess.shipping_location.postal_code|default('', true) }}<br>
       {{ sess.shipping_location.country|default('', true) }}
     {% endif %}
-    <a href="{{ url_for('sessions.edit_session', session_id=sess.id) }}">edit session</a>
+    <a href="{{ url_for('sessions.edit_session', session_id=sess.id) }}" style="font-size:smaller">Edit session</a>
   </div>
   <div>Order type:
     {% if can_edit_materials_header('order_type', current_user, shipment) and not readonly %}

--- a/tests/test_locations.py
+++ b/tests/test_locations.py
@@ -13,6 +13,7 @@ from app.models import (
     ClientWorkshopLocation,
     ClientShippingLocation,
     SessionShipping,
+    ParticipantAccount,
     ensure_virtual_workshop_locations,
 )
 
@@ -48,22 +49,13 @@ def test_virtual_defaults_idempotent(app):
         assert count == 5
 
 
-def test_session_form_filters_locations_and_inline(app):
+def test_next_redirect_and_dropdown_update(app):
     with app.app_context():
         admin = User(email="a@a", is_app_admin=True)
         admin.set_password("x")
         client = Client(name="C1")
         wl_active = ClientWorkshopLocation(client=client, label="L1", is_active=True)
         wl_inactive = ClientWorkshopLocation(client=client, label="L2", is_active=False)
-        sl_active = ClientShippingLocation(
-            client=client,
-            contact_name="Ship1",
-            address_line1="A1",
-            city="City",
-            postal_code="123",
-            country="US",
-            is_active=True,
-        )
         sl_inactive = ClientShippingLocation(
             client=client,
             contact_name="Ship2",
@@ -74,30 +66,93 @@ def test_session_form_filters_locations_and_inline(app):
             is_active=False,
         )
         wt = WorkshopType(code="WT", name="WT")
-        db.session.add_all([
-            admin,
-            client,
-            wl_active,
-            wl_inactive,
-            sl_active,
-            sl_inactive,
-            wt,
-        ])
+        db.session.add_all([admin, client, wl_active, wl_inactive, sl_inactive, wt])
         db.session.commit()
         admin_id = admin.id
         client_id = client.id
     tc = app.test_client()
     login_admin(tc, admin_id)
-    resp = tc.get(f"/sessions/new?client_id={client_id}")
-    assert b"L1" in resp.data
-    assert b"L2" not in resp.data
-    assert b"Ship1" in resp.data
-    assert b"Ship2" not in resp.data
+    next_url = f"/sessions/new?client_id={client_id}"
+    from urllib.parse import quote
     resp = tc.post(
-        f"/clients/{client_id}/workshop-locations/inline",
-        data={"label": "New Virtual", "is_virtual": "1", "platform": "Zoom"},
+        f"/clients/{client_id}/edit?section=shipping&next={quote(next_url)}",
+        data={
+            "form": "shipping",
+            "contact_name": "Ship1",
+            "address_line1": "A1",
+            "city": "City",
+            "postal_code": "123",
+            "country": "US",
+        },
+        follow_redirects=False,
     )
-    assert b"selected" in resp.data
+    assert resp.status_code == 302
+    assert resp.headers["Location"] == next_url
+    resp2 = tc.get(next_url)
+    assert b"L1" in resp2.data and b"L2" not in resp2.data
+    assert b"Ship1" in resp2.data and b"Ship2" not in resp2.data
+
+
+def test_rbac_active_toggle(app):
+    with app.app_context():
+        admin = User(email="admin@a", is_app_admin=True)
+        admin.set_password("x")
+        client = Client(name="C1")
+        ship = ClientShippingLocation(
+            client=client,
+            contact_name="Ship1",
+            address_line1="A1",
+            city="City",
+            postal_code="123",
+            country="US",
+        )
+        db.session.add_all([admin, client, ship])
+        db.session.commit()
+        admin_id = admin.id
+        client_id = client.id
+        ship_id = ship.id
+        account = ParticipantAccount(email="csa@x", full_name="CSA")
+        db.session.add(account)
+        db.session.commit()
+        account_id = account.id
+    tc = app.test_client()
+    # CSA cannot deactivate
+    with tc.session_transaction() as sess_tx:
+        sess_tx["participant_account_id"] = account_id
+    tc.post(
+        f"/clients/{client_id}/edit?section=shipping",
+        data={
+            "form": "shipping",
+            "loc_id": ship_id,
+            "contact_name": "Ship1",
+            "address_line1": "A1",
+            "city": "City",
+            "postal_code": "123",
+            "country": "US",
+            "is_active": "0",
+        },
+    )
+    with app.app_context():
+        assert db.session.get(ClientShippingLocation, ship_id).is_active
+    # Admin can deactivate
+    with tc.session_transaction() as sess_tx:
+        sess_tx.clear()
+        sess_tx["user_id"] = admin_id
+    tc.post(
+        f"/clients/{client_id}/edit?section=shipping",
+        data={
+            "form": "shipping",
+            "loc_id": ship_id,
+            "contact_name": "Ship1",
+            "address_line1": "A1",
+            "city": "City",
+            "postal_code": "123",
+            "country": "US",
+            "is_active": "0",
+        },
+    )
+    with app.app_context():
+        assert db.session.get(ClientShippingLocation, ship_id).is_active is False
 
 
 def test_materials_requires_shipping_location(app):


### PR DESCRIPTION
## Summary
- Manage workshop and shipping locations directly on the client edit page with inline create/edit forms and safe return links.
- Session forms now deep-link to client edit for adding locations and dropdowns default to blank selections.
- Materials page shows the session's shipping location read-only with a small "Edit session" link.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af1ddc0140832ea2b1ebe373cae966