### PR TITLE
Improve client location forms and materials shipping selection

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -175,6 +175,7 @@ class ClientShippingLocation(db.Model):
     state = db.Column(db.String(255))
     postal_code = db.Column(db.String(50))
     country = db.Column(db.String(100))
+    notes = db.Column(db.String(255))
     is_active = db.Column(
         db.Boolean, nullable=False, default=True, server_default=db.text("true")
     )
@@ -210,6 +211,7 @@ class ClientWorkshopLocation(db.Model):
         db.Boolean, nullable=False, default=False, server_default=db.text("false")
     )
     platform = db.Column(db.String(100))
+    access_notes = db.Column(db.String(255))
     address_line1 = db.Column(db.String(255))
     address_line2 = db.Column(db.String(255))
     city = db.Column(db.String(255))

--- a/app/routes/clients.py
+++ b/app/routes/clients.py
@@ -151,6 +151,7 @@ def edit_client(client_id, current_user, csa_account):
             loc.label = (request.form.get("label") or "").strip()
             loc.is_virtual = request.form.get("is_virtual") in {"1", "on", "true"}
             loc.platform = request.form.get("platform") or None
+            loc.access_notes = request.form.get("access_notes") or None
             loc.address_line1 = request.form.get("address_line1") or None
             loc.address_line2 = request.form.get("address_line2") or None
             loc.city = request.form.get("city") or None
@@ -178,6 +179,7 @@ def edit_client(client_id, current_user, csa_account):
             loc.state = request.form.get("state") or None
             loc.postal_code = request.form.get("postal_code") or None
             loc.country = request.form.get("country") or None
+            loc.notes = request.form.get("notes") or None
             if can_toggle and "is_active" in request.form:
                 loc.is_active = request.form.get("is_active") in {"1", "on", "true"}
             db.session.add(loc)

--- a/app/templates/clients/edit.html
+++ b/app/templates/clients/edit.html
@@ -63,13 +63,14 @@
   {% if next_url %}<input type="hidden" name="next" value="{{ next_url }}">{% endif %}
   <div><label>Label <input type="text" name="label" value="{{ edit_wl.label if edit_wl else '' }}" required></label></div>
   <div><label>Virtual <input type="checkbox" name="is_virtual" value="1" {% if edit_wl and edit_wl.is_virtual %}checked{% endif %}></label></div>
-  <div><label>Platform <input type="text" name="platform" value="{{ edit_wl.platform if edit_wl else '' }}"></label></div>
-  <div><label>Address line 1 <input type="text" name="address_line1" value="{{ edit_wl.address_line1 if edit_wl else '' }}"></label></div>
-  <div><label>Address line 2 <input type="text" name="address_line2" value="{{ edit_wl.address_line2 if edit_wl else '' }}"></label></div>
-  <div><label>City <input type="text" name="city" value="{{ edit_wl.city if edit_wl else '' }}"></label></div>
-  <div><label>State <input type="text" name="state" value="{{ edit_wl.state if edit_wl else '' }}"></label></div>
-  <div><label>Postal Code <input type="text" name="postal_code" value="{{ edit_wl.postal_code if edit_wl else '' }}"></label></div>
-  <div><label>Country <input type="text" name="country" value="{{ edit_wl.country if edit_wl else '' }}"></label></div>
+  <div id="platform-field"><label>Platform <input type="text" name="platform" value="{{ edit_wl.platform|default('', true) if edit_wl else '' }}"></label></div>
+  <div><label>Location access notes <input type="text" name="access_notes" value="{{ edit_wl.access_notes|default('', true) if edit_wl else '' }}"></label></div>
+  <div class="address-field"><label>Address line 1 <input type="text" name="address_line1" value="{{ edit_wl.address_line1|default('', true) if edit_wl else '' }}"></label></div>
+  <div class="address-field"><label>Address line 2 <input type="text" name="address_line2" value="{{ edit_wl.address_line2|default('', true) if edit_wl else '' }}"></label></div>
+  <div class="address-field"><label>City <input type="text" name="city" value="{{ edit_wl.city|default('', true) if edit_wl else '' }}"></label></div>
+  <div class="address-field"><label>State <input type="text" name="state" value="{{ edit_wl.state|default('', true) if edit_wl else '' }}"></label></div>
+  <div class="address-field"><label>Postal Code <input type="text" name="postal_code" value="{{ edit_wl.postal_code|default('', true) if edit_wl else '' }}"></label></div>
+  <div class="address-field"><label>Country <input type="text" name="country" value="{{ edit_wl.country|default('', true) if edit_wl else '' }}"></label></div>
   {% if can_toggle %}
   <div><label>Active <input type="checkbox" name="is_active" value="1" {% if not edit_wl or edit_wl.is_active %}checked{% endif %}></label></div>
   {% endif %}
