### PR TITLE
Expose Resource model in metadata

### DIFF
--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -615,3 +615,29 @@ def seed_virtual_workshop_locations() -> None:
 
 
 from .resource import Resource, resource_workshop_types  # noqa: E402,F401
+
+__all__ = [
+    "User",
+    "ParticipantAccount",
+    "Settings",
+    "Language",
+    "WorkshopType",
+    "Client",
+    "ClientShippingLocation",
+    "ClientWorkshopLocation",
+    "Session",
+    "Participant",
+    "SessionParticipant",
+    "Certificate",
+    "SessionFacilitator",
+    "MaterialType",
+    "Material",
+    "MaterialsOption",
+    "SessionShipping",
+    "SessionShippingItem",
+    "Badge",
+    "AuditLog",
+    "UserAuditLog",
+    "Resource",
+    "resource_workshop_types",
+]


### PR DESCRIPTION
## Summary
- Export Resource and its association table in models package to ensure Alembic picks up resources tables

## Testing
- `pytest`
- `DATABASE_URL=sqlite:///tmp.db python manage.py db migrate` (fails: sqlite3.OperationalError: no such table: information_schema.columns)

------
https://chatgpt.com/codex/tasks/task_e_68af5f4d6f6c832ea163a99a4d9e52f3