### PR TITLE
Add prework templates and participant assignments

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -60,6 +60,7 @@ Kepner-Tregoe’s Certs & Badges System (CBS) manages workshops (“Sessions”)
   Delivered auto-ticks Materials ordered + Workshop info sent. **[DONE]**
 - **Status (derived)**: New → In Progress → Ready for Delivery → Delivered → Closed; Cancelled overrides; On-hold shows as In Progress with a note. **[DONE]**
 - PRG everywhere; red flashes explain why a save is blocked. **[DONE]**
+- **Prework**: session page `/sessions/<id>/prework` lists participants and lets staff send prework assignments when the workshop type has a template. **[DONE]**
 
 ---
 
@@ -71,6 +72,7 @@ Kepner-Tregoe’s Certs & Badges System (CBS) manages workshops (“Sessions”)
   - Badge files live under `/srv/badges`.
   - Names map via slug (lowercase, no spaces). Helpers try `.webp` first, then `.png`.
   - To add a PNG alternative, drop `<slug>.png` in `/srv/badges`.
+- **Prework templates**: staff edit per Workshop Type at `/workshop-types/<id>/prework` (info & questions). **[DONE]**
 
 ---
 
@@ -119,6 +121,7 @@ Kepner-Tregoe’s Certs & Badges System (CBS) manages workshops (“Sessions”)
 - Sidebar (role-aware): Home, Sessions, Materials (orders), My Sessions, My Certificates, Settings (Users, Workshop Types, Clients, Materials, Languages, Mail Settings), Logout. Guests see only Login. **[DONE]**
 - Root `/` shows branded login card (no nav). **[DONE]**
 - Basic responsive styles; flashes consistent. **[DONE]**
+- Participant nav gating: "My Prework" shows for pending assignments before sessions start; "My Resources" unlock after session start; "My Certificates" show when earned. **[DONE]**
 
 ---
 

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -615,6 +615,14 @@ def seed_virtual_workshop_locations() -> None:
 
 
 from .resource import Resource, resource_workshop_types  # noqa: E402,F401
