### PR TITLE
Fix workshop type lookup and arrival date labeling

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -75,7 +75,7 @@ Kepner-Tregoe’s Certs & Badges System (CBS) manages workshops (“Sessions”)
 - Header fields on Materials page (mirrors Session + adds order bits):
   - **Order Type** (fixed list): KT-Run Standard materials / KT-Run Modular materials / KT-Run LDI materials / Client-run Bulk order / Simulation. **[DONE]**
   - **Materials type** dropdown filtered by Order Type (from **Materials Options** below). **[DONE]**
-  - **Latest arrival date** (required), **Workshop start date** (auto from Session), **SFC Project link**, **Delivery region** (from Session). **[DONE]**
+  - **Latest arrival date** (UI label, stored in `session_shipping.arrival_date`, required), **Workshop start date** (auto from Session), **SFC Project link**, **Delivery region** (from Session). **[DONE]**
   - Read-only **Shipping Location** (from Session). **[DONE]**
   - Status actions: Submit, Shipped (courier+tracking+ship date), Delivered (marks `materials_ordered = true`). **[DONE]**
 - **Permissions**:  

--- a/app/routes/materials_orders.py
+++ b/app/routes/materials_orders.py
@@ -61,7 +61,7 @@ def list_orders():
             {
                 "client": client.name if client else "",
                 "title": sess.title,
-                "workshop_type": wt.title if wt else "",
+                "workshop_type": wt.name if wt else "",
                 "start_date": sess.start_date,
                 "order_type": sh.order_type or "",
                 "materials_status": mstatus,

--- a/app/templates/sessions/materials.html
+++ b/app/templates/sessions/materials.html
@@ -86,7 +86,7 @@
     <div id="materials-option-info"><small>{{ selected_option.title }}{% if selected_option.languages %} — {{ selected_option.languages | map(attribute='name') | join(', ') }}{% endif %}{% if selected_option.formats %} ({{ selected_option.formats|join(', ') }}){% endif %}</small></div>
     {% else %}<div id="materials-option-info"></div>{% endif %}
   </div>
-  <div>Arrival date:
+  <div>Latest arrival date:
     {% if can_edit_materials_header('arrival_date', current_user, shipment) and not readonly %}
       <input type="date" name="arrival_date" value="{{ shipment.arrival_date.isoformat() if shipment.arrival_date else '' }}">
     {% else %}{{ shipment.arrival_date|default('', true) }}{% endif %}


### PR DESCRIPTION
## Summary
- use WorkshopType.name in materials order listing
- label arrival date inputs as "Latest arrival date" while storing to `arrival_date`
- document arrival date field mapping in CONTEXT

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68af3dbd3b34832e860580ca96ed7ae6