### PR TITLE
Fix magic-link handler and update navigation

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -62,6 +62,7 @@ Kepner-Tregoe’s Certs & Badges System (CBS) manages workshops (“Sessions”)
 - PRG everywhere; red flashes explain why a save is blocked. **[DONE]**
 - **Prework**: session page `/sessions/<id>/prework` lists participants and lets staff send prework assignments when the workshop type has a template. List-style questions snapshot kind/min/max and show a download link for staff. **[DONE]**
 - Prework send creates missing participant accounts on-the-fly (`[ACCOUNT]` logs), generates magic-link emails per participant, and logs `[MAIL-OUT]`/`[MAIL-FAIL]`. Rows can be marked **No Prework** (status `WAIVED`). A session-level `no_material_order` flag is set via the New Session form. Sending prework does not gate certificates. **[DONE]**
+- Magic links are single-use passwordless sign-ins. They compare `SHA256(token + SECRET_KEY)` against `magic_token_hash`, expire via `magic_token_expires`, and log `[AUTH]` or `[AUTH-FAIL]` outcomes. **[DONE]**
 - Staff can access Prework via a "Prework" button on the Workshop Type edit page and on Session list/detail pages. **[DONE]**
 - On New Session, there are two actions: **Proceed to materials order** and **No Materials Order (Save)** — the latter sets the flag and returns to the Session detail view. The Prework page does not show materials controls. **[DONE]**
 ---
@@ -121,7 +122,9 @@ Kepner-Tregoe’s Certs & Badges System (CBS) manages workshops (“Sessions”)
 ---
 
 ## 9) UI & Navigation
-- Sidebar (role-aware): Home, Sessions, Materials (orders), My Sessions, My Certificates, Settings (Users, Workshop Types, Clients, Materials, Languages, Mail Settings), Logout. Guests see only Login. **[DONE]**
+- Sidebar (role-aware):
+  - **Participants**: Home, My Workshops, My Resources, My Profile, Logout.
+  - **Staff (SysAdmin/Admin/Delivery/Contractor)**: Home, My Sessions, Sessions, Materials, Surveys, My Resources, My Profile, Settings, Logout. "My Certificates" lives under My Profile; no "Verify Certificates" link. **[DONE]**
 - Learner-facing navigation and emails say "Workshop" (e.g., "My Workshops"); staff UI retains "Session" wording. **[DONE]**
 - Root `/` shows branded login card (no nav). **[DONE]**
 - Basic responsive styles; flashes consistent. **[DONE]**
@@ -135,6 +138,7 @@ Kepner-Tregoe’s Certs & Badges System (CBS) manages workshops (“Sessions”)
 - Pagination on long tables; simple rate-limits on auth endpoints. **[DONE]**
 - Prework autosave endpoint: soft rate limit 10 writes/10s per assignment. **[DONE]**
 - Prework mails log `[ACCOUNT]`, `[MAIL-OUT]`, `[MAIL-FAIL]`; magic links expire after 30 days; accounts are created on send if missing. **[DONE]**
+- External URLs default to HTTPS (`PREFERRED_URL_SCHEME='https'`); prework emails always use HTTPS links. **[DONE]**
 - Migration 0032_prework_list_questions explicitly creates/drops PostgreSQL enum `prework_question_kind` for reliable upgrades/downgrades. **[DONE]**
 
 ---

--- a/app/app.py
+++ b/app/app.py
@@ -40,6 +40,7 @@ from .constants import LANGUAGE_NAMES
 def create_app():
     app = Flask(__name__, template_folder="templates")
     app.secret_key = os.getenv("SECRET_KEY", "dev")
+    app.config["PREFERRED_URL_SCHEME"] = "https"
     app.jinja_env.globals["slug_for_badge"] = slug_for_badge
     app.jinja_env.globals["best_badge_url"] = best_badge_url
 
@@ -167,7 +168,7 @@ def create_app():
                 query = query.filter(Session.status.notin_(["Closed", "Cancelled"]))
                 sessions_list = query.order_by(Session.start_date).all()
                 return render_template("home.html", sessions=sessions_list)
-            return redirect(url_for("learner.my_certs"))
+            return render_template("home.html")
         return redirect(url_for("auth.login"))
 
     def login_required(fn):

