### PR TITLE
Add Resources module with staff and learner views

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -42,6 +42,7 @@ def create_app():
 
     app.config["SQLALCHEMY_DATABASE_URI"] = DATABASE_URL
     app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
+    app.config["MAX_CONTENT_LENGTH"] = 25 * 1024 * 1024
 
     db.init_app(app)
 
@@ -214,6 +215,7 @@ def create_app():
     from .routes.accounts import bp as accounts_bp
     from .routes.materials import bp as materials_bp
     from .routes.materials_orders import bp as materials_orders_bp
+    from .routes.settings_resources import bp as settings_resources_bp
 
     app.register_blueprint(auth_bp)
     app.register_blueprint(settings_mail_bp)
@@ -229,12 +231,7 @@ def create_app():
     app.register_blueprint(accounts_bp)
     app.register_blueprint(materials_bp)
     app.register_blueprint(materials_orders_bp)
-
-    @app.get("/resources")
-    def resources():
-        if not (session.get("user_id") or session.get("participant_account_id")):
-            return redirect(url_for("auth.login"))
-        return render_template("resources.html")
+    app.register_blueprint(settings_resources_bp)
 
     @app.get("/surveys")
     def surveys():

--- a/app/forms/resource_forms.py
+++ b/app/forms/resource_forms.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import os
+import re
+from typing import Iterable
+
+ALLOWED_EXTENSIONS = {".pdf", ".docx", ".xlsx", ".pptx", ".csv", ".txt", ".html"}
+
+
+def slugify_filename(name: str, filename: str) -> str:
+    base, ext = os.path.splitext(filename)
+    ext = ext.lower()
+    slug = re.sub(r"[^a-z0-9]+", "-", name.lower()).strip("-")
+    return f"{slug}{ext}"
+
+
+def validate_resource_form(data: dict, files: dict, *, require_file: bool = False) -> tuple[list[str], dict]:
+    """Validate resource form input.
+    Returns (errors, cleaned_data).
+    """
+    errors: list[str] = []
+    cleaned: dict = {}
+    name = (data.get("name") or "").strip()
+    rtype = (data.get("type") or "").upper()
+    link = (data.get("link") or "").strip()
+    file = files.get("file")
+    active = bool(data.get("active"))
+    wt_ids = [int(x) for x in data.getlist("workshop_types") if x.isdigit()]
+    cleaned.update(name=name, type=rtype, link=link, file=file, active=active, workshop_type_ids=wt_ids)
+
+    if not name:
+        errors.append("Name required")
+    if rtype not in {"LINK", "DOCUMENT", "APP"}:
+        errors.append("Invalid type")
+    elif rtype in {"LINK", "APP"}:
+        if not link.startswith("http://") and not link.startswith("https://"):
+            errors.append("Valid URL required")
+        if file and getattr(file, "filename", ""):
+            errors.append("File not allowed for this type")
+    elif rtype == "DOCUMENT":
+        if require_file and (not file or not getattr(file, "filename", "")):
+            errors.append("File required")
+        if file and getattr(file, "filename", ""):
+            _, ext = os.path.splitext(file.filename)
+            if ext.lower() not in ALLOWED_EXTENSIONS:
+                errors.append("Invalid file type")
+    return errors, cleaned

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -4,8 +4,8 @@ import base64
 from flask import current_app
 from sqlalchemy.orm import validates
 
-from .app import db
-from .utils.passwords import hash_password, check_password
+from ..app import db
+from ..utils.passwords import hash_password, check_password
 
 
 class User(db.Model):
@@ -135,6 +135,12 @@ class WorkshopType(db.Model):
     created_at = db.Column(db.DateTime, server_default=db.func.now())
     __table_args__ = (
         db.Index("uix_workshop_types_code_upper", db.func.upper(code), unique=True),
+    )
+
+    resources = db.relationship(
+        "Resource",
+        secondary="resource_workshop_types",
+        back_populates="workshop_types",
     )
 
     @validates("code")
@@ -606,3 +612,6 @@ def ensure_virtual_workshop_locations(client_id: int) -> None:
 def seed_virtual_workshop_locations() -> None:
     for client in Client.query.all():
         ensure_virtual_workshop_locations(client.id)
