### PR TITLE
Normalize session times and enforce date validation

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -71,6 +71,7 @@ This matrix is the product source of truth; the `/settings/roles` page mirrors i
 - Client selection keeps Title and displays CRM; Client Session Administrator accepts staff emails. **[DONE]**
 - **Participants** tab: add/edit/remove, CSV import (FullName,Email,Title), lowercased emails, portal link after certs; accounts are created on demand and credentials are emailed. **[DONE]**
 - Saving a session requires **end date > start date**. If the start date is in the past, the form warns in red and requires an explicit “The selected start date is in the past. I’m sure.” checkbox.
+- Session form normalizes time fields to HH:MM; server validation enforces end > start; UI sets end.min = start; past-start requires acknowledgement.
 - **Lifecycle flags & gates** (server-enforced):  
   `materials_ordered`, `ready_for_delivery`, `info_sent`, `delivered`, `finalized`, `on_hold_at`, `cancelled_at`.  
   Gates:

--- a/app/app.py
+++ b/app/app.py
@@ -35,7 +35,7 @@ from .models import resource  # ensures app/models/resource.py is imported
 from .utils.badges import best_badge_url, slug_for_badge
 from .utils.rbac import app_admin_required
 from .constants import LANGUAGE_NAMES
-from .utils.time import fmt_dt
+from .utils.time import fmt_dt, fmt_time
 
 
 def create_app():
@@ -45,6 +45,7 @@ def create_app():
     app.jinja_env.globals["slug_for_badge"] = slug_for_badge
     app.jinja_env.globals["best_badge_url"] = best_badge_url
     app.jinja_env.filters["fmt_dt"] = fmt_dt
+    app.jinja_env.filters["fmt_time"] = fmt_time
 
     DB_USER = os.getenv("DB_USER", "cbs")
     DB_PASSWORD = os.getenv("POSTGRES_PASSWORD", "postgres")

--- a/app/templates/email/prework.html
+++ b/app/templates/email/prework.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html>
 <body>
-<p>Prework for your upcoming workshop "<strong>{{ session.title }}</strong>" ({% if session.workshop_type %}{{ session.workshop_type.name }}{% endif %}) scheduled for {{ session.start_date }} {{ session.daily_start_time.strftime('%H:%M') if session.daily_start_time else '' }} {{ session.timezone or '' }} is ready.</p>
+<p>Prework for your upcoming workshop "<strong>{{ session.title }}</strong>" ({% if session.workshop_type %}{{ session.workshop_type.name }}{% endif %}) scheduled for {{ session.start_date }} {{ session.daily_start_time|fmt_time }} {{ session.timezone or '' }} is ready.</p>
 {% if assignment.due_at %}
 <p>Please complete it by {{ assignment.due_at.date() }}.</p>
 {% endif %}

--- a/app/templates/email/prework.txt
+++ b/app/templates/email/prework.txt
@@ -1,6 +1,6 @@
 Hello,
 
-Prework for your upcoming workshop "{{ session.title }}" ({% if session.workshop_type %}{{ session.workshop_type.name }}{% endif %}) scheduled for {{ session.start_date }} {{ session.daily_start_time.strftime('%H:%M') if session.daily_start_time else '' }} {{ session.timezone or '' }} is ready.
+Prework for your upcoming workshop "{{ session.title }}" ({% if session.workshop_type %}{{ session.workshop_type.name }}{% endif %}) scheduled for {{ session.start_date }} {{ session.daily_start_time|fmt_time }} {{ session.timezone or '' }} is ready.
 
 {% if assignment.due_at %}Please complete it by {{ assignment.due_at.date() }}.{% endif %}
 

--- a/app/templates/home.html
+++ b/app/templates/home.html
@@ -42,7 +42,7 @@
     <td>{{ s.title }}</td>
     <td>{% if s.client %}{{ s.client.name }}{% endif %}</td>
     <td>{% if s.workshop_type %}{{ s.workshop_type.code }} / {{ s.workshop_type.name }}{% endif %}</td>
-    <td>{{ s.start_date }} - {{ s.end_date }} {{ s.daily_start_time.strftime('%H:%M') if s.daily_start_time else '' }}-{{ s.daily_end_time.strftime('%H:%M') if s.daily_end_time else '' }}</td>
+    <td>{{ s.start_date }} - {{ s.end_date }} {{ s.daily_start_time|fmt_time }}-{{ s.daily_end_time|fmt_time }}</td>
     <td>{{ s.region }}</td>
     <td>{{ s.delivery_type }}</td>
     <td>{{ s.status }}</td>

--- a/app/templates/my_sessions.html
+++ b/app/templates/my_sessions.html
@@ -22,7 +22,7 @@
       <td>{% if s.client %}{{ s.client.name }}{% endif %}</td>
       <td>{{ s.location }}</td>
       <td>{% if s.workshop_type %}{{ s.workshop_type.code }} / {{ s.workshop_type.name }}{% endif %}</td>
