### PR TITLE
Create enum types in migration 0039 for materials fields

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -189,6 +189,7 @@ This matrix is the product source of truth; the `/settings/roles` page mirrors i
 - External URLs default to HTTPS (`PREFERRED_URL_SCHEME='https'`); prework emails always use HTTPS links. **[DONE]**
 - Migration 0032_prework_list_questions explicitly creates/drops PostgreSQL enum `prework_question_kind` for reliable upgrades/downgrades. **[DONE]**
 - Migration 0037_preferred_view adds `users.preferred_view` to support UI Views. **[DONE]**
+- Migration 0039_materials_enhancements explicitly creates/drops PostgreSQL enum `materials_format` for reliable upgrades/downgrades. **[DONE]**
 
 ---
 

--- a/migrations/versions/0039_materials_enhancements.py
+++ b/migrations/versions/0039_materials_enhancements.py
@@ -2,6 +2,7 @@
 
 from alembic import op
 import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql as pg
 
 
 revision = '0039_materials_enhancements'
@@ -13,9 +14,11 @@ FORMATS = ('PHYSICAL', 'DIGITAL', 'MIXED', 'SIM_ONLY')
 
 
 def upgrade() -> None:
+    fmt_enum = pg.ENUM(*FORMATS, name='materials_format')
+    fmt_enum.create(op.get_bind(), checkfirst=True)
     op.add_column(
         'session_shipping',
-        sa.Column('materials_format', sa.Enum(*FORMATS, name='materials_format'), nullable=True),
+        sa.Column('materials_format', fmt_enum, nullable=True),
     )
     op.add_column(
         'session_shipping',
@@ -30,4 +33,7 @@ def downgrade() -> None:
     op.drop_column('session_shipping', 'materials_po_number')
     op.drop_column('session_shipping', 'materials_components')
     op.drop_column('session_shipping', 'materials_format')
-    sa.Enum(name='materials_format').drop(op.get_bind(), checkfirst=False)
+    comp_enum = pg.ENUM(name='materials_components')
+    fmt_enum = pg.ENUM(name='materials_format')
+    comp_enum.drop(op.get_bind(), checkfirst=True)
+    fmt_enum.drop(op.get_bind(), checkfirst=True)


### PR DESCRIPTION
## Summary
- explicitly create/drop PostgreSQL `materials_format` enum in migration 0039
- document enum creation in CONTEXT

## Testing
- `python manage.py db upgrade` *(fails: could not translate host name "db" to address)*
- `DATABASE_URL=sqlite:// pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b9de48c740832ea2fa03c0eb241c83