### PR TITLE
Ensure Resources pages use base layout and nav

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -158,5 +158,6 @@ Kepner-Tregoe’s Certs & Badges System (CBS) manages workshops (“Sessions”)
     - **Documents** → download directly from `/resources/<filename>`.  
 - **Permissions**:  
   - **SysAdmin, Administrator, Delivery**: full CRUD.  
-  - **Facilitator, Contractor**: view only.  
-  - **Participants**: view only, scoped to their workshop types.  
+  - **Facilitator, Contractor**: view only.
+  - **Participants**: view only, scoped to their workshop types.
+  - Resources pages use the standard base layout with persistent left sidebar; active nav: Settings→Resources; Learner→My Resources.

--- a/app/routes/learner.py
+++ b/app/routes/learner.py
@@ -78,7 +78,9 @@ def my_resources():
         )
         if items:
             grouped.append((wt, items))
-    return render_template("my_resources.html", grouped=grouped)
+    return render_template(
+        "my_resources.html", grouped=grouped, active_nav="my-resources"
+    )
     
 @bp.get("/my-certificates")
 @login_required

--- a/app/routes/settings_resources.py
+++ b/app/routes/settings_resources.py
@@ -50,7 +50,12 @@ def list_resources():
     if isinstance(current_user, Response):
         return current_user
     resources = Resource.query.order_by(Resource.name).all()
-    return render_template("settings_resources/list.html", resources=resources)
+    return render_template(
+        "settings_resources/list.html",
+        resources=resources,
+        active_nav="settings",
+        active_section="resources",
+    )
 
 
 @bp.get("/new")
@@ -60,7 +65,11 @@ def new_resource():
         return current_user
     workshop_types = WorkshopType.query.order_by(WorkshopType.name).all()
     return render_template(
-        "settings_resources/form.html", resource=None, workshop_types=workshop_types
+        "settings_resources/form.html",
+        resource=None,
+        workshop_types=workshop_types,
+        active_nav="settings",
+        active_section="resources",
     )
 
 
@@ -110,7 +119,11 @@ def edit_resource(res_id: int):
         abort(404)
     workshop_types = WorkshopType.query.order_by(WorkshopType.name).all()
     return render_template(
-        "settings_resources/form.html", resource=res, workshop_types=workshop_types
+        "settings_resources/form.html",
+        resource=res,
+        workshop_types=workshop_types,
+        active_nav="settings",
+        active_section="resources",
     )
 
 

--- a/app/templates/my_resources.html
+++ b/app/templates/my_resources.html
@@ -1,3 +1,4 @@
+{% extends 'base.html' %}
 {% block title %}My Resources{% endblock %}
 {% block content %}
 <h1>My Resources</h1>

--- a/app/templates/settings_resources/form.html
+++ b/app/templates/settings_resources/form.html
@@ -1,3 +1,4 @@
+{% extends 'base.html' %}
 {% block title %}Resource{% endblock %}
 {% block content %}
 <h1>{% if resource %}Edit{% else %}New{% endif %} Resource</h1>

--- a/app/templates/settings_resources/list.html
+++ b/app/templates/settings_resources/list.html
@@ -1,3 +1,4 @@
+{% extends 'base.html' %}
 {% block title %}Resources{% endblock %}
 {% block content %}
 <h1>Resources</h1>


### PR DESCRIPTION
## Summary
- extend Resources templates from the standard `base.html` to restore sidebar
- highlight Resources navigation by passing active_nav and active_section in routes
- document that Resources pages use the standard layout

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68af738d4960832e9c295aae3139b67f