### PR TITLE
Remove workshop short code and update certificate filenames

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -26,7 +26,7 @@ Every functional change must update this file **in the same PR**.
 - Do **not** include local PowerShell aliases in docs or code.
 - Business logic stays server-side; small JS for UI only.
 - All timestamps stored UTC; display with short timezone labels; **never show seconds**.
-- Certificates: `/srv/certificates/<year>/<session_id>/<workshop_short_code>_<certificate_name_slug>_<YYYY-MM-DD>.pdf` and linked in-portal.
+- Certificates: `/srv/certificates/<year>/<session_id>/<workshop_code>_<certificate_name_slug>_<YYYY-MM-DD>.pdf` (where `workshop_code = workshop_types.code`) and linked in-portal.
 - Emails lowercased-unique per table (see §2). Enforce in DB and app.
 - “KT Staff” is a **derived condition** (see §1.3), **not** a stored role.
 
@@ -117,7 +117,7 @@ Two separate tables; a person may exist in **both** with the same email.
 # 3. Data Model (summary)
 
 ## 3.1 Catalog & Sessions
-- `workshop_types` (name, **short_code**, **simulation_based** bool)
+- `workshop_types` (name, **code**, **simulation_based** bool)
 - `simulation_outlines` (6-digit **number**, **skill** enum: Systematic Troubleshooting/Frontline/Risk/PSDMxp/Refresher/Custom, **descriptor**, **level** enum: Novice/Competent/Advanced)
 - `sessions` (fk workshop_type_id, optional fk simulation_outline_id, start_date, end_date, timezone, location fields, **paper_size** enum A4/LETTER, **workshop_language** enum en/es/fr/ja/de/nl, notes, crm_notes, delivered_at, finalized_at, **no_prework**, **no_material_order**, optional **csa_participant_account_id**)
 - `session_facilitators` (m:n users↔sessions)
@@ -135,7 +135,7 @@ Two separate tables; a person may exist in **both** with the same email.
 
 ## 3.4 Certificates
 - `certificates` (session_id, participant_account_id, file_path, issued_at, layout_version; unique pair)
-  Files under `/srv/certificates/<year>/<session_id>/<workshop_short_code>_<certificate_name_slug>_<YYYY-MM-DD>.pdf`.
+  Files under `/srv/certificates/<year>/<session_id>/<workshop_code>_<certificate_name_slug>_<YYYY-MM-DD>.pdf` (using `workshop_types.code`).
 
 ## 3.5 Materials
 - `materials_orders` (session_id, **format** enum: All Physical/All Digital/Mixed/SIM Only; four **physical_components** booleans; **po_number**; **latest_arrival_date**; ship_date; courier; tracking; special_instructions)
@@ -202,7 +202,7 @@ Two separate tables; a person may exist in **both** with the same email.
 
 - Issued post-delivery; template chosen by session `paper_size` (A4 or Letter) and `workshop_language` (en, es, fr, ja, de, nl); missing template errors.
 - Name line at 145 mm italic, auto-shrink 48→32; Letter adds 1 cm inset left/right before fitting. Workshop line at 102 mm; date at 83 mm in `d Month YYYY`.
-- PDF saved to `/srv/certificates/<year>/<session_id>/<workshop_short_code>_<certificate_name_slug>_<YYYY-MM-DD>.pdf`.
+- PDF saved to `/srv/certificates/<year>/<session_id>/<workshop_code>_<certificate_name_slug>_<YYYY-MM-DD>.pdf` (using `workshop_types.code`).
 - Learner sees **My Certificates** only if they own ≥1 certificate.
 
 ---
@@ -253,7 +253,8 @@ Two separate tables; a person may exist in **both** with the same email.
 - **Materials (dashboard & orders)**: `app/routes/materials.py`, `app/routes/materials_orders.py`, templates `app/templates/materials/*.html`, `app/templates/materials_orders.html`
 - **Users & Roles**: `app/routes/users.py`, `app/templates/users/*.html`; matrix `app/routes/settings_roles.py`, `app/templates/settings_roles.html`
 - **Email**: `app/emailer.py`, `app/templates/email/*.html|.txt`
