### PR TITLE
Ensure Language and Delivery type shown on new sessions form

### DIFF
--- a/app/templates/sessions/form.html
+++ b/app/templates/sessions/form.html
@@ -58,7 +58,8 @@
             {{ o.number }} — {{ o.skill }} — {{ o.descriptor }} ({{ o.level }})
           </option>
         {% endfor %}
-      </select></label><div>
+      </select></label></div>
+    {% endif %}
     <div><label>Delivery Type*
       <select name="delivery_type" required>
         <option value="">--Select--</option>
@@ -77,7 +78,6 @@
         {% endif %}
       </select>
     </label></div>
-    {% endif %}
     <div><label>Capacity* <input type="number" name="capacity" value="{{ session.capacity or 16 }}" required></label></div>
     <div><label>Start Date* <input type="date" id="start-date" name="start_date" value="{{ session.start_date or '' }}" required></label>  
     <label>End Date* <input type="date" id="end-date" name="end_date" value="{{ session.end_date or '' }}" min="{{ session.start_date or '' }}" required></label><small>End date must be the same day or after the start date.</small></div>

--- a/tests/test_new_session_required.py
+++ b/tests/test_new_session_required.py
@@ -1,5 +1,4 @@
 import os
-from datetime import date
 import pytest
 
 from app.app import create_app, db
@@ -73,3 +72,14 @@ def test_new_session_requires_fields(app):
     assert "/sessions/" in resp.headers["Location"]
     with app.app_context():
         assert Session.query.count() == 1
+
+
+def test_new_session_form_shows_language_and_delivery(app):
+    admin_id, _, _ = _setup(app)
+    client = app.test_client()
+    with client.session_transaction() as sess_tx:
+        sess_tx["user_id"] = admin_id
+    resp = client.get("/sessions/new")
+    assert resp.status_code == 200
+    assert b"Delivery Type" in resp.data
+    assert b"Language" in resp.data


### PR DESCRIPTION
## Summary
- Always render Delivery Type and Language fields in new session form
- Cover form fields with regression test

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bb1caabff0832eb5e9e198b6b8900e