+from .prework import (
+    PreworkTemplate,
+    PreworkQuestion,
+    PreworkTemplateResource,
+    PreworkAssignment,
+    PreworkAnswer,
+    PreworkEmailLog,
+)  # noqa: E402,F401
 
 __all__ = [
     "User",
@@ -640,4 +648,10 @@ __all__ = [
     "UserAuditLog",
     "Resource",
     "resource_workshop_types",
+    "PreworkTemplate",
+    "PreworkQuestion",
+    "PreworkTemplateResource",
+    "PreworkAssignment",
+    "PreworkAnswer",
+    "PreworkEmailLog",
 ]

--- a/app/models/prework.py
+++ b/app/models/prework.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+from ..app import db
+
+
+class PreworkTemplate(db.Model):
+    __tablename__ = "prework_templates"
+
+    id = db.Column(db.Integer, primary_key=True)
+    workshop_type_id = db.Column(
+        db.Integer, db.ForeignKey("workshop_types.id", ondelete="CASCADE"), unique=True
+    )
+    is_active = db.Column(db.Boolean, nullable=False, default=True)
+    require_completion = db.Column(db.Boolean, nullable=False, default=True)
+    info_html = db.Column(db.Text)
+    created_at = db.Column(db.DateTime(timezone=True), server_default=db.func.now())
+
+    questions = db.relationship(
+        "PreworkQuestion", backref="template", cascade="all, delete-orphan"
+    )
+    resources = db.relationship(
+        "PreworkTemplateResource", backref="template", cascade="all, delete-orphan"
+    )
+
+
+class PreworkQuestion(db.Model):
+    __tablename__ = "prework_questions"
+
+    id = db.Column(db.Integer, primary_key=True)
+    template_id = db.Column(
+        db.Integer, db.ForeignKey("prework_templates.id", ondelete="CASCADE")
+    )
+    position = db.Column(db.Integer, nullable=False)
+    text = db.Column(db.Text, nullable=False)
+    required = db.Column(db.Boolean, nullable=False, default=True)
+    __table_args__ = (
+        db.UniqueConstraint("template_id", "position", name="uq_prework_question_position"),
+    )
+
+
+class PreworkTemplateResource(db.Model):
+    __tablename__ = "prework_template_resources"
+
+    template_id = db.Column(
+        db.Integer, db.ForeignKey("prework_templates.id", ondelete="CASCADE"), primary_key=True
+    )
+    resource_id = db.Column(
+        db.Integer, db.ForeignKey("resources.id", ondelete="CASCADE"), primary_key=True
+    )
+
+
+class PreworkAssignment(db.Model):
+    __tablename__ = "prework_assignments"
+
+    id = db.Column(db.Integer, primary_key=True)
+    session_id = db.Column(db.Integer, db.ForeignKey("sessions.id", ondelete="CASCADE"))
+    participant_account_id = db.Column(
+        db.Integer, db.ForeignKey("participant_accounts.id", ondelete="CASCADE")
+    )
+    template_id = db.Column(
+        db.Integer, db.ForeignKey("prework_templates.id", ondelete="SET NULL")
+    )
+    status = db.Column(db.String(16), nullable=False, default="PENDING")
+    due_at = db.Column(db.DateTime(timezone=True))
+    sent_at = db.Column(db.DateTime(timezone=True))
+    completed_at = db.Column(db.DateTime(timezone=True))
+    snapshot_json = db.Column(db.JSON, nullable=False)
+    magic_token_hash = db.Column(db.String(128))
+    magic_token_expires = db.Column(db.DateTime(timezone=True))
+    __table_args__ = (
+        db.UniqueConstraint(
+            "session_id", "participant_account_id", name="uq_prework_assignment_unique"
+        ),
+    )
+
+    session = db.relationship("Session")
+    participant_account = db.relationship("ParticipantAccount")
+    template = db.relationship("PreworkTemplate")
+    answers = db.relationship(
+        "PreworkAnswer", backref="assignment", cascade="all, delete-orphan"
+    )
+    emails = db.relationship(
+        "PreworkEmailLog", backref="assignment", cascade="all, delete-orphan"
+    )
+
+    def update_completion(self) -> None:
+        required = {
+            q.get("index")
+            for q in self.snapshot_json.get("questions", [])
+            if q.get("required")
+        }
+        answered = {
+            a.question_index
+            for a in self.answers
+            if a.answer_text and a.answer_text.strip()
+        }
+        if required.issubset(answered):
+            if self.status != "COMPLETED":
+                self.status = "COMPLETED"
+                self.completed_at = datetime.utcnow()
+        else:
+            if self.status == "COMPLETED":
+                self.status = "SENT"
+                self.completed_at = None
+
+
+class PreworkAnswer(db.Model):
+    __tablename__ = "prework_answers"
+
+    id = db.Column(db.Integer, primary_key=True)
+    assignment_id = db.Column(
+        db.Integer, db.ForeignKey("prework_assignments.id", ondelete="CASCADE")
+    )
+    question_index = db.Column(db.Integer, nullable=False)
+    answer_text = db.Column(db.Text, nullable=False)
+    updated_at = db.Column(
+        db.DateTime(timezone=True),
+        server_default=db.func.now(),
+        onupdate=db.func.now(),
+    )
+    __table_args__ = (
+        db.UniqueConstraint(
+            "assignment_id", "question_index", name="uq_prework_answer_unique"
+        ),
+    )
+
+
+class PreworkEmailLog(db.Model):
+    __tablename__ = "prework_email_log"
+
+    id = db.Column(db.Integer, primary_key=True)
+    assignment_id = db.Column(
+        db.Integer, db.ForeignKey("prework_assignments.id", ondelete="CASCADE")
+    )
+    to_email = db.Column(db.String(320))
+    subject = db.Column(db.String(255))
+    sent_at = db.Column(db.DateTime(timezone=True), server_default=db.func.now())

--- a/app/templates/my_prework.html
+++ b/app/templates/my_prework.html
@@ -1,0 +1,21 @@
+{% extends "base.html" %}
+{% block title %}My Prework{% endblock %}
+{% block content %}
+<h1>My Prework</h1>
+{% if assignments %}
+<ul>
+{% for a in assignments %}
+<li>
+{{ a.session.title if a.session else 'Session' }} - {{ a.status }}
+{% if a.status != 'COMPLETED' %}
+<a href="{{ url_for('learner.prework_form', assignment_id=a.id) }}">Open</a>
+{% else %}
+<a href="{{ url_for('learner.prework_form', assignment_id=a.id) }}">View</a>
+{% endif %}
+</li>
+{% endfor %}
+</ul>
+{% else %}
+<p>No prework assignments.</p>
+{% endif %}
+{% endblock %}

--- a/app/templates/nav.html
+++ b/app/templates/nav.html
@@ -2,7 +2,10 @@
   <!-- Navigation order updated -->
   <a href="/"><img src="{{ url_for('static', filename='ktlogo1.png') }}" onerror="this.onerror=null;this.src='/logo.png';" alt="KT Logo" style="max-height:48px;"></a>
   <a href="{{ url_for('home') }}">Home</a>
-  {% if current_user or session.get('participant_account_id') %}
+  {% if show_prework_nav %}
+  <a href="{{ url_for('learner.my_prework') }}">My Prework</a>
+  {% endif %}
+  {% if show_resources_nav %}
   <a href="{{ url_for('learner.my_resources') }}">My Resources</a>
   {% endif %}
   {% if current_user and (current_user.is_app_admin or current_user.is_admin) %}
@@ -17,7 +20,9 @@
   {% if current_user or is_csa %}
   <a href="{{ url_for('my_sessions.list_my_sessions') }}">My Sessions</a>
   {% endif %}
+  {% if show_certificates_nav %}
   <a href="{{ url_for('learner.my_certs') }}">My Certificates</a>
+  {% endif %}
   <a href="{{ url_for('verify_form') }}">Verify Certificates</a>
   {% if current_user or session.get('participant_account_id') or is_csa %}
   <details class="settings">

--- a/app/templates/prework_form.html
+++ b/app/templates/prework_form.html
@@ -1,0 +1,20 @@
+{% extends "base.html" %}
+{% block title %}Prework{% endblock %}
+{% block content %}
+<h1>Prework for {{ assignment.session.title if assignment.session else '' }}</h1>
+{% if assignment.template and assignment.template.info_html %}
+<div>{{ assignment.template.info_html|safe }}</div>
+{% endif %}
+<form method="post">
+{% for q in questions %}
+<div class="question">
+<label>{{ q.text }}</label><br>
+<textarea name="q{{ q.index }}" rows="3" cols="60">{{ answers.get(q.index, '') }}</textarea>
+</div>
+{% endfor %}
+<button type="submit">Submit</button>
+</form>
+{% if assignment.status == 'COMPLETED' %}
+<p>Status: Completed</p>
+{% endif %}
+{% endblock %}

--- a/app/templates/sessions/prework.html
+++ b/app/templates/sessions/prework.html
@@ -1,0 +1,23 @@
+{% extends "base.html" %}
+{% block title %}Prework - {{ session.title }}{% endblock %}
+{% block content %}
+<h1>Prework for {{ session.title }}</h1>
+{% if not template %}
+<p>No active prework template for this workshop type.</p>
+{% endif %}
+<form method="post">
+<table>
+<tr><th>Name</th><th>Email</th><th>Status</th><th>Sent</th><th>Completed</th></tr>
+{% for p, account, assignment in rows %}
+<tr>
+<td>{{ p.full_name }}</td>
+<td>{{ p.email }}</td>
+<td>{{ assignment.status if assignment else 'PENDING' }}</td>
+<td>{{ assignment.sent_at if assignment else '' }}</td>
+<td>{{ assignment.completed_at if assignment else '' }}</td>
+</tr>
+{% endfor %}
+</table>
+{% if template %}<button type="submit">Send Prework</button>{% endif %}
+</form>
+{% endblock %}

--- a/app/templates/workshop_types/prework.html
+++ b/app/templates/workshop_types/prework.html
@@ -1,0 +1,14 @@
+{% extends "base.html" %}
+{% block title %}Prework for {{ wt.name }}{% endblock %}
+{% block content %}
+<h1>Prework for {{ wt.name }}</h1>
+<form method="post">
+<label><input type="checkbox" name="is_active" value="1" {% if template and template.is_active %}checked{% endif %}> Active</label><br>
+<label><input type="checkbox" name="require_completion" value="1" {% if template and template.require_completion %}checked{% endif %}> Require completion</label><br>
+<label>Information</label><br>
+<textarea name="info" rows="4" cols="60">{{ template.info_html if template else '' }}</textarea><br>
+<label>Questions (one per line)</label><br>
+<textarea name="questions" rows="10" cols="80">{{ questions_text }}</textarea><br>
+<button type="submit">Save</button>
+</form>
+{% endblock %}

--- a/migrations/versions/0031_prework.py
+++ b/migrations/versions/0031_prework.py
@@ -1,0 +1,158 @@
+"""add prework tables
+
+Revision ID: 0031_prework
+Revises: 8583f5619ee6
+Create Date: 2025-09-10 00:00:00.000000
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "0031_prework"
+down_revision = "8583f5619ee6"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "prework_templates",
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column(
+            "workshop_type_id",
+            sa.Integer,
+            sa.ForeignKey("workshop_types.id", ondelete="CASCADE"),
+            nullable=False,
+            unique=True,
+        ),
+        sa.Column("is_active", sa.Boolean, nullable=False, server_default=sa.text("true")),
+        sa.Column(
+            "require_completion",
+            sa.Boolean,
+            nullable=False,
+            server_default=sa.text("true"),
+        ),
+        sa.Column("info_html", sa.Text()),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("timezone('utc', now())"),
+        ),
+    )
+    op.create_table(
+        "prework_questions",
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column(
+            "template_id",
+            sa.Integer,
+            sa.ForeignKey("prework_templates.id", ondelete="CASCADE"),
+        ),
+        sa.Column("position", sa.Integer, nullable=False),
+        sa.Column("text", sa.Text, nullable=False),
+        sa.Column(
+            "required",
+            sa.Boolean,
+            nullable=False,
+            server_default=sa.text("true"),
+        ),
+        sa.UniqueConstraint(
+            "template_id", "position", name="uq_prework_question_position"
+        ),
+    )
+    op.create_table(
+        "prework_template_resources",
+        sa.Column(
+            "template_id",
+            sa.Integer,
+            sa.ForeignKey("prework_templates.id", ondelete="CASCADE"),
+            primary_key=True,
+        ),
+        sa.Column(
+            "resource_id",
+            sa.Integer,
+            sa.ForeignKey("resources.id", ondelete="CASCADE"),
+            primary_key=True,
+        ),
+    )
+    op.create_table(
+        "prework_assignments",
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column(
+            "session_id",
+            sa.Integer,
+            sa.ForeignKey("sessions.id", ondelete="CASCADE"),
+        ),
+        sa.Column(
+            "participant_account_id",
+            sa.Integer,
+            sa.ForeignKey("participant_accounts.id", ondelete="CASCADE"),
+        ),
+        sa.Column(
+            "template_id",
+            sa.Integer,
+            sa.ForeignKey("prework_templates.id", ondelete="SET NULL"),
+        ),
+        sa.Column(
+            "status",
+            sa.String(16),
+            nullable=False,
+            server_default="PENDING",
+        ),
+        sa.Column("due_at", sa.DateTime(timezone=True)),
+        sa.Column("sent_at", sa.DateTime(timezone=True)),
+        sa.Column("completed_at", sa.DateTime(timezone=True)),
+        sa.Column("snapshot_json", sa.JSON, nullable=False),
+        sa.Column("magic_token_hash", sa.String(128)),
+        sa.Column("magic_token_expires", sa.DateTime(timezone=True)),
+        sa.UniqueConstraint(
+            "session_id",
+            "participant_account_id",
+            name="uq_prework_assignment_unique",
+        ),
+    )
+    op.create_table(
+        "prework_answers",
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column(
+            "assignment_id",
+            sa.Integer,
+            sa.ForeignKey("prework_assignments.id", ondelete="CASCADE"),
+        ),
+        sa.Column("question_index", sa.Integer, nullable=False),
+        sa.Column("answer_text", sa.Text, nullable=False),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("timezone('utc', now())"),
+            onupdate=sa.text("timezone('utc', now())"),
+        ),
+        sa.UniqueConstraint(
+            "assignment_id", "question_index", name="uq_prework_answer_unique"
+        ),
+    )
+    op.create_table(
+        "prework_email_log",
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column(
+            "assignment_id",
+            sa.Integer,
+            sa.ForeignKey("prework_assignments.id", ondelete="CASCADE"),
+        ),
+        sa.Column("to_email", sa.String(320)),
+        sa.Column("subject", sa.String(255)),
+        sa.Column(
+            "sent_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("timezone('utc', now())"),
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("prework_email_log")
+    op.drop_table("prework_answers")
+    op.drop_table("prework_assignments")
+    op.drop_table("prework_template_resources")
+    op.drop_table("prework_questions")
+    op.drop_table("prework_templates")

--- a/tests/test_prework.py
+++ b/tests/test_prework.py
@@ -1,0 +1,91 @@
+from datetime import date, time
+
+from app.app import create_app, db
+from app.models import (
+    WorkshopType,
+    PreworkTemplate,
+    PreworkQuestion,
+    Session,
+    ParticipantAccount,
+    Participant,
+    SessionParticipant,
+    PreworkAssignment,
+    PreworkAnswer,
+)
+
+
+def test_assignment_completion():
+    app = create_app()
+    with app.app_context():
+        db.create_all()
+        wt = WorkshopType(code="PW", name="Prework")
+        db.session.add(wt)
+        db.session.commit()
+        tpl = PreworkTemplate(workshop_type_id=wt.id, info_html="info")
+        db.session.add(tpl)
+        db.session.flush()
+        db.session.add(PreworkQuestion(template_id=tpl.id, position=1, text="Q1"))
+        db.session.commit()
+        sess = Session(title="S1", workshop_type_id=wt.id, start_date=date.today(), daily_start_time=time(8, 0))
+        acct = ParticipantAccount(email="a@example.com", full_name="A")
+        part = Participant(email="a@example.com", full_name="A", account=acct)
+        db.session.add_all([sess, acct, part])
+        db.session.flush()
+        db.session.add(SessionParticipant(session_id=sess.id, participant_id=part.id))
+        snapshot = {"questions": [{"index": 1, "text": "Q1", "required": True}], "resources": []}
+        assign = PreworkAssignment(
+            session_id=sess.id,
+            participant_account_id=acct.id,
+            template_id=tpl.id,
+            status="SENT",
+            snapshot_json=snapshot,
+        )
+        db.session.add(assign)
+        db.session.commit()
+        db.session.add(
+            PreworkAnswer(
+                assignment_id=assign.id, question_index=1, answer_text="A1"
+            )
+        )
+        db.session.commit()
+        assign.update_completion()
+        db.session.commit()
+        assert assign.status == "COMPLETED"
+
+
+def test_nav_gating_prework():
+    app = create_app()
+    with app.app_context():
+        db.create_all()
+        wt = WorkshopType(code="PW2", name="Prework2")
+        db.session.add(wt)
+        db.session.commit()
+        tpl = PreworkTemplate(workshop_type_id=wt.id, info_html="info")
+        db.session.add(tpl)
+        db.session.flush()
+        db.session.add(PreworkQuestion(template_id=tpl.id, position=1, text="Q1"))
+        db.session.commit()
+        future = date.fromordinal(date.today().toordinal() + 5)
+        sess = Session(title="Fut", workshop_type_id=wt.id, start_date=future, daily_start_time=time(8, 0))
+        acct = ParticipantAccount(email="b@example.com", full_name="B")
+        part = Participant(email="b@example.com", full_name="B", account=acct)
+        db.session.add_all([sess, acct, part])
+        db.session.flush()
+        db.session.add(SessionParticipant(session_id=sess.id, participant_id=part.id))
+        snapshot = {"questions": [{"index": 1, "text": "Q1", "required": True}], "resources": []}
+        assign = PreworkAssignment(
+            session_id=sess.id,
+            participant_account_id=acct.id,
+            template_id=tpl.id,
+            status="SENT",
+            snapshot_json=snapshot,
+        )
+        db.session.add(assign)
+        db.session.commit()
+        account_id = acct.id
+    with app.test_client() as c:
+        with c.session_transaction() as sess_data:
+            sess_data["participant_account_id"] = account_id
+        resp = c.get("/home", follow_redirects=True)
+        assert b"My Prework" in resp.data
+        assert b"My Resources" not in resp.data


### PR DESCRIPTION
## Summary
- introduce prework data models and migration
- allow staff to edit workshop-type prework templates and send session assignments
- add participant prework pages with nav gating for prework/resources/certificates

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68af98c63944832eb4098014b1e741fb