-      <td>{{ s.start_date }}-{{ s.end_date }}  {{ s.daily_start_time.strftime('%H:%M') if s.daily_start_time else '' }}-{{ s.daily_end_time.strftime('%H:%M') if s.daily_end_time else '' }}</td>
+      <td>{{ s.start_date }}-{{ s.end_date }}  {{ s.daily_start_time|fmt_time }}-{{ s.daily_end_time|fmt_time }}</td>
       <td>{{ s.region }}</td>
       <td>{{ s.delivery_type }}</td>
       <td>{{ s.computed_status }}</td>

--- a/app/templates/session_detail.html
+++ b/app/templates/session_detail.html
@@ -3,8 +3,6 @@
 {% block content %}
 <h1>{{ session.title }}</h1>
 {% if session.cancelled %}<div class="banner">Session cancelled.</div>{% endif %}
-{% set start_time = session.daily_start_time.strftime('%H:%M') if session.daily_start_time else '' %}
-{% set end_time = session.daily_end_time.strftime('%H:%M') if session.daily_end_time else '' %}
 {% if csa_view %}
 <div>
   Title: {{ session.title }}<br>
@@ -14,7 +12,7 @@
   {% if session.lead_facilitator %}{% set _ = facs.append(session.lead_facilitator) %}{% endif %}
   {% for fac in session.facilitators %}{% set _ = facs.append(fac) %}{% endfor %}
   {% for u in facs %}{{ u.full_name or u.email }} ({{ u.email }}){% if not loop.last %}, {% endif %}{% endfor %}<br>
-  Dates: {{ session.start_date }} – {{ session.end_date }} {{ start_time }}–{{ end_time }}<br>
+  Dates: {{ session.start_date }} – {{ session.end_date }} {{ session.daily_start_time|fmt_time }}–{{ session.daily_end_time|fmt_time }}<br>
   Timezone: {{ session.timezone }}<br>
   Language: {{ session.language }}<br>
   Delivery Type: {{ session.delivery_type }}<br>
@@ -32,7 +30,7 @@
 {% else %}
 <div>
   Workshop Type: {% if session.workshop_type %}{{ session.workshop_type.code }} - {{ session.workshop_type.name }}{% endif %}<br>
-  Dates: {{ session.start_date }} – {{ session.end_date }} {{ start_time }}–{{ end_time }}<br>
+  Dates: {{ session.start_date }} – {{ session.end_date }} {{ session.daily_start_time|fmt_time }}–{{ session.daily_end_time|fmt_time }}<br>
   Region: {{ session.region }}<br>
   Delivery Type: {{ session.delivery_type }}<br>
   Workshop Location: {{ session.workshop_location.label if session.workshop_location else '' }}<br>

--- a/app/templates/sessions/form.html
+++ b/app/templates/sessions/form.html
@@ -67,15 +67,13 @@
     </label></div>
     <div><label>Simulation Outline<br><textarea name="simulation_outline">{{ session.simulation_outline or '' }}</textarea></label></div>
     <div><label>Capacity* <input type="number" name="capacity" value="{{ session.capacity or 16 }}" required></label></div>
-    <div><label>Start Date* <input type="date" name="start_date" value="{{ session.start_date or '' }}" required></label></div>
-    <div><label>End Date* <input type="date" name="end_date" value="{{ session.end_date or '' }}" required></label></div>
+    <div><label>Start Date* <input type="date" id="start-date" name="start_date" value="{{ session.start_date or '' }}" required></label></div>
+    <div><label>End Date* <input type="date" id="end-date" name="end_date" value="{{ session.end_date or '' }}" min="{{ session.start_date or '' }}" required></label></div>
     {% if past_warning %}
     <div style="color:red;"><label><input type="checkbox" name="ack_past" value="true" required> The selected start date is in the past. I'm sure.</label></div>
     {% endif %}
-    {% set st = session.daily_start_time.strftime('%H:%M') if session.daily_start_time else '' %}
-    {% set et = session.daily_end_time.strftime('%H:%M') if session.daily_end_time else '' %}
-    <div><label>Daily Start Time <input type="time" name="daily_start_time" value="{{ st or '08:00' }}"></label></div>
-    <div><label>Daily End Time <input type="time" name="daily_end_time" value="{{ et or '17:00' }}"></label></div>
+    <div><label>Daily Start Time <input type="time" name="daily_start_time" value="{{ daily_start_time_str or '08:00' }}"></label></div>
+    <div><label>Daily End Time <input type="time" name="daily_end_time" value="{{ daily_end_time_str or '17:00' }}"></label></div>
     <div><label>Timezone
       <select name="timezone">
         <option value="">--Select--</option>
@@ -143,6 +141,15 @@
   {% endif %}
 </form>
 <script>
