### PR TITLE
Fix Resource metadata visibility and add migration

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -20,6 +20,7 @@ from sqlalchemy import or_, text
 db = SQLAlchemy()
 
 from .models import User, ParticipantAccount, Session, Client, Language
+from .models import resource  # ensures app/models/resource.py is imported
 from .utils.badges import best_badge_url, slug_for_badge
 from .utils.rbac import app_admin_required
 from .constants import LANGUAGE_NAMES

--- a/migrations/env.py
+++ b/migrations/env.py
@@ -3,48 +3,52 @@ from __future__ import with_statement
 import logging
 from logging.config import fileConfig
 
-from flask import current_app
 from alembic import context
+from app.app import create_app, db
 
 config = context.config
 
 fileConfig(config.config_file_name)
 logger = logging.getLogger("alembic.env")
 
-target_metadata = current_app.extensions["migrate"].db.metadata
+app = create_app()
+
+with app.app_context():
+    target_metadata = db.metadata
 
 
 def run_migrations_offline() -> None:
-    url = config.get_main_option("sqlalchemy.url")
-    if not url:
-        url = str(current_app.extensions["migrate"].db.engine.url)
-    context.configure(
-        url=url,
-        target_metadata=target_metadata,
-        literal_binds=True,
-        dialect_opts={"paramstyle": "named"},
-    )
-
-    with context.begin_transaction():
-        context.run_migrations()
-
-
-def run_migrations_online() -> None:
-    connectable = current_app.extensions["migrate"].db.engine
-
-    with connectable.connect() as connection:
+    with app.app_context():
+        url = config.get_main_option("sqlalchemy.url")
+        if not url:
+            url = app.config["SQLALCHEMY_DATABASE_URI"]
         context.configure(
-            connection=connection,
+            url=url,
             target_metadata=target_metadata,
-            compare_type=True,
+            literal_binds=True,
+            dialect_opts={"paramstyle": "named"},
         )
 
         with context.begin_transaction():
             context.run_migrations()
 
 
+def run_migrations_online() -> None:
+    with app.app_context():
+        connectable = db.engine
+
+        with connectable.connect() as connection:
+            context.configure(
+                connection=connection,
+                target_metadata=target_metadata,
+                compare_type=True,
+            )
+
+            with context.begin_transaction():
+                context.run_migrations()
+
+
 if context.is_offline_mode():
     run_migrations_offline()
 else:
     run_migrations_online()
-

--- a/migrations/versions/8583f5619ee6_add_resources_tables.py
+++ b/migrations/versions/8583f5619ee6_add_resources_tables.py
@@ -1,0 +1,48 @@
+"""add resources tables
+
+Revision ID: 8583f5619ee6
+Revises: 0030_location_notes
+Create Date: 2025-08-27 20:16:11.331844
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade() -> None:
+    op.create_table(
+        "resources",
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("name", sa.String(255), nullable=False),
+        sa.Column("type", sa.String(20), nullable=False),
+        sa.Column("resource_value", sa.String(2048)),
+        sa.Column(
+            "active", sa.Boolean, nullable=False, server_default=sa.text("true")
+        ),
+        sa.Column("created_at", sa.DateTime, server_default=sa.func.now()),
+    )
+    op.create_table(
+        "resource_workshop_types",
+        sa.Column(
+            "resource_id",
+            sa.Integer,
+            sa.ForeignKey("resources.id", ondelete="CASCADE"),
+            primary_key=True,
+        ),
+        sa.Column(
+            "workshop_type_id",
+            sa.Integer,
+            sa.ForeignKey("workshop_types.id", ondelete="CASCADE"),
+            primary_key=True,
+        ),
+        sa.UniqueConstraint(
+            "resource_id",
+            "workshop_type_id",
+            name="uix_resource_workshop_type",
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("resource_workshop_types")
+    op.drop_table("resources")
+


### PR DESCRIPTION
## Summary
- ensure resource model module is imported during app init so Alembic sees it
- instantiate app in Alembic env and expose metadata
- add migration creating `resources` and `resource_workshop_types` tables

## Testing
- `python manage.py db upgrade`
- `python manage.py db migrate -m "add resources tables"`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68af662def3c832ea367cb8e9595b222