-- **Utils**: `app/utils/materials.py` (arrival logic), `app/utils/time.py`, `app/utils/acl.py`, `app/utils/certificates.py`
+- **Certificates**: generator `app/utils/certificates.py`; templates under `app/assets/`
+- **Utils**: `app/utils/materials.py` (arrival logic), `app/utils/time.py`, `app/utils/acl.py`
 
 ---
 

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -147,7 +147,6 @@ class WorkshopType(db.Model):
 
     id = db.Column(db.Integer, primary_key=True)
     code = db.Column(db.String(16), nullable=False)
-    short_code = db.Column(db.String(16), nullable=False)
     name = db.Column(db.String(255), nullable=False)
     status = db.Column(db.String(16), default="active")
     description = db.Column(db.Text)
@@ -158,11 +157,6 @@ class WorkshopType(db.Model):
     created_at = db.Column(db.DateTime, server_default=db.func.now())
     __table_args__ = (
         db.Index("uix_workshop_types_code_upper", db.func.upper(code), unique=True),
-        db.Index(
-            "uix_workshop_types_short_code_upper",
-            db.func.upper(short_code),
-            unique=True,
-        ),
     )
 
     resources = db.relationship(
@@ -173,10 +167,6 @@ class WorkshopType(db.Model):
 
     @validates("code")
     def upper_code(self, key, value):  # pragma: no cover - simple normalizer
-        return (value or "").upper()
-
-    @validates("short_code")
-    def upper_short_code(self, key, value):  # pragma: no cover - simple normalizer
         return (value or "").upper()
 
 

--- a/app/templates/workshop_types/form.html
+++ b/app/templates/workshop_types/form.html
@@ -14,7 +14,6 @@
   <div><label>Code <input type="text" name="code" value="{{ wt.code }}" readonly></label></div>
   {% endif %}
   <div><label>Name <input type="text" name="name" value="{{ wt.name if wt else '' }}" required></label></div>
-  <div><label>Short Code <input type="text" name="short_code" value="{{ wt.short_code if wt else '' }}" maxlength="16" pattern="[A-Za-z0-9-]{2,16}" required></label><small>2–16 chars; A–Z, 0–9, dash.</small></div>
   <div><label>Status <input type="text" name="status" value="{{ wt.status if wt else 'active' }}"></label></div>
   <div><label>Badge
     <select name="badge">

--- a/app/utils/certificates.py
+++ b/app/utils/certificates.py
@@ -122,12 +122,12 @@ def render_certificate(
     year = completion.year
     rel_dir = os.path.join("certificates", str(year), str(session.id))
     ensure_dir(os.path.join("/srv", rel_dir))
-    short_code = (
-        session.workshop_type.short_code
-        if session.workshop_type and session.workshop_type.short_code
+    code = (
+        session.workshop_type.code
+        if session.workshop_type and session.workshop_type.code
         else "WORKSHOP"
     )
-    filename = f"{short_code}_{slug_certificate_name(display_name)}_{completion.strftime('%Y-%m-%d')}.pdf"
+    filename = f"{code}_{slug_certificate_name(display_name)}_{completion.strftime('%Y-%m-%d')}.pdf"
     rel_path = os.path.join(rel_dir, filename)
     with open(os.path.join("/srv", rel_path), "wb") as f:
         writer.write(f)

--- a/migrations/versions/0042_certificate_fields.py
+++ b/migrations/versions/0042_certificate_fields.py
@@ -1,4 +1,4 @@
-"""add certificate fields and workshop short code
+"""add certificate fields
 
 Revision ID: 0042_certificate_fields
 Revises: 0041_rename_materials_format_values
@@ -7,7 +7,6 @@ Create Date: 2025-??-??
 
 from alembic import op
 import sqlalchemy as sa
-import re
 
 revision = "0042_certificate_fields"
 down_revision = "0041_rename_materials_format_values"
@@ -17,11 +16,6 @@ depends_on = None
 
 PAPER_ENUM = sa.Enum("A4", "LETTER", name="paper_size")
 LANG_ENUM = sa.Enum("en", "es", "fr", "ja", "de", "nl", name="workshop_language")
-
-
-def slugify(name: str) -> str:
-    slug = re.sub(r"[^A-Za-z0-9]+", "-", name.upper()).strip("-")
-    return slug[:16] or "WT"
 
 
 def upgrade() -> None:
@@ -41,33 +35,8 @@ def upgrade() -> None:
     op.alter_column("sessions", "paper_size", server_default=None)
     op.alter_column("sessions", "workshop_language", server_default=None)
 
-    op.add_column(
-        "workshop_types",
-        sa.Column("short_code", sa.String(length=16), nullable=False, server_default=""),
-    )
-    op.create_index(
-        "uix_workshop_types_short_code_upper",
-        "workshop_types",
-        [sa.text("upper(short_code)")],
-        unique=True,
-    )
-    wt = sa.table(
-        "workshop_types",
-        sa.column("id", sa.Integer),
-        sa.column("name", sa.String),
-        sa.column("short_code", sa.String),
-    )
-    rows = bind.execute(sa.select(wt.c.id, wt.c.name)).fetchall()
-    for rid, name in rows:
-        bind.execute(
-            sa.update(wt).where(wt.c.id == rid).values(short_code=slugify(name))
-        )
-    op.alter_column("workshop_types", "short_code", server_default=None)
-
 
 def downgrade() -> None:
-    op.drop_index("uix_workshop_types_short_code_upper", table_name="workshop_types")
-    op.drop_column("workshop_types", "short_code")
     op.drop_column("sessions", "workshop_language")
     op.drop_column("sessions", "paper_size")
     LANG_ENUM.drop(op.get_bind(), checkfirst=True)

--- a/migrations/versions/0043_cleanup_workshop_type_code.py
+++ b/migrations/versions/0043_cleanup_workshop_type_code.py
@@ -1,0 +1,45 @@
+"""cleanup workshop_type short_code leftovers"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0043_cleanup_workshop_type_code"
+down_revision = "0042_certificate_fields"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+    cols = [c["name"] for c in insp.get_columns("workshop_types")]
+    if "short_code" in cols:
+        bind.execute(
+            sa.text(
+                "UPDATE workshop_types SET code = short_code "
+                "WHERE (code IS NULL OR code='') "
+                "AND short_code IS NOT NULL AND short_code<>''"
+            )
+        )
+        indexes = [ix["name"] for ix in insp.get_indexes("workshop_types")]
+        if "uix_workshop_types_short_code_upper" in indexes:
+            op.drop_index(
+                "uix_workshop_types_short_code_upper",
+                table_name="workshop_types",
+            )
+        op.drop_column("workshop_types", "short_code")
+
+
+def downgrade() -> None:
+    op.add_column(
+        "workshop_types",
+        sa.Column("short_code", sa.String(length=16), nullable=True),
+    )
+    bind = op.get_bind()
+    bind.execute(sa.text("UPDATE workshop_types SET short_code = code"))
+    op.create_index(
+        "uix_workshop_types_short_code_upper",
+        "workshop_types",
+        [sa.text("upper(short_code)")],
+        unique=True,
+    )

--- a/tests/test_clients_sessions.py
+++ b/tests/test_clients_sessions.py
@@ -45,7 +45,7 @@ def test_session_form_shows_client_crm(app):
         admin = User(email="admin@example.com", is_app_admin=True)
         admin.set_password("x")
         crm = User(email="crm@example.com")
-        wt = WorkshopType(code="WT", short_code="WT", name="WT")
+        wt = WorkshopType(code="WT", name="WT")
         client = Client(name="ClientA", status="active", crm=crm)
         db.session.add_all([admin, crm, wt, client])
         db.session.commit()
@@ -65,7 +65,7 @@ def test_csa_add_remove_participants(app):
     with app.app_context():
         admin = User(email="admin@example.com", is_app_admin=True)
         admin.set_password("x")
-        wt = WorkshopType(code="WT", short_code="WT", name="WT")
+        wt = WorkshopType(code="WT", name="WT")
         sess = Session(title="S1", workshop_type=wt, end_date=date.today())
         db.session.add_all([admin, wt, sess])
         db.session.commit()
@@ -121,7 +121,7 @@ def test_smtp_test_route(app, monkeypatch):
 
 def test_session_detail_redirects_when_not_logged_in(app):
     with app.app_context():
-        wt = WorkshopType(code="WT", short_code="WT", name="WT")
+        wt = WorkshopType(code="WT", name="WT")
         sess = Session(
             title="S1",
             workshop_type=wt,

--- a/tests/test_csa_assign_email.py
+++ b/tests/test_csa_assign_email.py
@@ -25,7 +25,7 @@ def _setup(app):
     with app.app_context():
         admin = User(email="admin@example.com", is_app_admin=True, is_admin=True)
         admin.set_password("x")
-        wt = WorkshopType(code="WT", short_code="WT", name="WT")
+        wt = WorkshopType(code="WT", name="WT")
         sess = Session(title="S1", workshop_type=wt, start_date=date(2100, 1, 1), end_date=date(2100, 1, 1))
         db.session.add_all([admin, wt, sess])
         db.session.commit()

--- a/tests/test_csa_home.py
+++ b/tests/test_csa_home.py
@@ -20,7 +20,7 @@ def app():
 
 def _setup(app):
     with app.app_context():
-        wt = WorkshopType(code="WT", short_code="WT", name="WT")
+        wt = WorkshopType(code="WT", name="WT")
         csa_acc = ParticipantAccount(email="csa@example.com", full_name="CSA", is_active=True)
         part_acc = ParticipantAccount(email="p@example.com", full_name="P", is_active=True)
         sess = Session(

--- a/tests/test_csa_permissions.py
+++ b/tests/test_csa_permissions.py
@@ -20,7 +20,7 @@ def app():
 
 def _setup(app):
     with app.app_context():
-        wt = WorkshopType(code="WT", short_code="WT", name="WT")
+        wt = WorkshopType(code="WT", name="WT")
         admin = User(email="admin@example.com", is_app_admin=True, is_admin=True)
         kcrm = User(email="kcrm@example.com", is_kcrm=True)
         csa_acc = ParticipantAccount(email="csa@example.com", full_name="CSA", is_active=True)

--- a/tests/test_learner_list.py
+++ b/tests/test_learner_list.py
@@ -29,7 +29,7 @@ def app():
 
 def _setup(app):
     with app.app_context():
-        wt = WorkshopType(code="WT", short_code="WT", name="WT")
+        wt = WorkshopType(code="WT", name="WT")
         db.session.add(wt)
         db.session.flush()
         tpl = PreworkTemplate(workshop_type_id=wt.id, info_html="info")

--- a/tests/test_lifecycle_profile.py
+++ b/tests/test_lifecycle_profile.py
@@ -46,7 +46,7 @@ def test_delivered_gating(app):
     with app.app_context():
         admin = User(email="admin@example.com", is_app_admin=True)
         admin.set_password("x")
-        wt = WorkshopType(code="WT", short_code="WT", name="WT")
+        wt = WorkshopType(code="WT", name="WT")
         sess = Session(title="S1", workshop_type=wt, end_date=date.today() + timedelta(days=1))
         db.session.add_all([admin, wt, sess])
         db.session.commit()
@@ -64,7 +64,7 @@ def test_finalize_gating(app):
     with app.app_context():
         admin = User(email="adm@example.com", is_app_admin=True)
         admin.set_password("x")
-        wt = WorkshopType(code="WT", short_code="WT", name="WT")
+        wt = WorkshopType(code="WT", name="WT")
         sess = Session(title="S1", workshop_type=wt, end_date=date.today())
         db.session.add_all([admin, wt, sess])
         db.session.commit()
@@ -82,7 +82,7 @@ def test_lifecycle_hidden_on_new(app):
     with app.app_context():
         admin = User(email="admin@example.com", is_app_admin=True)
         admin.set_password("x")
-        wt = WorkshopType(code="WT", short_code="WT", name="WT")
+        wt = WorkshopType(code="WT", name="WT")
         db.session.add_all([admin, wt])
         db.session.commit()
         admin_id = admin.id
@@ -96,7 +96,7 @@ def test_certificate_name_defaults(app):
     with app.app_context():
         admin = User(email="admin@example.com", is_app_admin=True)
         admin.set_password("x")
-        wt = WorkshopType(code="WT", short_code="WT", name="WT")
+        wt = WorkshopType(code="WT", name="WT")
         sess = Session(title="S1", workshop_type=wt, end_date=date.today(), ready_for_delivery=True)
         part = Participant(email="p@example.com", full_name="P One")
         db.session.add_all([admin, wt, sess, part])

--- a/tests/test_locations.py
+++ b/tests/test_locations.py
@@ -65,7 +65,7 @@ def test_next_redirect_and_dropdown_update(app):
             country="US",
             is_active=False,
         )
-        wt = WorkshopType(code="WT", short_code="WT", name="WT")
+        wt = WorkshopType(code="WT", name="WT")
         db.session.add_all([admin, client, wl_active, wl_inactive, sl_inactive, wt])
         db.session.commit()
         admin_id = admin.id
@@ -159,7 +159,7 @@ def test_materials_requires_shipping_location(app):
         admin = User(email="admin@example.com", is_app_admin=True)
         admin.set_password("x")
         client = Client(name="C1")
-        wt = WorkshopType(code="WT", short_code="WT", name="WT")
+        wt = WorkshopType(code="WT", name="WT")
         sess = Session(title="S1", workshop_type=wt, client=client)
         db.session.add_all([admin, client, wt, sess])
         db.session.commit()

--- a/tests/test_materials.py
+++ b/tests/test_materials.py
@@ -29,7 +29,7 @@ def test_materials_page_loads(app):
     with app.app_context():
         admin = User(email="admin@example.com", is_app_admin=True, is_admin=True)
         admin.set_password("x")
-        wt = WorkshopType(code="WT", short_code="WT", name="WT")
+        wt = WorkshopType(code="WT", name="WT")
         mt = MaterialType(name="Kit")
         client = Client(name="C1")
         ship = ClientShippingLocation(
@@ -67,7 +67,7 @@ def test_materials_page_without_client(app):
     with app.app_context():
         admin = User(email="admin@example.com", is_app_admin=True, is_admin=True)
         admin.set_password("x")
-        wt = WorkshopType(code="WT", short_code="WT", name="WT")
+        wt = WorkshopType(code="WT", name="WT")
         mt = MaterialType(name="Kit")
         mat = Material(material_type_id=mt.id, name="Sample Kit")
         sess = Session(

--- a/tests/test_materials_orders.py
+++ b/tests/test_materials_orders.py
@@ -31,7 +31,7 @@ def app():
 def _setup_data():
     admin = User(email="admin@example.com", is_app_admin=True, is_admin=True)
     admin.set_password("x")
-    wt = WorkshopType(code="WT", short_code="WT", name="WT")
+    wt = WorkshopType(code="WT", name="WT")
     mt = MaterialType(name="Kit")
     mat = Material(material_type_id=mt.id, name="Sample Kit")
     client = Client(name="C1")

--- a/tests/test_nav_participant.py
+++ b/tests/test_nav_participant.py
@@ -20,7 +20,7 @@ def app():
 
 def _setup(app):
     with app.app_context():
-        wt = WorkshopType(code="WT", short_code="WT", name="WT")
+        wt = WorkshopType(code="WT", name="WT")
         acc = ParticipantAccount(email="p@example.com", full_name="P", is_active=True)
         sess = Session(
             title="S",

--- a/tests/test_new_session_required.py
+++ b/tests/test_new_session_required.py
@@ -20,7 +20,7 @@ def _setup(app):
     with app.app_context():
         admin = User(email="admin@example.com", is_app_admin=True, is_admin=True)
         admin.set_password("x")
-        wt = WorkshopType(code="WT", short_code="WT", name="WT")
+        wt = WorkshopType(code="WT", name="WT")
         client = Client(name="ClientA", status="active")
         db.session.add_all([admin, wt, client])
         db.session.commit()

--- a/tests/test_prework.py
+++ b/tests/test_prework.py
@@ -24,7 +24,7 @@ def test_assignment_completion():
     app = create_app()
     with app.app_context():
         db.create_all()
-        wt = WorkshopType(code="PW", short_code="PW", name="Prework")
+        wt = WorkshopType(code="PW", name="Prework")
         db.session.add(wt)
         db.session.commit()
         tpl = PreworkTemplate(workshop_type_id=wt.id, info_html="info")
@@ -76,7 +76,7 @@ def test_no_prework_toggle_disables_send_prework(monkeypatch):
     with app.app_context():
         db.create_all()
         user = User(email="admin@example.com", is_app_admin=True)
-        wt = WorkshopType(code="NP", short_code="NP", name="NoPrework")
+        wt = WorkshopType(code="NP", name="NoPrework")
         db.session.add_all([user, wt])
         db.session.commit()
         tpl = PreworkTemplate(workshop_type_id=wt.id, info_html="info")
@@ -106,7 +106,7 @@ def test_account_invite_sets_timestamp(monkeypatch):
     with app.app_context():
         db.create_all()
         user = User(email="admin2@example.com", is_app_admin=True)
-        wt = WorkshopType(code="AI", short_code="AI", name="AcctInvite")
+        wt = WorkshopType(code="AI", name="AcctInvite")
         db.session.add_all([user, wt])
         db.session.commit()
         tpl = PreworkTemplate(workshop_type_id=wt.id, info_html="info")
@@ -151,7 +151,7 @@ def test_nav_gating_prework():
     app = create_app()
     with app.app_context():
         db.create_all()
-        wt = WorkshopType(code="PW2", short_code="PW2", name="Prework2")
+        wt = WorkshopType(code="PW2", name="Prework2")
         db.session.add(wt)
         db.session.commit()
         tpl = PreworkTemplate(workshop_type_id=wt.id, info_html="info")
@@ -201,7 +201,7 @@ def test_item_index_unique():
     app = create_app()
     with app.app_context():
         db.create_all()
-        wt = WorkshopType(code="MI", short_code="MI", name="ItemIdx")
+        wt = WorkshopType(code="MI", name="ItemIdx")
         db.session.add(wt)
         db.session.commit()
         tpl = PreworkTemplate(workshop_type_id=wt.id, info_html="info")
@@ -254,7 +254,7 @@ def test_list_question_autosave_and_completion():
     app = create_app()
     with app.app_context():
         db.create_all()
-        wt = WorkshopType(code="LQ", short_code="LQ", name="ListQ")
+        wt = WorkshopType(code="LQ", name="ListQ")
         db.session.add(wt)
         db.session.commit()
         tpl = PreworkTemplate(workshop_type_id=wt.id, info_html="info")
@@ -325,7 +325,7 @@ def test_prework_download_route():
     app = create_app()
     with app.app_context():
         db.create_all()
-        wt = WorkshopType(code="DL", short_code="DL", name="Download")
+        wt = WorkshopType(code="DL", name="Download")
         db.session.add(wt)
         db.session.commit()
         tpl = PreworkTemplate(workshop_type_id=wt.id, info_html="info")
@@ -371,7 +371,7 @@ def test_staff_send_flows_run(monkeypatch):
     with app.app_context():
         db.create_all()
         user = User(email="staff@example.com", is_app_admin=True)
-        wt = WorkshopType(code="SF", short_code="SF", name="SendFlow")
+        wt = WorkshopType(code="SF", name="SendFlow")
         db.session.add_all([user, wt])
         db.session.commit()
         tpl = PreworkTemplate(workshop_type_id=wt.id, info_html="info")
@@ -402,7 +402,7 @@ def test_contractor_can_send_prework(monkeypatch):
     with app.app_context():
         db.create_all()
         user = User(email="cont@example.com", is_kt_contractor=True)
-        wt = WorkshopType(code="CT", short_code="CT", name="Contractor")
+        wt = WorkshopType(code="CT", name="Contractor")
         db.session.add_all([user, wt])
         db.session.commit()
         tpl = PreworkTemplate(workshop_type_id=wt.id, info_html="info")

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -41,7 +41,7 @@ def test_resource_validation_and_slug(app):
 
 def test_my_resources_view(app):
     with app.app_context():
-        wt = WorkshopType(code="ABC", short_code="ABC", name="Type A")
+        wt = WorkshopType(code="ABC", name="Type A")
         sess = Session(title="S1", workshop_type=wt)
         p = Participant(email="p@example.com", full_name="P")
         db.session.add_all([wt, sess, p])

--- a/tests/test_session_date_rules.py
+++ b/tests/test_session_date_rules.py
@@ -22,7 +22,7 @@ def _setup(app):
     with app.app_context():
         admin = User(email="admin@example.com", is_app_admin=True, is_admin=True)
         admin.set_password("x")
-        wt = WorkshopType(code="WT", short_code="WT", name="WT")
+        wt = WorkshopType(code="WT", name="WT")
         client = Client(name="ClientA", status="active")
         db.session.add_all([admin, wt, client])
         db.session.commit()

--- a/tests/test_simulation_outline_visibility.py
+++ b/tests/test_simulation_outline_visibility.py
@@ -29,7 +29,7 @@ def app():
 def _base_setup(sim_based=False):
     admin = User(email="admin@example.com", is_app_admin=True, is_admin=True)
     admin.set_password("x")
-    wt = WorkshopType(code="WT", short_code="WT", name="WT", simulation_based=sim_based)
+    wt = WorkshopType(code="WT", name="WT", simulation_based=sim_based)
     so = SimulationOutline(number="S1", skill="Custom", descriptor="Desc", level="Novice")
     client = Client(name="C1")
     ship = ClientShippingLocation(client=client, contact_name="CN", address_line1="A1", city="City", postal_code="123", country="US")

--- a/tests/test_simulation_outlines.py
+++ b/tests/test_simulation_outlines.py
@@ -28,7 +28,7 @@ def setup_basic(app):
     with app.app_context():
         admin = User(email="admin@example.com", is_app_admin=True, is_admin=True)
         admin.set_password("x")
-        wt = WorkshopType(code="WT", short_code="WT", name="WT", simulation_based=True)
+        wt = WorkshopType(code="WT", name="WT", simulation_based=True)
         client = Client(name="C1")
         lang = Language(name="English")
         sim = SimulationOutline(number="123456", skill="Risk", descriptor="Desc", level="Novice")

--- a/tests/test_workshop_types.py
+++ b/tests/test_workshop_types.py
@@ -31,10 +31,10 @@ def app():
 
 def test_workshop_type_code_unique(app):
     with app.app_context():
-        wt1 = WorkshopType(code="abc", short_code="abc", name="One")
+        wt1 = WorkshopType(code="abc", name="One")
         db.session.add(wt1)
         db.session.commit()
-        wt2 = WorkshopType(code="aBc", short_code="aBc", name="Two")
+        wt2 = WorkshopType(code="aBc", name="Two")
         db.session.add(wt2)
         with pytest.raises(Exception):
             db.session.commit()
@@ -42,7 +42,7 @@ def test_workshop_type_code_unique(app):
 
 def test_session_sets_code_from_workshop_type(app):
     with app.app_context():
-        wt = WorkshopType(code="AAA", short_code="AAA", name="Type A")
+        wt = WorkshopType(code="AAA", name="Type A")
         sess = Session(title="S1")
         sess.workshop_type = wt
         db.session.add_all([wt, sess])
@@ -52,7 +52,7 @@ def test_session_sets_code_from_workshop_type(app):
 
 def test_certificate_uses_workshop_type_name(app):
     with app.app_context():
-        wt = WorkshopType(code="BBB", short_code="BBB", name="Type B")
+        wt = WorkshopType(code="BBB", name="Type B")
         sess = Session(title="S2", workshop_type=wt, end_date=date.today(), workshop_language="es")
         acc = ParticipantAccount(email="p@example.com", full_name="P")
         p = Participant(email="p@example.com", full_name="P", account=acc)


### PR DESCRIPTION
## Summary
- drop lingering `short_code` from workshop types
- save certificates using workshop type `code` in the filename
- document certificate filename pattern and code pointers

## Testing
- `python manage.py db upgrade` *(fails to reach head: stops at core schema; environment limitation)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bb45d469dc832ea4d1806ca7ac2434