@@ -104,18 +105,34 @@
   <input type="hidden" name="form" value="shipping">
   {% if edit_sl %}<input type="hidden" name="loc_id" value="{{ edit_sl.id }}">{% endif %}
   {% if next_url %}<input type="hidden" name="next" value="{{ next_url }}">{% endif %}
-  <div><label>Contact Name <input type="text" name="contact_name" value="{{ edit_sl.contact_name if edit_sl else '' }}"></label></div>
-  <div><label>Contact Phone <input type="text" name="contact_phone" value="{{ edit_sl.contact_phone if edit_sl else '' }}"></label></div>
-  <div><label>Contact Email <input type="email" name="contact_email" value="{{ edit_sl.contact_email if edit_sl else '' }}"></label></div>
-  <div><label>Address line 1 <input type="text" name="address_line1" value="{{ edit_sl.address_line1 if edit_sl else '' }}"></label></div>
-  <div><label>Address line 2 <input type="text" name="address_line2" value="{{ edit_sl.address_line2 if edit_sl else '' }}"></label></div>
-  <div><label>City <input type="text" name="city" value="{{ edit_sl.city if edit_sl else '' }}"></label></div>
-  <div><label>State <input type="text" name="state" value="{{ edit_sl.state if edit_sl else '' }}"></label></div>
-  <div><label>Postal Code <input type="text" name="postal_code" value="{{ edit_sl.postal_code if edit_sl else '' }}"></label></div>
-  <div><label>Country <input type="text" name="country" value="{{ edit_sl.country if edit_sl else '' }}"></label></div>
+  <div><label>Contact Name <input type="text" name="contact_name" value="{{ edit_sl.contact_name|default('', true) if edit_sl else '' }}"></label></div>
+  <div><label>Contact Phone <input type="text" name="contact_phone" value="{{ edit_sl.contact_phone|default('', true) if edit_sl else '' }}"></label></div>
+  <div><label>Contact Email <input type="email" name="contact_email" value="{{ edit_sl.contact_email|default('', true) if edit_sl else '' }}"></label></div>
+  <div><label>Shipping Notes <input type="text" name="notes" value="{{ edit_sl.notes|default('', true) if edit_sl else '' }}"></label></div>
+  <div><label>Address line 1 <input type="text" name="address_line1" value="{{ edit_sl.address_line1|default('', true) if edit_sl else '' }}"></label></div>
+  <div><label>Address line 2 <input type="text" name="address_line2" value="{{ edit_sl.address_line2|default('', true) if edit_sl else '' }}"></label></div>
+  <div><label>City <input type="text" name="city" value="{{ edit_sl.city|default('', true) if edit_sl else '' }}"></label></div>
+  <div><label>State <input type="text" name="state" value="{{ edit_sl.state|default('', true) if edit_sl else '' }}"></label></div>
+  <div><label>Postal Code <input type="text" name="postal_code" value="{{ edit_sl.postal_code|default('', true) if edit_sl else '' }}"></label></div>
+  <div><label>Country <input type="text" name="country" value="{{ edit_sl.country|default('', true) if edit_sl else '' }}"></label></div>
   {% if can_toggle %}
   <div><label>Active <input type="checkbox" name="is_active" value="1" {% if not edit_sl or edit_sl.is_active %}checked{% endif %}></label></div>
   {% endif %}
   <button type="submit">Save</button>
 </form>
