### PR TITLE
Add certificate template selection and workshop short codes

### DIFF
--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -147,6 +147,7 @@ class WorkshopType(db.Model):
 
     id = db.Column(db.Integer, primary_key=True)
     code = db.Column(db.String(16), nullable=False)
+    short_code = db.Column(db.String(16), nullable=False)
     name = db.Column(db.String(255), nullable=False)
     status = db.Column(db.String(16), default="active")
     description = db.Column(db.Text)
@@ -157,6 +158,11 @@ class WorkshopType(db.Model):
     created_at = db.Column(db.DateTime, server_default=db.func.now())
     __table_args__ = (
         db.Index("uix_workshop_types_code_upper", db.func.upper(code), unique=True),
+        db.Index(
+            "uix_workshop_types_short_code_upper",
+            db.func.upper(short_code),
+            unique=True,
+        ),
     )
 
     resources = db.relationship(
@@ -167,6 +173,10 @@ class WorkshopType(db.Model):
 
     @validates("code")
     def upper_code(self, key, value):  # pragma: no cover - simple normalizer
+        return (value or "").upper()
+
+    @validates("short_code")
+    def upper_short_code(self, key, value):  # pragma: no cover - simple normalizer
         return (value or "").upper()
 
 
@@ -279,6 +289,18 @@ class Session(db.Model):
     delivery_type = db.Column(db.String(32))
     region = db.Column(db.String(8))
     language = db.Column(db.String(16))
+    paper_size = db.Column(
+        db.Enum("A4", "LETTER", name="paper_size"),
+        nullable=False,
+        default="A4",
+        server_default="A4",
+    )
+    workshop_language = db.Column(
+        db.Enum("en", "es", "fr", "ja", "de", "nl", name="workshop_language"),
+        nullable=False,
+        default="en",
+        server_default="en",
+    )
     capacity = db.Column(db.Integer)
     status = db.Column(
         db.String(16), nullable=False, default="New", server_default="New"

--- a/app/routes/workshop_types.py
+++ b/app/routes/workshop_types.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 from flask import Blueprint, abort, flash, redirect, render_template, request, url_for
 
 from ..app import db, User
@@ -45,14 +46,22 @@ def new_type(current_user):
 def create_type(current_user):
     code = (request.form.get('code') or '').strip().upper()
     name = (request.form.get('name') or '').strip()
-    if not code or not name:
-        flash('Code and Name required', 'error')
+    short_code = (request.form.get('short_code') or '').strip().upper()
+    if not code or not name or not short_code:
+        flash('Code, Name, and Short Code required', 'error')
         return redirect(url_for('workshop_types.new_type'))
     if WorkshopType.query.filter(db.func.upper(WorkshopType.code) == code).first():
         flash('Code already exists', 'error')
         return redirect(url_for('workshop_types.new_type'))
+    if not re.fullmatch(r'[A-Z0-9-]{2,16}', short_code):
+        flash('Invalid Short Code', 'error')
+        return redirect(url_for('workshop_types.new_type'))
+    if WorkshopType.query.filter(db.func.upper(WorkshopType.short_code) == short_code).first():
+        flash('Short Code already exists', 'error')
+        return redirect(url_for('workshop_types.new_type'))
     wt = WorkshopType(
         code=code,
+        short_code=short_code,
         name=name,
         status=request.form.get('status') or 'active',
         description=request.form.get('description') or None,
@@ -88,6 +97,16 @@ def update_type(type_id: int, current_user):
     wt = db.session.get(WorkshopType, type_id)
     if not wt:
         abort(404)
+    short_code = (request.form.get('short_code') or wt.short_code or '').strip().upper()
+    if not re.fullmatch(r'[A-Z0-9-]{2,16}', short_code):
+        flash('Invalid Short Code', 'error')
+        return redirect(url_for('workshop_types.edit_type', type_id=type_id))
+    if (
+        WorkshopType.query.filter(db.func.upper(WorkshopType.short_code) == short_code, WorkshopType.id != type_id).first()
+    ):
+        flash('Short Code already exists', 'error')
+        return redirect(url_for('workshop_types.edit_type', type_id=type_id))
+    wt.short_code = short_code
     wt.name = request.form.get('name') or wt.name
     wt.status = request.form.get('status') or wt.status
     wt.description = request.form.get('description') or None

--- a/app/templates/sessions/form.html
+++ b/app/templates/sessions/form.html
@@ -78,6 +78,20 @@
         {% endif %}
       </select>
     </label></div>
+    <div><label>Paper size*
+      <select name="paper_size" required>
+        {% for opt in paper_sizes %}
+        <option value="{{ opt }}" {% if session.paper_size==opt %}selected{% endif %}>{{ opt }}</option>
+        {% endfor %}
+      </select>
+    </label></div>
+    <div><label>Workshop language*
+      <select name="workshop_language" required>
+        {% for code,label in workshop_languages %}
+        <option value="{{ code }}" {% if session.workshop_language==code %}selected{% endif %}>{{ label }}</option>
+        {% endfor %}
+      </select>
+    </label></div>
     <div><label>Capacity* <input type="number" name="capacity" value="{{ session.capacity or 16 }}" required></label></div>
     <div><label>Start Date* <input type="date" id="start-date" name="start_date" value="{{ session.start_date or '' }}" required></label>  
     <label>End Date* <input type="date" id="end-date" name="end_date" value="{{ session.end_date or '' }}" min="{{ session.start_date or '' }}" required></label><small>End date must be the same day or after the start date.</small></div>

--- a/app/templates/workshop_types/form.html
+++ b/app/templates/workshop_types/form.html
@@ -14,6 +14,7 @@
   <div><label>Code <input type="text" name="code" value="{{ wt.code }}" readonly></label></div>
   {% endif %}
   <div><label>Name <input type="text" name="name" value="{{ wt.name if wt else '' }}" required></label></div>
+  <div><label>Short Code <input type="text" name="short_code" value="{{ wt.short_code if wt else '' }}" maxlength="16" pattern="[A-Za-z0-9-]{2,16}" required></label><small>2–16 chars; A–Z, 0–9, dash.</small></div>
   <div><label>Status <input type="text" name="status" value="{{ wt.status if wt else 'active' }}"></label></div>
   <div><label>Badge
     <select name="badge">

--- a/manage.py
+++ b/manage.py
@@ -1,6 +1,10 @@
 from app.app import create_app, db
 from flask_migrate import Migrate
 from flask.cli import FlaskGroup
+import click
+from sqlalchemy import func
+from app.utils.certificates import render_certificate
+from app.models import Session, ParticipantAccount
 
 
 migrate = Migrate()
@@ -13,6 +17,24 @@ def create_cbs_app():
 
 
 cli = FlaskGroup(create_app=create_cbs_app)
+
+
+@cli.command("gen_cert")
+@click.option("--session", "session_id", required=True, type=int)
+@click.option("--email", "email", required=True)
+def gen_cert(session_id: int, email: str):
+    """Generate a certificate for a participant."""
+    sess = db.session.get(Session, session_id)
+    acct = (
+        db.session.query(ParticipantAccount)
+        .filter(func.lower(ParticipantAccount.email) == email.lower())
+        .one_or_none()
+    )
+    if not sess or not acct:
+        click.echo("Not found", err=True)
+        return
+    path = render_certificate(sess, acct)
+    click.echo(path)
 
 
 if __name__ == "__main__":

--- a/migrations/versions/0042_certificate_fields.py
+++ b/migrations/versions/0042_certificate_fields.py
@@ -1,0 +1,74 @@
+"""add certificate fields and workshop short code
+
+Revision ID: 0042_certificate_fields
+Revises: 0041_rename_materials_format_values
+Create Date: 2025-??-??
+"""
+
+from alembic import op
+import sqlalchemy as sa
+import re
+
+revision = "0042_certificate_fields"
+down_revision = "0041_rename_materials_format_values"
+branch_labels = None
+depends_on = None
+
+
+PAPER_ENUM = sa.Enum("A4", "LETTER", name="paper_size")
+LANG_ENUM = sa.Enum("en", "es", "fr", "ja", "de", "nl", name="workshop_language")
+
+
+def slugify(name: str) -> str:
+    slug = re.sub(r"[^A-Za-z0-9]+", "-", name.upper()).strip("-")
+    return slug[:16] or "WT"
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    PAPER_ENUM.create(bind, checkfirst=True)
+    LANG_ENUM.create(bind, checkfirst=True)
+    op.add_column(
+        "sessions",
+        sa.Column("paper_size", PAPER_ENUM, nullable=False, server_default="A4"),
+    )
+    op.add_column(
+        "sessions",
+        sa.Column("workshop_language", LANG_ENUM, nullable=False, server_default="en"),
+    )
+    op.execute("UPDATE sessions SET paper_size='A4' WHERE paper_size IS NULL")
+    op.execute("UPDATE sessions SET workshop_language='en' WHERE workshop_language IS NULL")
+    op.alter_column("sessions", "paper_size", server_default=None)
+    op.alter_column("sessions", "workshop_language", server_default=None)
+
+    op.add_column(
+        "workshop_types",
+        sa.Column("short_code", sa.String(length=16), nullable=False, server_default=""),
+    )
+    op.create_index(
+        "uix_workshop_types_short_code_upper",
+        "workshop_types",
+        [sa.text("upper(short_code)")],
+        unique=True,
+    )
+    wt = sa.table(
+        "workshop_types",
+        sa.column("id", sa.Integer),
+        sa.column("name", sa.String),
+        sa.column("short_code", sa.String),
+    )
+    rows = bind.execute(sa.select(wt.c.id, wt.c.name)).fetchall()
+    for rid, name in rows:
+        bind.execute(
+            sa.update(wt).where(wt.c.id == rid).values(short_code=slugify(name))
+        )
+    op.alter_column("workshop_types", "short_code", server_default=None)
+
+
+def downgrade() -> None:
+    op.drop_index("uix_workshop_types_short_code_upper", table_name="workshop_types")
+    op.drop_column("workshop_types", "short_code")
+    op.drop_column("sessions", "workshop_language")
+    op.drop_column("sessions", "paper_size")
+    LANG_ENUM.drop(op.get_bind(), checkfirst=True)
+    PAPER_ENUM.drop(op.get_bind(), checkfirst=True)

--- a/tests/test_clients_sessions.py
+++ b/tests/test_clients_sessions.py
@@ -45,7 +45,7 @@ def test_session_form_shows_client_crm(app):
         admin = User(email="admin@example.com", is_app_admin=True)
         admin.set_password("x")
         crm = User(email="crm@example.com")
-        wt = WorkshopType(code="WT", name="WT")
+        wt = WorkshopType(code="WT", short_code="WT", name="WT")
         client = Client(name="ClientA", status="active", crm=crm)
         db.session.add_all([admin, crm, wt, client])
         db.session.commit()
@@ -65,7 +65,7 @@ def test_csa_add_remove_participants(app):
     with app.app_context():
         admin = User(email="admin@example.com", is_app_admin=True)
         admin.set_password("x")
-        wt = WorkshopType(code="WT", name="WT")
+        wt = WorkshopType(code="WT", short_code="WT", name="WT")
         sess = Session(title="S1", workshop_type=wt, end_date=date.today())
         db.session.add_all([admin, wt, sess])
         db.session.commit()
@@ -121,7 +121,7 @@ def test_smtp_test_route(app, monkeypatch):
 
 def test_session_detail_redirects_when_not_logged_in(app):
     with app.app_context():
-        wt = WorkshopType(code="WT", name="WT")
+        wt = WorkshopType(code="WT", short_code="WT", name="WT")
         sess = Session(
             title="S1",
             workshop_type=wt,

--- a/tests/test_csa_assign_email.py
+++ b/tests/test_csa_assign_email.py
@@ -25,7 +25,7 @@ def _setup(app):
     with app.app_context():
         admin = User(email="admin@example.com", is_app_admin=True, is_admin=True)
         admin.set_password("x")
-        wt = WorkshopType(code="WT", name="WT")
+        wt = WorkshopType(code="WT", short_code="WT", name="WT")
         sess = Session(title="S1", workshop_type=wt, start_date=date(2100, 1, 1), end_date=date(2100, 1, 1))
         db.session.add_all([admin, wt, sess])
         db.session.commit()

--- a/tests/test_csa_home.py
+++ b/tests/test_csa_home.py
@@ -20,7 +20,7 @@ def app():
 
 def _setup(app):
     with app.app_context():
-        wt = WorkshopType(code="WT", name="WT")
+        wt = WorkshopType(code="WT", short_code="WT", name="WT")
         csa_acc = ParticipantAccount(email="csa@example.com", full_name="CSA", is_active=True)
         part_acc = ParticipantAccount(email="p@example.com", full_name="P", is_active=True)
         sess = Session(

--- a/tests/test_csa_permissions.py
+++ b/tests/test_csa_permissions.py
@@ -20,7 +20,7 @@ def app():
 
 def _setup(app):
     with app.app_context():
-        wt = WorkshopType(code="WT", name="WT")
+        wt = WorkshopType(code="WT", short_code="WT", name="WT")
         admin = User(email="admin@example.com", is_app_admin=True, is_admin=True)
         kcrm = User(email="kcrm@example.com", is_kcrm=True)
         csa_acc = ParticipantAccount(email="csa@example.com", full_name="CSA", is_active=True)

--- a/tests/test_learner_list.py
+++ b/tests/test_learner_list.py
@@ -29,7 +29,7 @@ def app():
 
 def _setup(app):
     with app.app_context():
-        wt = WorkshopType(code="WT", name="WT")
+        wt = WorkshopType(code="WT", short_code="WT", name="WT")
         db.session.add(wt)
         db.session.flush()
         tpl = PreworkTemplate(workshop_type_id=wt.id, info_html="info")

--- a/tests/test_lifecycle_profile.py
+++ b/tests/test_lifecycle_profile.py
@@ -46,7 +46,7 @@ def test_delivered_gating(app):
     with app.app_context():
         admin = User(email="admin@example.com", is_app_admin=True)
         admin.set_password("x")
-        wt = WorkshopType(code="WT", name="WT")
+        wt = WorkshopType(code="WT", short_code="WT", name="WT")
         sess = Session(title="S1", workshop_type=wt, end_date=date.today() + timedelta(days=1))
         db.session.add_all([admin, wt, sess])
         db.session.commit()
@@ -64,7 +64,7 @@ def test_finalize_gating(app):
     with app.app_context():
         admin = User(email="adm@example.com", is_app_admin=True)
         admin.set_password("x")
-        wt = WorkshopType(code="WT", name="WT")
+        wt = WorkshopType(code="WT", short_code="WT", name="WT")
         sess = Session(title="S1", workshop_type=wt, end_date=date.today())
         db.session.add_all([admin, wt, sess])
         db.session.commit()
@@ -82,7 +82,7 @@ def test_lifecycle_hidden_on_new(app):
     with app.app_context():
         admin = User(email="admin@example.com", is_app_admin=True)
         admin.set_password("x")
-        wt = WorkshopType(code="WT", name="WT")
+        wt = WorkshopType(code="WT", short_code="WT", name="WT")
         db.session.add_all([admin, wt])
         db.session.commit()
         admin_id = admin.id
@@ -96,7 +96,7 @@ def test_certificate_name_defaults(app):
     with app.app_context():
         admin = User(email="admin@example.com", is_app_admin=True)
         admin.set_password("x")
-        wt = WorkshopType(code="WT", name="WT")
+        wt = WorkshopType(code="WT", short_code="WT", name="WT")
         sess = Session(title="S1", workshop_type=wt, end_date=date.today(), ready_for_delivery=True)
         part = Participant(email="p@example.com", full_name="P One")
         db.session.add_all([admin, wt, sess, part])

--- a/tests/test_locations.py
+++ b/tests/test_locations.py
@@ -65,7 +65,7 @@ def test_next_redirect_and_dropdown_update(app):
             country="US",
             is_active=False,
         )
-        wt = WorkshopType(code="WT", name="WT")
+        wt = WorkshopType(code="WT", short_code="WT", name="WT")
         db.session.add_all([admin, client, wl_active, wl_inactive, sl_inactive, wt])
         db.session.commit()
         admin_id = admin.id
@@ -159,7 +159,7 @@ def test_materials_requires_shipping_location(app):
         admin = User(email="admin@example.com", is_app_admin=True)
         admin.set_password("x")
         client = Client(name="C1")
-        wt = WorkshopType(code="WT", name="WT")
+        wt = WorkshopType(code="WT", short_code="WT", name="WT")
         sess = Session(title="S1", workshop_type=wt, client=client)
         db.session.add_all([admin, client, wt, sess])
         db.session.commit()

--- a/tests/test_materials.py
+++ b/tests/test_materials.py
@@ -29,7 +29,7 @@ def test_materials_page_loads(app):
     with app.app_context():
         admin = User(email="admin@example.com", is_app_admin=True, is_admin=True)
         admin.set_password("x")
-        wt = WorkshopType(code="WT", name="WT")
+        wt = WorkshopType(code="WT", short_code="WT", name="WT")
         mt = MaterialType(name="Kit")
         client = Client(name="C1")
         ship = ClientShippingLocation(
@@ -67,7 +67,7 @@ def test_materials_page_without_client(app):
     with app.app_context():
         admin = User(email="admin@example.com", is_app_admin=True, is_admin=True)
         admin.set_password("x")
-        wt = WorkshopType(code="WT", name="WT")
+        wt = WorkshopType(code="WT", short_code="WT", name="WT")
         mt = MaterialType(name="Kit")
         mat = Material(material_type_id=mt.id, name="Sample Kit")
         sess = Session(

--- a/tests/test_materials_orders.py
+++ b/tests/test_materials_orders.py
@@ -31,7 +31,7 @@ def app():
 def _setup_data():
     admin = User(email="admin@example.com", is_app_admin=True, is_admin=True)
     admin.set_password("x")
-    wt = WorkshopType(code="WT", name="WT")
+    wt = WorkshopType(code="WT", short_code="WT", name="WT")
     mt = MaterialType(name="Kit")
     mat = Material(material_type_id=mt.id, name="Sample Kit")
     client = Client(name="C1")

--- a/tests/test_nav_participant.py
+++ b/tests/test_nav_participant.py
@@ -20,7 +20,7 @@ def app():
 
 def _setup(app):
     with app.app_context():
-        wt = WorkshopType(code="WT", name="WT")
+        wt = WorkshopType(code="WT", short_code="WT", name="WT")
         acc = ParticipantAccount(email="p@example.com", full_name="P", is_active=True)
         sess = Session(
             title="S",

--- a/tests/test_new_session_required.py
+++ b/tests/test_new_session_required.py
@@ -20,7 +20,7 @@ def _setup(app):
     with app.app_context():
         admin = User(email="admin@example.com", is_app_admin=True, is_admin=True)
         admin.set_password("x")
-        wt = WorkshopType(code="WT", name="WT")
+        wt = WorkshopType(code="WT", short_code="WT", name="WT")
         client = Client(name="ClientA", status="active")
         db.session.add_all([admin, wt, client])
         db.session.commit()
@@ -41,6 +41,8 @@ def test_new_session_requires_fields(app):
             "workshop_type_id": str(wt_id),
             "delivery_type": "Onsite",
             "language": "English",
+            "paper_size": "A4",
+            "workshop_language": "en",
             "capacity": "16",
             "start_date": "2100-01-01",
             "end_date": "2100-01-02",
@@ -62,6 +64,8 @@ def test_new_session_requires_fields(app):
             "workshop_type_id": str(wt_id),
             "delivery_type": "Onsite",
             "language": "English",
+            "paper_size": "A4",
+            "workshop_language": "en",
             "capacity": "16",
             "start_date": "2100-01-01",
             "end_date": "2100-01-02",
@@ -83,3 +87,5 @@ def test_new_session_form_shows_language_and_delivery(app):
     assert resp.status_code == 200
     assert b"Delivery Type" in resp.data
     assert b"Language" in resp.data
+    assert b"Paper size" in resp.data
+    assert b"Workshop language" in resp.data

--- a/tests/test_prework.py
+++ b/tests/test_prework.py
@@ -24,7 +24,7 @@ def test_assignment_completion():
     app = create_app()
     with app.app_context():
         db.create_all()
-        wt = WorkshopType(code="PW", name="Prework")
+        wt = WorkshopType(code="PW", short_code="PW", name="Prework")
         db.session.add(wt)
         db.session.commit()
         tpl = PreworkTemplate(workshop_type_id=wt.id, info_html="info")
@@ -76,7 +76,7 @@ def test_no_prework_toggle_disables_send_prework(monkeypatch):
     with app.app_context():
         db.create_all()
         user = User(email="admin@example.com", is_app_admin=True)
-        wt = WorkshopType(code="NP", name="NoPrework")
+        wt = WorkshopType(code="NP", short_code="NP", name="NoPrework")
         db.session.add_all([user, wt])
         db.session.commit()
         tpl = PreworkTemplate(workshop_type_id=wt.id, info_html="info")
@@ -106,7 +106,7 @@ def test_account_invite_sets_timestamp(monkeypatch):
     with app.app_context():
         db.create_all()
         user = User(email="admin2@example.com", is_app_admin=True)
-        wt = WorkshopType(code="AI", name="AcctInvite")
+        wt = WorkshopType(code="AI", short_code="AI", name="AcctInvite")
         db.session.add_all([user, wt])
         db.session.commit()
         tpl = PreworkTemplate(workshop_type_id=wt.id, info_html="info")
@@ -151,7 +151,7 @@ def test_nav_gating_prework():
     app = create_app()
     with app.app_context():
         db.create_all()
-        wt = WorkshopType(code="PW2", name="Prework2")
+        wt = WorkshopType(code="PW2", short_code="PW2", name="Prework2")
         db.session.add(wt)
         db.session.commit()
         tpl = PreworkTemplate(workshop_type_id=wt.id, info_html="info")
@@ -201,7 +201,7 @@ def test_item_index_unique():
     app = create_app()
     with app.app_context():
         db.create_all()
-        wt = WorkshopType(code="MI", name="ItemIdx")
+        wt = WorkshopType(code="MI", short_code="MI", name="ItemIdx")
         db.session.add(wt)
         db.session.commit()
         tpl = PreworkTemplate(workshop_type_id=wt.id, info_html="info")
@@ -254,7 +254,7 @@ def test_list_question_autosave_and_completion():
     app = create_app()
     with app.app_context():
         db.create_all()
-        wt = WorkshopType(code="LQ", name="ListQ")
+        wt = WorkshopType(code="LQ", short_code="LQ", name="ListQ")
         db.session.add(wt)
         db.session.commit()
         tpl = PreworkTemplate(workshop_type_id=wt.id, info_html="info")
@@ -325,7 +325,7 @@ def test_prework_download_route():
     app = create_app()
     with app.app_context():
         db.create_all()
-        wt = WorkshopType(code="DL", name="Download")
+        wt = WorkshopType(code="DL", short_code="DL", name="Download")
         db.session.add(wt)
         db.session.commit()
         tpl = PreworkTemplate(workshop_type_id=wt.id, info_html="info")
@@ -371,7 +371,7 @@ def test_staff_send_flows_run(monkeypatch):
     with app.app_context():
         db.create_all()
         user = User(email="staff@example.com", is_app_admin=True)
-        wt = WorkshopType(code="SF", name="SendFlow")
+        wt = WorkshopType(code="SF", short_code="SF", name="SendFlow")
         db.session.add_all([user, wt])
         db.session.commit()
         tpl = PreworkTemplate(workshop_type_id=wt.id, info_html="info")
@@ -402,7 +402,7 @@ def test_contractor_can_send_prework(monkeypatch):
     with app.app_context():
         db.create_all()
         user = User(email="cont@example.com", is_kt_contractor=True)
-        wt = WorkshopType(code="CT", name="Contractor")
+        wt = WorkshopType(code="CT", short_code="CT", name="Contractor")
         db.session.add_all([user, wt])
         db.session.commit()
         tpl = PreworkTemplate(workshop_type_id=wt.id, info_html="info")

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -41,7 +41,7 @@ def test_resource_validation_and_slug(app):
 
 def test_my_resources_view(app):
     with app.app_context():
-        wt = WorkshopType(code="ABC", name="Type A")
+        wt = WorkshopType(code="ABC", short_code="ABC", name="Type A")
         sess = Session(title="S1", workshop_type=wt)
         p = Participant(email="p@example.com", full_name="P")
         db.session.add_all([wt, sess, p])

--- a/tests/test_session_date_rules.py
+++ b/tests/test_session_date_rules.py
@@ -22,7 +22,7 @@ def _setup(app):
     with app.app_context():
         admin = User(email="admin@example.com", is_app_admin=True, is_admin=True)
         admin.set_password("x")
-        wt = WorkshopType(code="WT", name="WT")
+        wt = WorkshopType(code="WT", short_code="WT", name="WT")
         client = Client(name="ClientA", status="active")
         db.session.add_all([admin, wt, client])
         db.session.commit()
@@ -42,6 +42,8 @@ def _base_form(client_id, wt_id):
         "workshop_type_id": str(wt_id),
         "delivery_type": "Onsite",
         "language": "English",
+        "paper_size": "A4",
+        "workshop_language": "en",
         "capacity": "16",
         "daily_start_time": "09:00",
         "daily_end_time": "17:00",

--- a/tests/test_simulation_outline_visibility.py
+++ b/tests/test_simulation_outline_visibility.py
@@ -29,7 +29,7 @@ def app():
 def _base_setup(sim_based=False):
     admin = User(email="admin@example.com", is_app_admin=True, is_admin=True)
     admin.set_password("x")
-    wt = WorkshopType(code="WT", name="WT", simulation_based=sim_based)
+    wt = WorkshopType(code="WT", short_code="WT", name="WT", simulation_based=sim_based)
     so = SimulationOutline(number="S1", skill="Custom", descriptor="Desc", level="Novice")
     client = Client(name="C1")
     ship = ClientShippingLocation(client=client, contact_name="CN", address_line1="A1", city="City", postal_code="123", country="US")

--- a/tests/test_simulation_outlines.py
+++ b/tests/test_simulation_outlines.py
@@ -28,7 +28,7 @@ def setup_basic(app):
     with app.app_context():
         admin = User(email="admin@example.com", is_app_admin=True, is_admin=True)
         admin.set_password("x")
-        wt = WorkshopType(code="WT", name="WT", simulation_based=True)
+        wt = WorkshopType(code="WT", short_code="WT", name="WT", simulation_based=True)
         client = Client(name="C1")
         lang = Language(name="English")
         sim = SimulationOutline(number="123456", skill="Risk", descriptor="Desc", level="Novice")
@@ -50,6 +50,8 @@ def test_simulation_outline_dropdown_and_save(app):
         "workshop_type_id": str(wt_id),
         "delivery_type": "Onsite",
         "language": "English",
+        "paper_size": "A4",
+        "workshop_language": "en",
         "capacity": "10",
         "start_date": future_start.isoformat(),
         "end_date": future_end.isoformat(),

--- a/tests/test_workshop_types.py
+++ b/tests/test_workshop_types.py
@@ -11,10 +11,11 @@ from app.models import (
     WorkshopType,
     Session,
     Participant,
+    ParticipantAccount,
     SessionParticipant,
     Certificate,
 )
-from app.utils.certificates import generate_for_session
+from app.utils.certificates import render_for_session
 
 
 @pytest.fixture
@@ -30,10 +31,10 @@ def app():
 
 def test_workshop_type_code_unique(app):
     with app.app_context():
-        wt1 = WorkshopType(code="abc", name="One")
+        wt1 = WorkshopType(code="abc", short_code="abc", name="One")
         db.session.add(wt1)
         db.session.commit()
-        wt2 = WorkshopType(code="aBc", name="Two")
+        wt2 = WorkshopType(code="aBc", short_code="aBc", name="Two")
         db.session.add(wt2)
         with pytest.raises(Exception):
             db.session.commit()
@@ -41,7 +42,7 @@ def test_workshop_type_code_unique(app):
 
 def test_session_sets_code_from_workshop_type(app):
     with app.app_context():
-        wt = WorkshopType(code="AAA", name="Type A")
+        wt = WorkshopType(code="AAA", short_code="AAA", name="Type A")
         sess = Session(title="S1")
         sess.workshop_type = wt
         db.session.add_all([wt, sess])
@@ -51,16 +52,17 @@ def test_session_sets_code_from_workshop_type(app):
 
 def test_certificate_uses_workshop_type_name(app):
     with app.app_context():
-        wt = WorkshopType(code="BBB", name="Type B")
-        sess = Session(title="S2", workshop_type=wt, end_date=date.today())
-        p = Participant(email="p@example.com", full_name="P")
-        db.session.add_all([wt, sess, p])
+        wt = WorkshopType(code="BBB", short_code="BBB", name="Type B")
+        sess = Session(title="S2", workshop_type=wt, end_date=date.today(), workshop_language="es")
+        acc = ParticipantAccount(email="p@example.com", full_name="P")
+        p = Participant(email="p@example.com", full_name="P", account=acc)
+        db.session.add_all([wt, sess, acc, p])
         db.session.flush()
         link = SessionParticipant(
             session_id=sess.id, participant_id=p.id, completion_date=date.today()
         )
         db.session.add(link)
         db.session.commit()
-        generate_for_session(sess.id)
+        render_for_session(sess.id)
         cert = db.session.query(Certificate).one()
         assert cert.workshop_name == wt.name


### PR DESCRIPTION
## Summary
- support A4/Letter paper sizes and localized certificate templates with safe filename pattern
- add workshop type short codes and session paper/language options
- provide CLI to render individual certificates

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bb3cf32084832eaef05f2e2d1a47aa