### PR TITLE
Restore CSA sessions menu and add learner workshops list

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -72,7 +72,7 @@ This matrix is the product source of truth; the `/settings/roles` page mirrors i
 - **Participants** tab: add/edit/remove, CSV import (FullName,Email,Title), lowercased emails, portal link after certs; accounts are created on demand and credentials are emailed. **[DONE]**
 - Saving a session requires **end date ≥ start date** (single-day allowed). If the start date is in the past, the form warns in red and requires an explicit “The selected start date is in the past. I’m sure.” checkbox.
 - Session form normalizes time fields to HH:MM; server validation enforces end > start; UI sets end.min = start; past-start requires acknowledgement.
-- **Lifecycle flags & gates** (server-enforced):  
+- **Lifecycle flags & gates** (server-enforced):
   `materials_ordered`, `ready_for_delivery`, `info_sent`, `delivered`, `finalized`, `on_hold_at`, `cancelled_at`.  
   Gates:
   - Ready requires **participants > 0**.  
@@ -85,6 +85,7 @@ This matrix is the product source of truth; the `/settings/roles` page mirrors i
 - **Prework**: session page `/sessions/<id>/prework` lists participants and lets staff send prework assignments when the workshop type has a template. List-style questions snapshot kind/min/max and show a download link for staff. **[DONE]**
 - Session-level `no_prework` toggle disables "Send Prework" and marks assignment rows **WAIVED**; page also offers **Send Accounts without Prework** to email portal links only. Logs `[SESS] no_prework=<true|false> session=<id>` and `[MAIL-OUT] account-invite …`. **[DONE]**
 - Prework send creates missing participant accounts on-the-fly (`[ACCOUNT]` logs), generates magic-link emails per participant, and logs `[MAIL-OUT]`/`[MAIL-FAIL]`. A session-level `no_material_order` flag is set via the New Session form. Sending prework does not gate certificates. **[DONE]**
+- Learner “My Workshops” list shows a **Prework** action for each enrolled session, linking directly to that participant’s prework page (or “No prework” when none). **[2025-09-04]**
 - Magic links are single-use passwordless sign-ins. They compare `SHA256(token + SECRET_KEY)` against `magic_token_hash`, expire via `magic_token_expires`, and log `[AUTH]` or `[AUTH-FAIL]` outcomes. **[DONE]**
 - Staff can access Prework via a "Prework" button on the Workshop Type edit page and on Session list/detail pages. **[DONE]**
 - On New Session, there are two actions: **Proceed to materials order** and **No Materials Order (Save)** — the latter sets the flag and returns to the Session detail view. The Prework page does not show materials controls. **[DONE]**
@@ -232,6 +233,12 @@ This matrix is the product source of truth; the `/settings/roles` page mirrors i
 - **Delivery** – “My Workshops,” Resources, and Prework quick links; learner links visible (useful for support).
 - **Learner** – Learner home (My Prework • My Workshops • My Certificates); all staff pages hidden.
 
+**Navigation defaults (2025-09-04):**
+- Participants land on **My Workshops** after login.
+- CSAs land on **My Sessions** and also have a **My Workshops** menu entry.
+- Participants (non-CSA) menu: Home • My Workshops • My Profile • Logout.
+- CSA menu: Home • My Sessions • My Workshops • My Profile • Logout.
+
 **Default View by Role**
 - `App_Admin` → **Admin**
 - `is_kt_admin` → **Admin**
@@ -290,7 +297,7 @@ Legend: **V**=View, **C**=Create, **E**=Edit, **D**=Delete, **A**=Action (send/g
 - **Participants:** **A** add/remove participants until the session start time; view roster.
 - **No prework, materials, certificates, workshop-type, users, or settings access.**
 - **No session field edits** beyond participant management.
-- Landing page lists assigned sessions ("My Workshops" menu entry); CSAs do not have a view switcher.
+- Landing page lists assigned sessions (**My Sessions**); CSA menu also includes **My Workshops**. CSAs do not have a view switcher.
 
 **CSA Email/Logs**
 - When CSA is assigned or changed, the system sends a “CSA assigned” email to the user and logs `[MAIL-OUT] csa-assign session=<id> user=<id> to=<email> result=sent]`. Re-sending occurs only when the assignment changes.

--- a/app/app.py
+++ b/app/app.py
@@ -174,9 +174,9 @@ def create_app():
                 .first()
                 is not None
             )