+
+
+from .resource import Resource, resource_workshop_types  # noqa: E402,F401

--- a/app/models/resource.py
+++ b/app/models/resource.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from sqlalchemy.orm import validates
+
+from ..app import db
+
+resource_workshop_types = db.Table(
+    "resource_workshop_types",
+    db.Column(
+        "resource_id",
+        db.Integer,
+        db.ForeignKey("resources.id", ondelete="CASCADE"),
+        primary_key=True,
+    ),
+    db.Column(
+        "workshop_type_id",
+        db.Integer,
+        db.ForeignKey("workshop_types.id", ondelete="CASCADE"),
+        primary_key=True,
+    ),
+    db.UniqueConstraint("resource_id", "workshop_type_id", name="uix_resource_workshop_type"),
+)
+
+
+class Resource(db.Model):
+    __tablename__ = "resources"
+
+    id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.String(255), nullable=False)
+    type = db.Column(db.String(20), nullable=False)
+    resource_value = db.Column(db.String(2048))
+    active = db.Column(db.Boolean, nullable=False, default=True)
+    created_at = db.Column(db.DateTime, server_default=db.func.now())
+
+    workshop_types = db.relationship(
+        "WorkshopType",
+        secondary=resource_workshop_types,
+        back_populates="resources",
+    )
+
+    TYPE_CHOICES = ("LINK", "DOCUMENT", "APP")
+
+    @property
+    def public_url(self) -> str | None:
+        if self.type == "DOCUMENT" and self.resource_value:
+            return f"/resources/{self.resource_value}"
+        return self.resource_value
+
+    @validates("type")
+    def _normalize_type(self, key, value):
+        value = (value or "").upper()
+        if value not in self.TYPE_CHOICES:
+            raise ValueError("invalid resource type")
+        return value
+
+    def validate(self) -> None:
+        if self.type in {"LINK", "APP"}:
+            if not self.resource_value or not self.resource_value.startswith(("http://", "https://")):
+                raise ValueError("URL required")
+        elif self.type == "DOCUMENT":
+            if not self.resource_value:
+                raise ValueError("filename required")
+        else:
+            raise ValueError("invalid resource type")

