### PR TITLE
Normalize participant account emails and reuse existing records

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -144,6 +144,7 @@ Kepner-Tregoe’s Certs & Badges System (CBS) manages workshops (“Sessions”)
 - Pagination on long tables; simple rate-limits on auth endpoints. **[DONE]**
 - Prework autosave endpoint: soft rate limit 10 writes/10s per assignment. **[DONE]**
 - Prework mails log `[ACCOUNT]`, `[MAIL-OUT]`, `[MAIL-FAIL]`; magic links expire after 30 days; accounts are created on send if missing. **[DONE]**
+- Account creation uses normalize→lookup→create with race-safe fallback; emails are stored lowercased.
 - All token timestamps are timezone-aware UTC. **[DONE]**
 - External URLs default to HTTPS (`PREFERRED_URL_SCHEME='https'`); prework emails always use HTTPS links. **[DONE]**
 - Migration 0032_prework_list_questions explicitly creates/drops PostgreSQL enum `prework_question_kind` for reliable upgrades/downgrades. **[DONE]**

--- a/app/utils/accounts.py
+++ b/app/utils/accounts.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from typing import Dict, Optional
+
+from flask import current_app
+from sqlalchemy import func
+from sqlalchemy.exc import IntegrityError
+
+from ..app import db
+from ..models import Participant, ParticipantAccount
+from .strings import normalize_email
+
+
+def get_participant_account_by_email(email: str) -> Optional[ParticipantAccount]:
+    """Return participant account by email (case-insensitive)."""
+    email_norm = normalize_email(email)
+    if not email_norm:
+        return None
+    return ParticipantAccount.query.filter(
+        func.lower(ParticipantAccount.email) == email_norm
+    ).one_or_none()
+
+
+def ensure_participant_account(
+    participant: Participant, cache: Optional[Dict[str, ParticipantAccount]] = None
+) -> ParticipantAccount:
+    """Ensure a ParticipantAccount exists for the given participant."""
+    email_norm = normalize_email(participant.email or "")
+    if cache is not None and email_norm in cache:
+        account = cache[email_norm]
+        participant.account_id = account.id
+        db.session.add(participant)
+        return account
+
+    account = get_participant_account_by_email(email_norm)
+    if account:
+        participant.account_id = account.id
+        db.session.add(participant)
+        current_app.logger.info(
+            f"[ACCOUNT] found pa={account.id} email={email_norm}"
+        )
+        if cache is not None:
+            cache[email_norm] = account
+        return account
+
+    account = ParticipantAccount(
+        email=email_norm,
+        full_name=participant.full_name or participant.email,
+        certificate_name=participant.full_name or participant.email,
+        is_active=True,
+    )
+    db.session.add(account)
+    try:
+        db.session.flush()
+        current_app.logger.info(
+            f"[ACCOUNT] created pa={account.id} email={email_norm}"
+        )
+    except IntegrityError:
+        db.session.rollback()
+        account = get_participant_account_by_email(email_norm)
+        if account:
+            current_app.logger.info(
+                f"[ACCOUNT] reused pa={account.id} email={email_norm}"
+            )
+        else:
+            raise
+    participant.account_id = account.id
+    db.session.add(participant)
+    if cache is not None:
+        cache[email_norm] = account
+    return account

--- a/app/utils/strings.py
+++ b/app/utils/strings.py
@@ -1,0 +1,6 @@
+from __future__ import annotations
+
+
+def normalize_email(s: str) -> str:
+    """Normalize an email by stripping whitespace and lowercasing."""
+    return (s or "").strip().lower()

--- a/tests/test_accounts.py
+++ b/tests/test_accounts.py
@@ -1,0 +1,52 @@
+import pathlib
+import sys
+
+import os
+
+os.environ["DATABASE_URL"] = "sqlite:///:memory:"
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from app.app import create_app, db
+from app.models import Participant, ParticipantAccount
+from app.utils import accounts as acct_utils
+
+
+def test_ensure_account_case_insensitive_reuse():
+    app = create_app()
+    with app.app_context():
+        db.create_all()
+        existing = ParticipantAccount(email="p@example.com", full_name="P")
+        db.session.add(existing)
+        db.session.commit()
+        p = Participant(email="P@Example.com", full_name="P2")
+        db.session.add(p)
+        db.session.commit()
+        acct = acct_utils.ensure_participant_account(p, {})
+        assert acct.id == existing.id
+        assert ParticipantAccount.query.count() == 1
+
+
+def test_ensure_account_integrity_error_fallback(monkeypatch):
+    app = create_app()
+    with app.app_context():
+        db.create_all()
+        existing = ParticipantAccount(email="i@example.com", full_name="I")
+        db.session.add(existing)
+        db.session.commit()
+        p = Participant(email="i@example.com", full_name="I2")
+        db.session.add(p)
+        db.session.commit()
+        orig = acct_utils.get_participant_account_by_email
+        calls = {"n": 0}
+
+        def fake_get(email: str):
+            if calls["n"] == 0:
+                calls["n"] += 1
+                return None
+            return orig(email)
+
+        monkeypatch.setattr(acct_utils, "get_participant_account_by_email", fake_get)
+        acct = acct_utils.ensure_participant_account(p, {})
+        assert acct.id == existing.id
+        assert ParticipantAccount.query.count() == 1

--- a/tests/test_prework.py
+++ b/tests/test_prework.py
@@ -356,3 +356,34 @@ def test_prework_download_route():
         resp = c.get(f"/prework/{assign_id}/download")
         assert resp.status_code == 200
         assert b"window.print" in resp.data
+
+
+def test_staff_send_flows_run(monkeypatch):
+    app = create_app()
+    with app.app_context():
+        db.create_all()
+        user = User(email="staff@example.com", is_app_admin=True)
+        wt = WorkshopType(code="SF", name="SendFlow")
+        db.session.add_all([user, wt])
+        db.session.commit()
+        tpl = PreworkTemplate(workshop_type_id=wt.id, info_html="info")
+        db.session.add(tpl)
+        db.session.flush()
+        db.session.add(PreworkQuestion(template_id=tpl.id, position=1, text="Q", kind="TEXT"))
+        sess = Session(title="S", workshop_type_id=wt.id, start_date=date.today(), daily_start_time=time(8, 0))
+        part = Participant(email="sf@example.com", full_name="SF")
+        db.session.add_all([sess, part])
+        db.session.flush()
+        db.session.add(SessionParticipant(session_id=sess.id, participant_id=part.id))
+        db.session.commit()
+        sess_id = sess.id
+        user_id = user.id
+    with app.test_client() as c:
+        with c.session_transaction() as s:
+            s["user_id"] = user_id
+        monkeypatch.setattr(emailer, "send", lambda *a, **k: {"ok": True})
+        c.post(f"/sessions/{sess_id}/prework", data={"action": "send_all"})
+        c.post(f"/sessions/{sess_id}/prework", data={"action": "send_accounts"})
+    with app.app_context():
+        assert ParticipantAccount.query.count() == 1
+        assert PreworkAssignment.query.count() == 1


### PR DESCRIPTION
## Summary
- normalize and lowercase participant emails
- reuse or create participant accounts with race-safe fallback
- cover account creation edge cases with tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b0aa317c48832e8ee2c9df2ae6e2ad