### PR TITLE
Restore badge download link alongside badge chip

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -64,11 +64,11 @@ Kepner-Tregoe’s Certs & Badges System (CBS) manages workshops (“Sessions”)
 
 ## 4) Workshop Types & Badges
 - WorkshopTypes: `code` (unique uppercase), `name`, `status`, `description`, optional `badge` from: **None, Foundations, Practitioner, Advanced, Expert, Coach, Facilitator, Program Leader**. **[DONE]**
-- Certificates and session UI can show **Download Badge** when the workshop type has a badge. **[DONE]**
+- Certificates and session UI show a small badge chip and a **Badge** download link when the workshop type has a badge. **[DONE]**
 - **Badges static delivery**: images live in `app/assets/badges`, synced to `/srv/badges`, served at `/badges/<slug>.webp`.
   Canonical filename/slug for Foundations is `foundations.webp`. **Do not commit new badge binaries.** **[DONE]**
   - Badge files live under `/srv/badges`.
-  - Names map via slug (lowercase, no spaces). We try `.webp` first, then `.png`.
+  - Names map via slug (lowercase, no spaces). Helpers try `.webp` first, then `.png`.
   - To add a PNG alternative, drop `<slug>.png` in `/srv/badges`.
 
 ---

--- a/app/app.py
+++ b/app/app.py
@@ -20,7 +20,7 @@ from sqlalchemy import or_, text
 db = SQLAlchemy()
 
 from .models import User, ParticipantAccount, Session, Client, Language
-from .utils.badges import badge_candidates, slug_for_badge
+from .utils.badges import best_badge_url, slug_for_badge
 from .utils.rbac import app_admin_required
 from .constants import LANGUAGE_NAMES
 
@@ -28,8 +28,8 @@ from .constants import LANGUAGE_NAMES
 def create_app():
     app = Flask(__name__, template_folder="templates")
     app.secret_key = os.getenv("SECRET_KEY", "dev")
-    app.jinja_env.globals["badge_candidates"] = badge_candidates
     app.jinja_env.globals["slug_for_badge"] = slug_for_badge
+    app.jinja_env.globals["best_badge_url"] = best_badge_url
 
     DB_USER = os.getenv("DB_USER", "cbs")
     DB_PASSWORD = os.getenv("POSTGRES_PASSWORD", "postgres")

--- a/app/templates/my_certificates.html
+++ b/app/templates/my_certificates.html
@@ -5,13 +5,11 @@
 <ul>
 {% for c in certs %}
   <li>
-    {% set b = c.session.workshop_type.badge if c.session and c.session.workshop_type else None %}
-    {% if b and b != 'None' %}
-      {% set cand = badge_candidates(b) %}
-      <picture style="vertical-align:middle;">
-        <source srcset="{{ cand[0] }}" type="image/webp">
-        <img src="{{ cand[1] }}" alt="{{ b }} badge" style="height:20px;width:auto;">
-      </picture>
+    {% set badge_name = c.session.workshop_type.badge if c.session and c.session.workshop_type else None %}
+    {% set badge_url = best_badge_url(badge_name) %}
+    {% if badge_url %}
+      <a href="{{ badge_url }}" download><img src="{{ badge_url }}" alt="{{ badge_name }} badge" style="height:20px;width:auto;vertical-align:middle;"></a>
+      <a href="{{ badge_url }}" download>Badge</a>
     {% endif %}
     <a href="{{ url_for('learner.download_certificate', cert_id=c.id) }}">{{ c.workshop_name }} - {{ c.workshop_date }}</a>
   </li>

--- a/app/templates/session_detail.html
+++ b/app/templates/session_detail.html
@@ -135,13 +135,11 @@
     </td>
     <td>
       {% if row.certificate %}
-        {% set b = session.workshop_type.badge if session.workshop_type else None %}
-        {% if b and b != 'None' %}
-          {% set cand = badge_candidates(b) %}
-          <picture style="vertical-align:middle;">
-            <source srcset="{{ cand[0] }}" type="image/webp">
-            <img src="{{ cand[1] }}" alt="{{ b }} badge" style="height:20px;width:auto;">
-          </picture>
+        {% set badge_name = session.workshop_type.badge if session.workshop_type else None %}
+        {% set badge_url = best_badge_url(badge_name) %}
+        {% if badge_url %}
+          <a href="{{ badge_url }}" download><img src="{{ badge_url }}" alt="{{ badge_name }} badge" style="height:20px;width:auto;vertical-align:middle;"></a>
+          <a href="{{ badge_url }}" download>Badge</a>
         {% endif %}
         <a href="{{ url_for('learner.download_certificate', cert_id=row.certificate.id) }}">Download Certificate</a>
       {% endif %}

--- a/app/utils/badges.py
+++ b/app/utils/badges.py
@@ -1,10 +1,26 @@
 from __future__ import annotations
 
+import os
+from flask import current_app
+
 
 def slug_for_badge(name: str) -> str:
     return (name or "").replace(" ", "").lower()
 
 
-def badge_candidates(name: str) -> list[str]:
+def best_badge_url(name: str | None) -> str | None:
+    if not name:
+        return None
     slug = slug_for_badge(name)
-    return [f"/badges/{slug}.webp", f"/badges/{slug}.png"]
+    if not slug:
+        return None
+
+    site_dir = "/srv/badges"
+    asset_dir = os.path.join(current_app.root_path, "assets", "badges")
+    for ext in ("webp", "png"):
+        filename = f"{slug}.{ext}"
+        if os.path.isfile(os.path.join(site_dir, filename)) or os.path.isfile(
+            os.path.join(asset_dir, filename)
+        ):
+            return f"/badges/{slug}.{ext}"
+    return None


### PR DESCRIPTION
## Summary
- add best_badge_url helper and expose to templates
- show clickable badge chip with explicit Badge download link on certificate pages
- document badge link behavior and image lookup fallback

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68af450fe550832ea5d0c89e2c0b013d