+  var startField = document.getElementById('start-date');
+  var endField = document.getElementById('end-date');
+  function syncEndMin(){
+    if(endField && startField){ endField.min = startField.value; }
+  }
+  if(startField && endField){
+    syncEndMin();
+    startField.addEventListener('change', syncEndMin);
+  }
   var delivered = document.querySelector('input[name="delivered"]');
   var ready = document.querySelector('input[name="ready_for_delivery"]');
   var finalized = document.querySelector('input[name="finalized"]');

--- a/app/utils/time.py
+++ b/app/utils/time.py
@@ -1,4 +1,4 @@
-from datetime import datetime, date, timezone
+from datetime import datetime, date, time, timezone
 
 
 def now_utc() -> datetime:
@@ -15,3 +15,15 @@ def fmt_dt(value: datetime | date | None) -> str:
     if isinstance(value, date):
         return value.strftime("%-d %b %Y")
     return str(value)
+
+
+def fmt_time(value: time | str | None) -> str:
+    """Render times as HH:MM, accepting strings or time objects."""
+    if not value:
+        return ""
+    if isinstance(value, str):
+        try:
+            value = time.fromisoformat(value)
+        except ValueError:
+            return value
+    return value.strftime("%H:%M")

--- a/tests/test_session_date_rules.py
+++ b/tests/test_session_date_rules.py
@@ -1,0 +1,100 @@
+import os
+from datetime import date, time
+
+import pytest
+
+from app.app import create_app, db
+from app.models import User, Client, WorkshopType, Session
+
+
+@pytest.fixture
+def app():
+    os.environ["DATABASE_URL"] = "sqlite:///:memory:"
+    os.makedirs("/srv", exist_ok=True)
+    app = create_app()
+    with app.app_context():
+        db.create_all()
+        yield app
+        db.session.remove()
+
+
+def _setup(app):
+    with app.app_context():
+        admin = User(email="admin@example.com", is_app_admin=True, is_admin=True)
+        admin.set_password("x")
+        wt = WorkshopType(code="WT", name="WT")
+        client = Client(name="ClientA", status="active")
+        db.session.add_all([admin, wt, client])
+        db.session.commit()
+        return admin.id, wt.id, client.id
+
+
+def _login(client, admin_id):
+    with client.session_transaction() as sess_tx:
+        sess_tx["user_id"] = admin_id
+
+
+def _base_form(client_id, wt_id):
+    return {
+        "title": "S1",
+        "client_id": str(client_id),
+        "region": "NA",
+        "workshop_type_id": str(wt_id),
+        "delivery_type": "Onsite",
+        "language": "English",
+        "capacity": "16",
+        "daily_start_time": "09:00",
+        "daily_end_time": "17:00",
+    }
+
+
+def test_end_date_rule(app):
+    admin_id, wt_id, client_id = _setup(app)
+    client = app.test_client()
+    _login(client, admin_id)
+    form = _base_form(client_id, wt_id)
+    form.update({"start_date": "2100-01-02", "end_date": "2100-01-02"})
+    resp = client.post("/sessions/new", data=form)
+    assert resp.status_code == 400
+    assert b"End date must be after start date" in resp.data
+    with app.app_context():
+        assert Session.query.count() == 0
+    form["end_date"] = "2100-01-03"
+    resp = client.post("/sessions/new", data=form, follow_redirects=False)
+    assert resp.status_code == 302
+    with app.app_context():
+        sess = Session.query.one()
+        assert sess.end_date == date(2100, 1, 3)
+        assert isinstance(sess.daily_start_time, time)
+
+
+def test_past_start_requires_ack(app):
+    admin_id, wt_id, client_id = _setup(app)
+    client = app.test_client()
+    _login(client, admin_id)
+    form = _base_form(client_id, wt_id)
+    form.update({"start_date": "2000-01-01", "end_date": "2000-01-02"})
+    resp = client.post("/sessions/new", data=form)
+    assert resp.status_code == 400
+    assert b"The selected start date is in the past" in resp.data
+    form["ack_past"] = "true"
+    resp = client.post("/sessions/new", data=form, follow_redirects=False)
+    assert resp.status_code == 302
+
+
+def test_times_preserved_on_error(app):
+    admin_id, wt_id, client_id = _setup(app)
+    client = app.test_client()
+    _login(client, admin_id)
+    form = _base_form(client_id, wt_id)
+    form.update({
+        "start_date": "2100-01-01",
+        "end_date": "2100-01-01",
+        "daily_start_time": "09:30",
+        "daily_end_time": "17:15",
+    })
+    resp = client.post("/sessions/new", data=form)
+    assert resp.status_code == 400
+    assert b'value="09:30"' in resp.data
+    assert b'value="17:15"' in resp.data
+


### PR DESCRIPTION
## Summary
- Parse session time fields into time objects and normalize display via new `fmt_time` filter
- Prevent invalid session dates and past starts without acknowledgement; keep form values on errors
- Harden session form and docs; add tests for date and time validation

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b0b5848198832e80cfe65a105418ac