--- a/app/routes/sessions.py
+++ b/app/routes/sessions.py
@@ -1138,7 +1138,9 @@ def session_prework(session_id: int, current_user):
 
         def send_mail(assignment: PreworkAssignment, account: ParticipantAccount) -> bool:
             token = secrets.token_urlsafe(16)
-            assignment.magic_token_hash = hashlib.sha256(token.encode()).hexdigest()
+            assignment.magic_token_hash = hashlib.sha256(
+                (token + current_app.secret_key).encode()
+            ).hexdigest()
             assignment.magic_token_expires = datetime.utcnow() + timedelta(
                 days=MAGIC_LINK_TTL_DAYS
             )
@@ -1148,6 +1150,7 @@ def session_prework(session_id: int, current_user):
                 assignment_id=assignment.id,
                 token=token,
                 _external=True,
+                _scheme="https",
             )
             subject = f"Prework for Workshop: {sess.title}"
             body = render_template(

--- a/app/templates/email/prework.html
+++ b/app/templates/email/prework.html
@@ -2,8 +2,12 @@
 <html>
 <body>
 <p>Prework for your upcoming workshop "<strong>{{ session.title }}</strong>" ({% if session.workshop_type %}{{ session.workshop_type.name }}{% endif %}) scheduled for {{ session.start_date }} {{ session.daily_start_time }} {{ session.timezone or '' }} is ready.</p>
-<p>Please complete it by {{ assignment.due_at.date() if assignment.due_at else 'the due date' }}.</p>
+{% if assignment.due_at %}
+<p>Please complete it by {{ assignment.due_at.date() }}.</p>
+{% endif %}
+<p>This secure link signs you in automatically — no username or password needed.</p>
 <p><a href="{{ link }}" style="display:inline-block;padding:10px 20px;background:#4B2E83;color:#fff;text-decoration:none;">Start Prework</a></p>
+<p>If the button doesn't work, copy and paste this URL:<br>{{ link }}</p>
 </body>
 </html>
 

--- a/app/templates/email/prework.txt
+++ b/app/templates/email/prework.txt
@@ -2,8 +2,9 @@ Hello,
 
 Prework for your upcoming workshop "{{ session.title }}" ({% if session.workshop_type %}{{ session.workshop_type.name }}{% endif %}) scheduled for {{ session.start_date }} {{ session.daily_start_time }} {{ session.timezone or '' }} is ready.
 
-Please complete it by {{ assignment.due_at.date() if assignment.due_at else 'the due date' }}.
+{% if assignment.due_at %}Please complete it by {{ assignment.due_at.date() }}.{% endif %}
 
+This secure link signs you in automatically — no username or password needed.
 Start your prework here:
 {{ link }}
 

--- a/app/templates/home.html
+++ b/app/templates/home.html
@@ -3,7 +3,20 @@
 {% block content %}
 <h2>Welcome, {{ session.get('user_email') }}</h2>
 {% if current_user or is_csa %}
-<p><a href="{{ url_for('my_sessions.list_my_sessions') }}">{% if current_user %}My Sessions{% else %}My Workshops{% endif %}</a> | <a href="{{ url_for('learner.my_certs') }}">My Certificates</a></p>
+<p><a href="{{ url_for('my_sessions.list_my_sessions') }}">{% if current_user %}My Sessions{% else %}My Workshops{% endif %}</a></p>
+{% elif session.get('participant_account_id') %}
+  {% if show_prework_nav %}
+  <div>
+    <h3>My Prework</h3>
+    <p><a href="{{ url_for('learner.my_prework') }}">Start Prework</a></p>
+  </div>
+  {% endif %}
+  {% if show_certificates_nav %}
+  <div>
+    <h3>My Certificates</h3>
+    <p><a href="{{ url_for('learner.my_certs') }}">View Certificates</a></p>
+  </div>
+  {% endif %}
 {% endif %}
 {% if sessions %}
 <h2>{% if current_user %}Sessions{% else %}Workshops{% endif %}</h2>

--- a/app/templates/nav.html
+++ b/app/templates/nav.html
@@ -1,68 +1,66 @@
 <nav>
-  <!-- Navigation order updated -->
   <a href="/"><img src="{{ url_for('static', filename='ktlogo1.png') }}" onerror="this.onerror=null;this.src='/logo.png';" alt="KT Logo" style="max-height:48px;"></a>
-  <a href="{{ url_for('home') }}">Home</a>
-  {% if show_prework_nav %}
-  <a href="{{ url_for('learner.my_prework') }}">My Prework</a>
-  {% endif %}
-  {% if show_resources_nav %}
-  <a href="{{ url_for('learner.my_resources') }}">My Resources</a>
-  {% endif %}
-  {% if current_user and (current_user.is_app_admin or current_user.is_admin) %}
-  <a href="{{ url_for('sessions.list_sessions') }}">Sessions</a>
-  {% endif %}
-  {% if current_user and (current_user.is_app_admin or current_user.is_admin or current_user.is_kcrm or current_user.is_kt_delivery or current_user.is_kt_contractor) %}
-  <a href="{{ url_for('materials_orders.list_orders') }}">Materials</a>
-  {% endif %}
-  {% if current_user or session.get('participant_account_id') %}
-  <a href="{{ url_for('surveys') }}">Surveys</a>
-  {% endif %}
   {% if current_user %}
-  <a href="{{ url_for('my_sessions.list_my_sessions') }}">My Sessions</a>
-  {% elif is_csa %}
-  <a href="{{ url_for('my_sessions.list_my_sessions') }}">My Workshops</a>
-  {% endif %}
-  {% if show_certificates_nav %}
-  <a href="{{ url_for('learner.my_certs') }}">My Certificates</a>
-  {% endif %}
-  <a href="{{ url_for('verify_form') }}">Verify Certificates</a>
-  {% if current_user or session.get('participant_account_id') or is_csa %}
-  <details class="settings">
-    <summary class="nav-link">Settings</summary>
-    <ul>
-      {% if current_user and (current_user.is_app_admin or current_user.is_admin) %}
-        <li><a href="{{ url_for('clients.list_clients') }}">Clients</a></li>
-        <li><a href="{{ url_for('workshop_types.list_types') }}">Workshop Types</a></li>
-        <li><a href="{{ url_for('settings_languages.list_langs') }}">Languages</a></li>
-        <li>
-          <details>
-            <summary class="nav-link">Material settings</summary>
-            <ul>
-              <li><a href="{{ url_for('settings_materials.list_options', slug='standard') }}">Standard</a></li>
-              <li><a href="{{ url_for('settings_materials.list_options', slug='modular') }}">Modular</a></li>
-              <li><a href="{{ url_for('settings_materials.list_options', slug='ldi') }}">LDI</a></li>
-              <li><a href="{{ url_for('settings_materials.list_options', slug='bulk') }}">Bulk Order</a></li>
-              <li><a href="{{ url_for('settings_materials.list_options', slug='simulation') }}">Simulation</a></li>
-            </ul>
-          </details>
-        </li>
-      {% endif %}
-      {% if current_user and (current_user.is_app_admin or current_user.is_admin or current_user.is_kt_delivery or current_user.is_kt_facilitator or current_user.is_kt_contractor) %}
-        <li><a href="{{ url_for('settings_resources.list_resources') }}">Resources</a></li>
-      {% endif %}
+    <a href="{{ url_for('home') }}">Home</a>
+    <a href="{{ url_for('my_sessions.list_my_sessions') }}">My Sessions</a>
+    {% if current_user.is_app_admin or current_user.is_admin %}
+    <a href="{{ url_for('sessions.list_sessions') }}">Sessions</a>
+    {% endif %}
+    {% if current_user.is_app_admin or current_user.is_admin or current_user.is_kcrm or current_user.is_kt_delivery or current_user.is_kt_contractor %}
+    <a href="{{ url_for('materials_orders.list_orders') }}">Materials</a>
+    {% endif %}
+    <a href="{{ url_for('surveys') }}">Surveys</a>
+    {% if show_resources_nav %}
+    <a href="{{ url_for('learner.my_resources') }}">My Resources</a>
+    {% endif %}
+    <details class="profile">
+      <summary class="nav-link">My Profile</summary>
+      <ul>
         <li><a href="{{ url_for('learner.profile') }}">My Profile</a></li>
-      {% if current_user and (current_user.is_app_admin or current_user.is_admin) %}
-      <li><a href="{{ url_for('users.list_users') }}">Users</a></li>
-      {% if current_user.is_app_admin %}
-      <li><a href="{{ url_for('settings_mail.settings') }}">Mail Settings</a></li>
-      {% endif %}
-      {% endif %}
-    </ul>
-  </details>
-  {% endif %}
-  {% if current_user or session.get('participant_account_id') or is_csa %}
-  <a href="{{ url_for('auth.logout') }}">Logout</a>
+        <li><a href="{{ url_for('learner.my_certs') }}">My Certificates</a></li>
+      </ul>
+    </details>
+    <details class="settings">
+      <summary class="nav-link">Settings</summary>
+      <ul>
+        {% if current_user.is_app_admin or current_user.is_admin %}
+          <li><a href="{{ url_for('clients.list_clients') }}">Clients</a></li>
+          <li><a href="{{ url_for('workshop_types.list_types') }}">Workshop Types</a></li>
+          <li><a href="{{ url_for('settings_languages.list_langs') }}">Languages</a></li>
+          <li>
+            <details>
+              <summary class="nav-link">Material settings</summary>
+              <ul>
+                <li><a href="{{ url_for('settings_materials.list_options', slug='standard') }}">Standard</a></li>
+                <li><a href="{{ url_for('settings_materials.list_options', slug='modular') }}">Modular</a></li>
+                <li><a href="{{ url_for('settings_materials.list_options', slug='ldi') }}">LDI</a></li>
+                <li><a href="{{ url_for('settings_materials.list_options', slug='bulk') }}">Bulk Order</a></li>
+                <li><a href="{{ url_for('settings_materials.list_options', slug='simulation') }}">Simulation</a></li>
+              </ul>
+            </details>
+          </li>
+        {% endif %}
+        {% if current_user.is_app_admin or current_user.is_admin or current_user.is_kt_delivery or current_user.is_kt_facilitator or current_user.is_kt_contractor %}
+          <li><a href="{{ url_for('settings_resources.list_resources') }}">Resources</a></li>
+        {% endif %}
+        {% if current_user.is_app_admin or current_user.is_admin %}
+          <li><a href="{{ url_for('users.list_users') }}">Users</a></li>
+          {% if current_user.is_app_admin %}
+          <li><a href="{{ url_for('settings_mail.settings') }}">Mail Settings</a></li>
+          {% endif %}
+        {% endif %}
+      </ul>
+    </details>
+    <a href="{{ url_for('auth.logout') }}">Logout</a>
+  {% elif session.get('participant_account_id') %}
+    <a href="{{ url_for('home') }}">Home</a>
+    <a href="{{ url_for('my_sessions.list_my_sessions') }}">My Workshops</a>
+    {% if show_resources_nav %}
+    <a href="{{ url_for('learner.my_resources') }}">My Resources</a>
+    {% endif %}
+    <a href="{{ url_for('learner.profile') }}">My Profile</a>
+    <a href="{{ url_for('auth.logout') }}">Logout</a>
   {% else %}
-  <a href="{{ url_for('auth.login') }}">Login</a>
+    <a href="{{ url_for('auth.login') }}">Login</a>
   {% endif %}
 </nav>

--- a/app/templates/prework_magic_error.html
+++ b/app/templates/prework_magic_error.html
@@ -1,0 +1,13 @@
+{% extends "base.html" %}
+{% block title %}Prework Link{% endblock %}
+{% block content %}
+<h1>Prework Link Invalid</h1>
+<p>This link is invalid or has expired.</p>
+{% if is_staff and assignment %}
+<form method="post" action="{{ url_for('auth.prework_magic_resend', assignment_id=assignment.id) }}">
+  <button type="submit">Request a new link</button>
+</form>
+{% else %}
+<p>Please request a new link from your workshop contact.</p>
+{% endif %}
+{% endblock %}


### PR DESCRIPTION
## Summary
- Harden prework magic-link auth with signed tokens, HTTPS links, and clear logs
- Clarify prework email copy and expose passwordless sign‑in
- Rework participant and staff navigation & home cards per spec

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b0920eaad4832e88f9b681f4766d37