--- a/app/routes/settings_resources.py
+++ b/app/routes/settings_resources.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+import os
+
+from flask import Blueprint, abort, flash, redirect, render_template, request, session, url_for
+from sqlalchemy import func
+
+from ..app import db, User
+from ..models import Resource, WorkshopType, AuditLog
+from ..forms.resource_forms import slugify_filename, validate_resource_form
+from ..utils.storage import ensure_dir
+
+bp = Blueprint("settings_resources", __name__, url_prefix="/settings/resources")
+
+
+def _current_user(require_edit: bool = False) -> User:
+    user_id = session.get("user_id")
+    if not user_id:
+        return redirect(url_for("auth.login"))
+    user = db.session.get(User, user_id)
+    if not user:
+        abort(403)
+    can_view = (
+        user.is_app_admin
+        or user.is_admin
+        or user.is_kt_delivery
+        or user.is_kt_facilitator
+        or user.is_kt_contractor
+    )
+    if not can_view:
+        abort(403)
+    if require_edit and not (user.is_app_admin or user.is_admin or user.is_kt_delivery):
+        abort(403)
+    return user
+
+
+@bp.get("/")
+def list_resources():
+    current_user = _current_user()
+    resources = Resource.query.order_by(Resource.name).all()
+    return render_template("settings_resources/list.html", resources=resources)
+
+
+@bp.get("/new")
+def new_resource():
+    current_user = _current_user(require_edit=True)
+    workshop_types = WorkshopType.query.order_by(WorkshopType.name).all()
+    return render_template(
+        "settings_resources/form.html", resource=None, workshop_types=workshop_types
+    )
+
+
+@bp.post("/new")
+def create_resource():
+    current_user = _current_user(require_edit=True)
+    errors, cleaned = validate_resource_form(request.form, request.files, require_file=True if (request.form.get("type") or "").upper() == "DOCUMENT" else False)
+    name = cleaned.get("name")
+    if Resource.query.filter(func.lower(Resource.name) == name.lower(), Resource.active == True).first():
+        errors.append("Name must be unique")
+    if errors:
+        for e in errors:
+            flash(e, "error")
+        return redirect(url_for("settings_resources.new_resource"))
+    rtype = cleaned["type"]
+    if rtype == "DOCUMENT":
+        file = cleaned["file"]
+        filename = slugify_filename(name, file.filename)
+        ensure_dir("/srv/resources")
+        file.save(os.path.join("/srv/resources", filename))
+        resource_value = filename
+    else:
+        resource_value = cleaned["link"]
+    res = Resource(
+        name=name,
+        type=rtype,
+        resource_value=resource_value,
+        active=cleaned["active"],
+    )
+    res.workshop_types = WorkshopType.query.filter(WorkshopType.id.in_(cleaned["workshop_type_ids"])).all()
+    db.session.add(res)
+    db.session.add(AuditLog(user_id=current_user.id, action="resource_create", details=name))
+    db.session.commit()
+    flash("Resource created", "success")
+    return redirect(url_for("settings_resources.list_resources"))
+
+
+@bp.get("/<int:res_id>/edit")
+def edit_resource(res_id: int):
+    current_user = _current_user(require_edit=True)
+    res = db.session.get(Resource, res_id)
+    if not res:
+        abort(404)
+    workshop_types = WorkshopType.query.order_by(WorkshopType.name).all()
+    return render_template(
+        "settings_resources/form.html", resource=res, workshop_types=workshop_types
+    )
+
+
+@bp.post("/<int:res_id>/edit")
+def update_resource(res_id: int):
+    current_user = _current_user(require_edit=True)
+    res = db.session.get(Resource, res_id)
+    if not res:
+        abort(404)
+    errors, cleaned = validate_resource_form(request.form, request.files)
+    name = cleaned.get("name")
+    existing = (
+        Resource.query.filter(
+            func.lower(Resource.name) == name.lower(),
+            Resource.id != res.id,
+            Resource.active == True,
+        ).first()
+    )
+    if existing:
+        errors.append("Name must be unique")
+    if errors:
+        for e in errors:
+            flash(e, "error")
+        return redirect(url_for("settings_resources.edit_resource", res_id=res_id))
+    rtype = cleaned["type"]
+    res.name = name
+    res.type = rtype
+    res.active = cleaned["active"]
+    if rtype == "DOCUMENT":
+        file = cleaned["file"]
+        if file and getattr(file, "filename", ""):
+            filename = slugify_filename(name, file.filename)
+            ensure_dir("/srv/resources")
+            file.save(os.path.join("/srv/resources", filename))
+            res.resource_value = filename
+    else:
+        res.resource_value = cleaned["link"]
+    res.workshop_types = WorkshopType.query.filter(WorkshopType.id.in_(cleaned["workshop_type_ids"])).all()
+    db.session.add(AuditLog(user_id=current_user.id, action="resource_update", details=name))
+    db.session.commit()
+    flash("Resource updated", "success")
+    return redirect(url_for("settings_resources.list_resources"))

--- a/app/templates/my_resources.html
+++ b/app/templates/my_resources.html
@@ -1,0 +1,22 @@
+{% block title %}My Resources{% endblock %}
+{% block content %}
+<h1>My Resources</h1>
+{% if grouped %}
+  {% for wt, items in grouped %}
+    <h2>{{ wt.name }}</h2>
+    <ul>
+    {% for r in items %}
+      <li>
+        {% if r.type == 'DOCUMENT' %}
+          <a href="{{ r.public_url }}" download>{{ r.name }}</a>
+        {% else %}
+          <a href="{{ r.resource_value }}" target="_blank">{{ r.name }}</a>
+        {% endif %}
+      </li>
+    {% endfor %}
+    </ul>
+  {% endfor %}
+{% else %}
+  <p>No resources available.</p>
+{% endif %}
+{% endblock %}

--- a/app/templates/nav.html
+++ b/app/templates/nav.html
@@ -3,7 +3,7 @@
   <a href="/"><img src="{{ url_for('static', filename='ktlogo1.png') }}" onerror="this.onerror=null;this.src='/logo.png';" alt="KT Logo" style="max-height:48px;"></a>
   <a href="{{ url_for('home') }}">Home</a>
   {% if current_user or session.get('participant_account_id') %}
