### PR TITLE
feat: add prework links for staff

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -61,7 +61,7 @@ Kepner-Tregoe’s Certs & Badges System (CBS) manages workshops (“Sessions”)
 - **Status (derived)**: New → In Progress → Ready for Delivery → Delivered → Closed; Cancelled overrides; On-hold shows as In Progress with a note. **[DONE]**
 - PRG everywhere; red flashes explain why a save is blocked. **[DONE]**
 - **Prework**: session page `/sessions/<id>/prework` lists participants and lets staff send prework assignments when the workshop type has a template. **[DONE]**
-
+- Staff can access Prework via a "Prework" button on the Workshop Type edit page and on Session list/detail pages. **[DONE]**
 ---
 
 ## 4) Workshop Types & Badges
@@ -73,7 +73,7 @@ Kepner-Tregoe’s Certs & Badges System (CBS) manages workshops (“Sessions”)
   - Names map via slug (lowercase, no spaces). Helpers try `.webp` first, then `.png`.
   - To add a PNG alternative, drop `<slug>.png` in `/srv/badges`.
 - **Prework templates**: staff edit per Workshop Type at `/workshop-types/<id>/prework` (info & questions). **[DONE]**
-
+- Staff can access Prework via a "Prework" button on the Workshop Type edit page and on Session list/detail pages. **[DONE]**
 ---
 
 ## 5) Materials & Shipping (single shipment per session)

--- a/app/templates/session_detail.html
+++ b/app/templates/session_detail.html
@@ -57,6 +57,7 @@
 {% if session.delivered and not session.finalized and not session.cancelled %}
 <form action="{{ url_for('sessions.finalize_session', session_id=session.id) }}" method="post" style="display:inline" onsubmit="return confirm('Finalize session?');"><button type="submit">Finalize session</button></form>
 {% endif %}
+ {% if current_user.is_app_admin or current_user.is_admin or current_user.is_kt_delivery or current_user.is_kt_contractor %}| <a href="{{ url_for('sessions.session_prework', session_id=session.id) }}">Prework</a>{% endif %}
  | <a href="{{ url_for('materials.materials_view', session_id=session.id) }}">Materials Order</a>
 </p>
 <div>

--- a/app/templates/sessions.html
+++ b/app/templates/sessions.html
@@ -9,7 +9,7 @@
 <p><a href="{{ url_for('sessions.list_sessions', global=1) }}">Show Global Sessions</a></p>
 {% endif %}
 <table border="1" cellpadding="4" cellspacing="0">
-  <tr><th>Title</th><th>Location</th><th>Workshop Type</th><th>Start</th><th>End</th><th>Client</th><th>Status</th></tr>
+  <tr><th>Title</th><th>Location</th><th>Workshop Type</th><th>Start</th><th>End</th><th>Client</th><th>Status</th><th>Actions</th></tr>
   {% for s in sessions %}
   <tr>
     <td><a href="{{ url_for('sessions.session_detail', session_id=s.id) }}">{{ s.title }}</a></td>
@@ -19,6 +19,11 @@
     <td>{{ s.end_date }}</td>
     <td>{% if s.client %}{{ s.client.name }}{% endif %}</td>
     <td>{{ s.status }}</td>
+    <td>
+      {% if current_user and (current_user.is_app_admin or current_user.is_admin or current_user.is_kt_delivery or current_user.is_kt_contractor) %}
+        <a href="{{ url_for('sessions.session_prework', session_id=s.id) }}">Prework</a>
+      {% endif %}
+    </td>
   </tr>
   {% endfor %}
 </table>

--- a/app/templates/workshop_types/form.html
+++ b/app/templates/workshop_types/form.html
@@ -1,7 +1,12 @@
 {% extends 'base.html' %}
 {% block title %}{{ 'New Workshop Type' if not wt else 'Edit Workshop Type' }}{% endblock %}
 {% block content %}
-<h1>{{ 'New Workshop Type' if not wt else 'Edit Workshop Type' }}</h1>
+<h1>
+  {{ 'New Workshop Type' if not wt else 'Edit Workshop Type' }}
+  {% if wt and current_user and (current_user.is_app_admin or current_user.is_admin or current_user.is_kt_delivery or current_user.is_kt_contractor) %}
+    <a href="{{ url_for('workshop_types.prework', type_id=wt.id) }}">Prework</a>
+  {% endif %}
+</h1>
 <form method="post">
   {% if not wt %}
   <div><label>Code <input type="text" name="code" required></label></div>


### PR DESCRIPTION
## Summary
- surface Prework button on workshop type edit page
- add Prework actions on session list and detail pages
- document new Prework entry points

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68af9e0a8e4c832e9bf18cb260c644ef