-            if is_csa and get_active_view(None, request, True) == "CSA":
+            if is_csa:
                 return redirect(url_for("csa.my_sessions"))
-            return render_template("home.html")
+            return redirect(url_for("learner.my_workshops"))
         return redirect(url_for("auth.login"))
 
     def login_required(fn):

--- a/app/templates/my_workshops.html
+++ b/app/templates/my_workshops.html
@@ -1,0 +1,27 @@
+{% extends 'base.html' %}
+{% block title %}My Workshops{% endblock %}
+{% block content %}
+<h1>My Workshops</h1>
+{% if sessions %}
+<table border="1" cellpadding="4" cellspacing="0">
+  <tr><th>Dates</th><th>Client</th><th>Title</th><th>Action</th></tr>
+  {% for s in sessions %}
+  <tr>
+    <td>{{ s.start_date }} - {{ s.end_date }}</td>
+    <td>{{ s.client.name if s.client else '' }}</td>
+    <td>{{ s.title }}</td>
+    <td>
+      {% set assignment = assignments.get(s.id) if assignments else None %}
+      {% if assignment and assignment.status != 'WAIVED' %}
+        <a href="{{ url_for('learner.prework_form', assignment_id=assignment.id) }}">Prework</a>
+      {% else %}
+        <span class="muted">No prework</span>
+      {% endif %}
+    </td>
+  </tr>
+  {% endfor %}
+</table>
+{% else %}
+<p>No workshops found.</p>
+{% endif %}
+{% endblock %}

--- a/app/utils/nav.py
+++ b/app/utils/nav.py
@@ -50,9 +50,11 @@ def _staff_base_menu(user, show_resources: bool) -> List[MenuItem]:
 def _participant_menu(show_resources: bool, is_csa: bool) -> List[MenuItem]:
     items: List[MenuItem] = []
     items.append({'id': 'home', 'label': 'Home', 'endpoint': 'home'})
-    label = 'My Workshops'
-    endpoint = 'csa.my_sessions' if is_csa else 'my_sessions.list_my_sessions'
-    items.append({'id': 'my_sessions', 'label': label, 'endpoint': endpoint})
+    if is_csa:
+        items.append({'id': 'my_sessions', 'label': 'My Sessions', 'endpoint': 'csa.my_sessions'})
+        items.append({'id': 'my_workshops', 'label': 'My Workshops', 'endpoint': 'learner.my_workshops'})
+    else:
+        items.append({'id': 'my_workshops', 'label': 'My Workshops', 'endpoint': 'learner.my_workshops'})
     if show_resources:
         items.append({'id': 'my_resources', 'label': 'My Resources', 'endpoint': 'learner.my_resources'})
     items.append({'id': 'profile', 'label': 'My Profile', 'endpoint': 'learner.profile'})
@@ -65,8 +67,8 @@ VIEW_FILTERS = {
     'SESSION_MANAGER': {'home', 'my_sessions', 'sessions', 'surveys', 'my_resources', 'profile', 'logout'},
     'MATERIALS': {'home', 'my_sessions', 'materials', 'surveys', 'my_resources', 'profile', 'settings', 'logout'},
     'DELIVERY': {'home', 'my_sessions', 'surveys', 'my_resources', 'profile', 'logout'},
-    'LEARNER': {'home', 'my_sessions', 'my_resources', 'profile', 'logout'},
-    'CSA': {'home', 'my_sessions', 'my_resources', 'profile', 'logout'},
+    'LEARNER': {'home', 'my_workshops', 'my_resources', 'profile', 'logout'},
+    'CSA': {'home', 'my_sessions', 'my_workshops', 'my_resources', 'profile', 'logout'},
 }
 
 