-  <a href="{{ url_for('resources') }}">Resources</a>
+  <a href="{{ url_for('learner.my_resources') }}">My Resources</a>
   {% endif %}
   {% if current_user and (current_user.is_app_admin or current_user.is_admin) %}
   <a href="{{ url_for('sessions.list_sessions') }}">Sessions</a>
@@ -39,7 +39,10 @@
             </ul>
           </details>
         </li>
-        {% endif %}
+      {% endif %}
+      {% if current_user and (current_user.is_app_admin or current_user.is_admin or current_user.is_kt_delivery or current_user.is_kt_facilitator or current_user.is_kt_contractor) %}
+        <li><a href="{{ url_for('settings_resources.list_resources') }}">Resources</a></li>
+      {% endif %}
         <li><a href="{{ url_for('learner.profile') }}">My Profile</a></li>
       {% if current_user and (current_user.is_app_admin or current_user.is_admin) %}
       <li><a href="{{ url_for('users.list_users') }}">Users</a></li>

--- a/app/templates/resources.html
+++ b/app/templates/resources.html
@@ -1,6 +1,0 @@
-{% extends "base.html" %}
-{% block title %}Resources{% endblock %}
-{% block content %}
-<h1>Resources</h1>
-<p>Placeholder for learner resources hub.</p>
-{% endblock %}

--- a/app/templates/settings_resources/form.html
+++ b/app/templates/settings_resources/form.html
@@ -1,0 +1,26 @@
+{% block title %}Resource{% endblock %}
+{% block content %}
+<h1>{% if resource %}Edit{% else %}New{% endif %} Resource</h1>
+<form method="post" enctype="multipart/form-data">
+  <label>Name <input type="text" name="name" value="{{ resource.name if resource else '' }}"></label><br>
+  <label>Type
+    <select name="type">
+      {% set cur = resource.type if resource else 'LINK' %}
+      <option value="LINK" {% if cur=='LINK' %}selected{% endif %}>Link</option>
+      <option value="DOCUMENT" {% if cur=='DOCUMENT' %}selected{% endif %}>Document</option>
+      <option value="APP" {% if cur=='APP' %}selected{% endif %}>App</option>
+    </select>
+  </label><br>
+  <label>Link <input type="url" name="link" value="{{ resource.resource_value if resource and resource.type in ['LINK','APP'] else '' }}"></label><br>
+  <label>File <input type="file" name="file"></label><br>
+  <fieldset>
+    <legend>Workshop Types</legend>
+    {% set selected = [wt.id for wt in resource.workshop_types] if resource else [] %}
+    {% for wt in workshop_types %}
+      <label><input type="checkbox" name="workshop_types" value="{{ wt.id }}" {% if wt.id in selected %}checked{% endif %}> {{ wt.name }}</label><br>
+    {% endfor %}
+  </fieldset>
+  <label><input type="checkbox" name="active" {% if not resource or resource.active %}checked{% endif %}> Active</label><br>
+  <button type="submit">Save</button>
+</form>
+{% endblock %}

--- a/app/templates/settings_resources/list.html
+++ b/app/templates/settings_resources/list.html
@@ -1,0 +1,26 @@
+{% block title %}Resources{% endblock %}
+{% block content %}
+<h1>Resources</h1>
+<p><a href="{{ url_for('settings_resources.new_resource') }}">New Resource</a></p>
+<table border="1" cellpadding="4" cellspacing="0">
+  <tr>
+    <th>Name</th><th>Type</th><th>Target</th><th>Workshop Types</th><th>Active</th><th>Actions</th>
+  </tr>
+  {% for r in resources %}
+  <tr>
+    <td>{{ r.name }}</td>
+    <td>{{ r.type }}</td>
+    <td>
+      {% if r.type == 'DOCUMENT' %}
+        {{ r.resource_value }}
+      {% else %}
+        <a href="{{ r.resource_value }}" target="_blank">{{ r.resource_value }}</a>
+      {% endif %}
+    </td>
+    <td>{% for wt in r.workshop_types %}{{ wt.name }}{% if not loop.last %}, {% endif %}{% endfor %}</td>
+    <td>{{ 'Yes' if r.active else 'No' }}</td>
+    <td><a href="{{ url_for('settings_resources.edit_resource', res_id=r.id) }}">Edit</a></td>
+  </tr>
+  {% endfor %}
+</table>
+{% endblock %}

