### PR TITLE
Allow staff participants and fix materials view error

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -48,7 +48,7 @@ Kepner-Tregoe’s Certs & Badges System (CBS) manages workshops (“Sessions”)
 
 ## 3) Sessions
 - **Create & edit** (staff only): title, **Workshop Type** (Code), start/end (date-only), daily start/end time, timezone, delivery type (Onsite/Virtual/Self-paced/Hybrid), region, language, capacity, status notes, **Workshop Location**, **Shipping Location**, lead + additional facilitators (delivery/contractor users; lead excluded from additional list). Prefill times 08:00–17:00. “Include out-of-region facilitators” preserves form inputs. **[DONE]**
-- **Participants** tab: add/edit/remove, CSV import (FullName,Email,Title), lowercased emails, portal link after certs. **[DONE]**
+- **Participants** tab: add/edit/remove, CSV import (FullName,Email,Title), lowercased emails, portal link after certs; accounts auto-created with default password "KTRocks!" and staff emails allowed. **[DONE]**
 - **Lifecycle flags & gates** (server-enforced):  
   `materials_ordered`, `ready_for_delivery`, `info_sent`, `delivered`, `finalized`, `on_hold_at`, `cancelled_at`.  
   Gates:
@@ -86,6 +86,7 @@ Kepner-Tregoe’s Certs & Badges System (CBS) manages workshops (“Sessions”)
 - **Materials Options (Settings → Materials)**: single table with
   - `order_type`, `title`, **languages (many-to-many)**, **formats** (`Digital (KTBooks)`, `Physical`, `Self-paced`, `Mixed`), `is_active`. **[DONE]**
   - Admin/SysAdmin only. **[DONE]**
+- Materials view page no longer errors when accessed without imports. **[DONE]**
 
 ---
 

--- a/app/templates/session_detail.html
+++ b/app/templates/session_detail.html
@@ -79,10 +79,6 @@
   <input type="text" name="full_name" placeholder="Full name">
   <input type="email" name="email" placeholder="Email" required>
   <input type="text" name="title" placeholder="Title">
-  {% if current_user and (current_user.is_admin or current_user.is_app_admin) %}
-  <input type="password" name="password" placeholder="Set password">
-  <input type="password" name="password_confirm" placeholder="Confirm password">
-  {% endif %}
   <button type="submit">Add Participant</button>
 </form>
 <form action="{{ url_for('sessions.import_csv', session_id=session.id) }}" method="post" enctype="multipart/form-data">
@@ -152,9 +148,6 @@
       <form action="{{ url_for('sessions.remove_participant', session_id=session.id, participant_id=row.participant.id) }}" method="post" style="display:inline">
         <button type="submit">Remove</button>
       </form>
-      {% endif %}
-      {% if current_user and row.participant.account and (current_user.is_admin or current_user.is_app_admin) %}
-      <a href="{{ url_for('accounts.set_account_password', account_id=row.participant.account.id, next=request.path) }}">Set password</a>
       {% endif %}
     </td>
   </tr>

--- a/tests/test_cross_table_uniqueness.py
+++ b/tests/test_cross_table_uniqueness.py
@@ -63,7 +63,7 @@ def test_participant_create_blocked_by_user(app):
         data={"email": "staff@example.com", "full_name": "Test"},
         follow_redirects=True,
     )
-    assert b"That email belongs to a staff user." in resp.data
+    assert b"Participant added" in resp.data
     with app.app_context():
         assert (
             ParticipantAccount.query.filter_by(email="staff@example.com").first()


### PR DESCRIPTION
## Summary
- streamline participant addition: remove password fields, auto-create accounts with default password, and permit staff emails with existing account info
- ensure participant names persist and remove password-setting link on session detail
- fix materials view page by importing missing datetime helpers

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af37f74940832e9601601ea7225ad2