--- a/tests/test_csa_home.py
+++ b/tests/test_csa_home.py
@@ -50,7 +50,7 @@ def test_csa_my_sessions_page(app):
     assert b"My Sessions" in resp.data
     assert f"/sessions/{sess_id}".encode() in resp.data
     assert b'href="/csa/my-sessions"' in resp.data
-    assert b'My Workshops' in resp.data
+    assert b'href="/my-workshops"' in resp.data
     assert b'action="/settings/view"' not in resp.data
 
 
@@ -58,7 +58,7 @@ def test_csa_home_redirect(app):
     csa_id, part_id, sess_id = _setup(app)
     client = app.test_client()
     _login(client, csa_id)
-    resp = client.get("/home")
+    resp = client.get("/")
     assert resp.status_code == 302
     assert "/csa/my-sessions" in resp.headers["Location"]
 
@@ -67,5 +67,5 @@ def test_participant_no_view_switcher(app):
     csa_id, part_id, sess_id = _setup(app)
     client = app.test_client()
     _login(client, part_id)
-    resp = client.get("/home")
+    resp = client.get("/my-workshops")
     assert b'action="/settings/view"' not in resp.data

--- a/tests/test_learner_list.py
+++ b/tests/test_learner_list.py
@@ -1,0 +1,76 @@
+import os
+from datetime import date, time
+
+import pytest
+
+from app.app import create_app, db
+from app.models import (
+    WorkshopType,
+    PreworkTemplate,
+    PreworkQuestion,
+    Session,
+    ParticipantAccount,
+    Participant,
+    SessionParticipant,
+    PreworkAssignment,
+)
+
+
+@pytest.fixture
+def app():
+    os.environ["DATABASE_URL"] = "sqlite:///:memory:"
+    os.makedirs("/srv", exist_ok=True)
+    app = create_app()
+    with app.app_context():
+        db.create_all()
+        yield app
+        db.session.remove()
+
+
+def _setup(app):
+    with app.app_context():
+        wt = WorkshopType(code="WT", name="WT")
+        db.session.add(wt)
+        db.session.flush()
+        tpl = PreworkTemplate(workshop_type_id=wt.id, info_html="info")
+        db.session.add(tpl)
+        db.session.flush()
+        db.session.add(PreworkQuestion(template_id=tpl.id, position=1, text="Q1", kind="TEXT"))
+        acct = ParticipantAccount(email="csa@example.com", full_name="CSA", is_active=True)
+        part = Participant(email="csa@example.com", full_name="CSA", account=acct)
+        sess = Session(
+            title="S",
+            workshop_type=wt,
+            start_date=date.today(),
+            end_date=date.today(),
+            daily_start_time=time(9, 0),
+            timezone="UTC",
+        )
+        db.session.add_all([acct, part, sess])
+        db.session.flush()
+        db.session.add(SessionParticipant(session_id=sess.id, participant_id=part.id))
+        assign = PreworkAssignment(
+            session_id=sess.id,
+            participant_account_id=acct.id,
+            template_id=tpl.id,
+            status="SENT",
+            snapshot_json={"questions": [], "resources": []},
+        )
+        db.session.add(assign)
+        db.session.commit()
+        return acct.id, assign.id
+
+
+def _login(client, account_id):
+    with client.session_transaction() as sess:
+        sess["participant_account_id"] = account_id
+
+
+def test_my_workshops_prework_action(app):
+    account_id, assign_id = _setup(app)
+    client = app.test_client()
+    _login(client, account_id)
+    resp = client.get("/my-workshops")
+    assert f"/prework/{assign_id}".encode() in resp.data
+    resp2 = client.get(f"/prework/{assign_id}")
+    assert resp2.status_code == 200