--- a/migrations/versions/0012_add_resources.py
+++ b/migrations/versions/0012_add_resources.py
@@ -1,0 +1,47 @@
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0012_add_resources"
+down_revision = "0011_user_roles_and_unique_email"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+
+    if "resources" not in insp.get_table_names():
+        op.create_table(
+            "resources",
+            sa.Column("id", sa.Integer, primary_key=True),
+            sa.Column("name", sa.String(255), nullable=False),
+            sa.Column("type", sa.String(20), nullable=False),
+            sa.Column("resource_value", sa.String(2048)),
+            sa.Column("active", sa.Boolean, server_default=sa.text("true"), nullable=False),
+            sa.Column("created_at", sa.DateTime, server_default=sa.func.now()),
+        )
+        op.execute(
+            "CREATE UNIQUE INDEX IF NOT EXISTS ix_resources_name_lower_active ON resources (lower(name)) WHERE active"
+        )
+
+    if "resource_workshop_types" not in insp.get_table_names():
+        op.create_table(
+            "resource_workshop_types",
+            sa.Column(
+                "resource_id",
+                sa.Integer,
+                sa.ForeignKey("resources.id", ondelete="CASCADE"),
+                primary_key=True,
+            ),
+            sa.Column(
+                "workshop_type_id",
+                sa.Integer,
+                sa.ForeignKey("workshop_types.id", ondelete="CASCADE"),
+                primary_key=True,
+            ),
+        )
+
+
+def downgrade():
+    pass

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -1,0 +1,67 @@
+import os
+import sys
+
+import pytest
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from app.app import create_app, db
+from app.models import (
+    WorkshopType,
+    Session,
+    Participant,
+    SessionParticipant,
+    ParticipantAccount,
+    Resource,
+)
+from app.forms.resource_forms import slugify_filename
+
+
+@pytest.fixture
+def app():
+    os.environ["DATABASE_URL"] = "sqlite:///:memory:"
+    os.makedirs("/srv/resources", exist_ok=True)
+    app = create_app()
+    with app.app_context():
+        db.create_all()
+        yield app
+        db.session.remove()
+
+
+def test_resource_validation_and_slug(app):
+    with app.app_context():
+        r = Resource(name="Link", type="LINK", resource_value="https://example.com")
+        r.validate()
+        r2 = Resource(name="Doc", type="DOCUMENT", resource_value="")
+        with pytest.raises(ValueError):
+            r2.validate()
+        fname = slugify_filename("DA Template", "My File.XLSX")
+        assert fname == "da-template.xlsx"
+
+
+def test_my_resources_view(app):
+    with app.app_context():
+        wt = WorkshopType(code="ABC", name="Type A")
+        sess = Session(title="S1", workshop_type=wt)
+        p = Participant(email="p@example.com", full_name="P")
+        db.session.add_all([wt, sess, p])
+        db.session.flush()
+        link = SessionParticipant(session_id=sess.id, participant_id=p.id)
+        db.session.add(link)
+        link_res = Resource(name="LinkR", type="LINK", resource_value="https://kt.com", active=True)
+        doc_res = Resource(name="DocR", type="DOCUMENT", resource_value="doc.pdf", active=True)
+        link_res.workshop_types.append(wt)
+        doc_res.workshop_types.append(wt)
+        db.session.add_all([link_res, doc_res])
+        account = ParticipantAccount(email="p@example.com", full_name="P")
+        db.session.add(account)
+        db.session.commit()
+        account_id = account.id
+    client = app.test_client()
+    with client.session_transaction() as sess:
+        sess["participant_account_id"] = account_id
+    resp = client.get("/my-resources")
+    html = resp.get_data(as_text=True)
+    assert "Type A" in html
+    assert "LinkR" in html and "https://kt.com" in html
+    assert "/resources/doc.pdf" in html


### PR DESCRIPTION
## Summary
- add Resource model with workshop type mapping and file/public URL helpers
- allow staff to manage resources and uploads at `/settings/resources`
- show participants their mapped resources grouped by workshop type at `/my-resources`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af4df7660c832e956bd3d2de439ca0