+<script>
+  function toggleVirtual(){
+    const cb = document.querySelector('input[name="is_virtual"]');
+    const show = cb.checked;
+    document.getElementById('platform-field').style.display = show ? 'block' : 'none';
+    document.querySelectorAll('.address-field').forEach(el => {
+      el.style.display = show ? 'none' : 'block';
+    });
+  }
+  const virtCb = document.querySelector('input[name="is_virtual"]');
+  if (virtCb){
+    virtCb.addEventListener('change', toggleVirtual);
+    toggleVirtual();
+  }
+</script>
 {% endblock %}

--- a/app/templates/sessions/form.html
+++ b/app/templates/sessions/form.html
@@ -35,15 +35,6 @@
       </select>
       <a href="#" id="add-workshop-location">Add</a>
     </label></div>
-    <div><label>Shipping Location
-      <select name="shipping_location_id" id="shipping-location-select">
-        <option value=""></option>
-        {% for loc in shipping_locations %}
-        <option value="{{ loc.id }}" {% if session.shipping_location_id==loc.id %}selected{% endif %}>{{ loc.display_name() }}</option>
-        {% endfor %}
-      </select>
-      <a href="#" id="add-shipping-location">Add</a>
-    </label></div>
   </fieldset>
   <fieldset>
     <legend>Details</legend>
@@ -253,12 +244,6 @@
     var cid = document.getElementById('client-select').value;
     if(!cid){ alert('Select client first'); return; }
     window.location = '/clients/'+cid+'/edit?section=workshop&next='+encodeURIComponent(nextUrl());
-  });
-  document.getElementById('add-shipping-location').addEventListener('click', function(e){
-    e.preventDefault();
-    var cid = document.getElementById('client-select').value;
-    if(!cid){ alert('Select client first'); return; }
-    window.location = '/clients/'+cid+'/edit?section=shipping&next='+encodeURIComponent(nextUrl());
   });
 </script>
 <script src="{{ url_for('static', filename='js/form_state.js') }}"></script>

--- a/app/templates/sessions/materials.html
+++ b/app/templates/sessions/materials.html
@@ -16,13 +16,22 @@
     {% endif %}
   </div>
   <div>Shipping location:
+    {% if can_manage and not readonly %}
+      <select name="shipping_location_id">
+        <option value=""></option>
+        {% for loc in shipping_locations %}
+        <option value="{{ loc.id }}" {% if sess.shipping_location_id==loc.id %}selected{% endif %}>{{ loc.display_name() }}</option>
+        {% endfor %}
+      </select>
+      <a href="{{ url_for('clients.edit_client', client_id=sess.client_id, section='shipping', next=url_for('materials.materials_view', session_id=sess.id)) }}" style="font-size:smaller">Edit locations</a>
+    {% endif %}
     {% if sess.shipping_location %}
+      {% if can_manage and not readonly %}<br>{% endif %}
       {{ sess.shipping_location.contact_name|default('', true) }}<br>
       {{ sess.shipping_location.address_line1|default('', true) }}{% if sess.shipping_location.address_line2 %} {{ sess.shipping_location.address_line2 }}{% endif %}<br>
       {{ sess.shipping_location.city|default('', true) }} {{ sess.shipping_location.state|default('', true) }} {{ sess.shipping_location.postal_code|default('', true) }}<br>
       {{ sess.shipping_location.country|default('', true) }}
     {% endif %}
-    <a href="{{ url_for('sessions.edit_session', session_id=sess.id) }}" style="font-size:smaller">Edit session</a>
   </div>
   <div>Order type:
     {% if can_edit_materials_header('order_type', current_user, shipment) and not readonly %}

--- a/migrations/versions/0030_location_notes.py
+++ b/migrations/versions/0030_location_notes.py
@@ -1,0 +1,19 @@
+"""add notes to client locations"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = '0030_location_notes'
+down_revision = '0029_client_locations'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column('client_workshop_locations', sa.Column('access_notes', sa.String(length=255)))
+    op.add_column('client_shipping_locations', sa.Column('notes', sa.String(length=255)))
+
+
+def downgrade() -> None:
+    op.drop_column('client_shipping_locations', 'notes')
+    op.drop_column('client_workshop_locations', 'access_notes')


### PR DESCRIPTION
## Summary
- Hide workshop platform & address fields based on virtual flag and add access notes and shipping notes
- Prevent blank fields from defaulting to "None" in location forms
- Move shipping location selection from session forms to materials order page and support notes

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68af22a540d8832e82fd4d3c3849d889