--- a/tests/test_login.py
+++ b/tests/test_login.py
@@ -46,7 +46,7 @@ def test_participant_login(app):
         db.session.commit()
     client = app.test_client()
     resp = client.post("/login", data={"email": "learner@example.com", "password": "pw"}, follow_redirects=True)
-    assert resp.request.path == "/my-certificates"
+    assert resp.request.path == "/my-workshops"
 
 
 def test_unknown_email(app):

--- a/tests/test_nav_participant.py
+++ b/tests/test_nav_participant.py
@@ -1,0 +1,52 @@
+import os
+from datetime import date, time
+
+import pytest
+
+from app.app import create_app, db
+from app.models import WorkshopType, Session, ParticipantAccount
+
+
+@pytest.fixture
+def app():
+    os.environ["DATABASE_URL"] = "sqlite:///:memory:"
+    os.makedirs("/srv", exist_ok=True)
+    app = create_app()
+    with app.app_context():
+        db.create_all()
+        yield app
+        db.session.remove()
+
+
+def _setup(app):
+    with app.app_context():
+        wt = WorkshopType(code="WT", name="WT")
+        acc = ParticipantAccount(email="p@example.com", full_name="P", is_active=True)
+        sess = Session(
+            title="S",
+            workshop_type=wt,
+            start_date=date.today(),
+            end_date=date.today(),
+            daily_start_time=time(9, 0),
+            timezone="UTC",
+        )
+        db.session.add_all([wt, acc, sess])
+        db.session.commit()
+        return acc.id
+
+
+def _login(client, account_id):
+    with client.session_transaction() as sess:
+        sess["participant_account_id"] = account_id
+
+
+def test_participant_nav_simple(app):
+    acc_id = _setup(app)
+    client = app.test_client()
+    _login(client, acc_id)
+    resp = client.get("/my-workshops")
+    assert b"Home" in resp.data
+    assert b"My Workshops" in resp.data
+    assert b"My Sessions" not in resp.data
+    assert b"My Profile" in resp.data
+    assert b"Logout" in resp.data

--- a/tests/test_passwords.py
+++ b/tests/test_passwords.py
@@ -69,7 +69,7 @@ def test_manual_participant_create_login(app):
         data={"email": "learner@example.com", "password": temp_pw},
         follow_redirects=True,
     )
-    assert resp.request.path == "/my-certificates"
+    assert resp.request.path == "/my-workshops"
 
 
 def test_provision_sets_default_password(app):

--- a/tests/test_prework.py
+++ b/tests/test_prework.py
@@ -192,8 +192,8 @@ def test_nav_gating_prework():
     with app.test_client() as c:
         with c.session_transaction() as sess_data:
             sess_data["participant_account_id"] = account_id
-        resp = c.get("/home", follow_redirects=True)
-        assert b"My Prework" in resp.data
+        resp = c.get("/my-workshops")
+        assert b"Prework" in resp.data
         assert b"My Resources" not in resp.data
 
 

--- a/tests/test_view_switcher.py
+++ b/tests/test_view_switcher.py
@@ -74,9 +74,9 @@ def test_participant_forced_learner_view(app):
     client = app.test_client()
     client.set_cookie('active_view', 'ADMIN', domain='localhost')
     login(client, 'learner@example.com', 'pw')
-    resp = client.get('/home')
+    resp = client.get('/home', follow_redirects=True)
+    assert resp.request.path == '/my-workshops'
     assert b'Admin Dashboard' not in resp.data
-    assert b'Welcome,' in resp.data
 
 
 def test_staff_view_switcher_shows_session_admin_option(app):


### PR DESCRIPTION
## Summary
- Add "My Workshops" list for learners with Prework actions
- Show both "My Sessions" and "My Workshops" in CSA navigation
- Redirect participants to My Workshops and CSAs to My Sessions after login
- Document dual-menu behavior and Prework action in CONTEXT

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b9c80d5f28832e80d4d93fcfee581c