### PR TITLE
Use session region for certificate paper size

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -200,7 +200,7 @@ Two separate tables; a person may exist in **both** with the same email.
 
 # 8. Certificates
 
-- Issued post-delivery; template chosen by session `paper_size` (A4 or Letter) and `workshop_language` (en, es, fr, ja, de, nl); missing template errors.
+- Issued post-delivery; paper size is derived from session Region (North America → Letter; other regions → A4). Language comes from session `workshop_language`. Templates live under `app/assets/` as `fncert_template_{a4|letter}_{lang}.pdf`; missing template errors list available files.
 - Name line at 145 mm italic, auto-shrink 48→32; Letter adds 1 cm inset left/right before fitting. Workshop line at 102 mm; date at 83 mm in `d Month YYYY`.
 - PDF saved to `/srv/certificates/<year>/<session_id>/<workshop_code>_<certificate_name_slug>_<YYYY-MM-DD>.pdf` (using `workshop_types.code`).
 - Learner sees **My Certificates** only if they own ≥1 certificate.
@@ -253,7 +253,7 @@ Two separate tables; a person may exist in **both** with the same email.
 - **Materials (dashboard & orders)**: `app/routes/materials.py`, `app/routes/materials_orders.py`, templates `app/templates/materials/*.html`, `app/templates/materials_orders.html`
 - **Users & Roles**: `app/routes/users.py`, `app/templates/users/*.html`; matrix `app/routes/settings_roles.py`, `app/templates/settings_roles.html`
 - **Email**: `app/emailer.py`, `app/templates/email/*.html|.txt`
-- **Certificates**: generator `app/utils/certificates.py`; templates under `app/assets/`
+- **Certificates**: generator `app/utils/certificates.py` (region→paper mapping, explicit asset path); templates under `app/assets/`
 - **Utils**: `app/utils/materials.py` (arrival logic), `app/utils/time.py`, `app/utils/acl.py`
 
 ---

--- a/app/routes/sessions.py
+++ b/app/routes/sessions.py
@@ -65,8 +65,6 @@ from ..utils.acl import (
 )
 
 bp = Blueprint("sessions", __name__, url_prefix="/sessions")
-
-PAPER_SIZES = ["A4", "LETTER"]
 WORKSHOP_LANGUAGES = [
     ("en", "English"),
     ("es", "Spanish"),
@@ -257,9 +255,6 @@ def new_session(current_user):
         language = request.form.get("language")
         if not language:
             missing.append("Language")
-        paper_size = request.form.get("paper_size")
-        if paper_size not in PAPER_SIZES:
-            paper_size = "A4"
         workshop_language = request.form.get("workshop_language")
         if workshop_language not in [c for c, _ in WORKSHOP_LANGUAGES]:
             workshop_language = "en"
@@ -310,7 +305,6 @@ def new_session(current_user):
             delivery_type=delivery_type,
             region=region,
             language=language,
-            paper_size=paper_size,
             workshop_language=workshop_language,
             capacity=capacity_val,
             materials_ordered=materials_ordered,
@@ -337,7 +331,6 @@ def new_session(current_user):
                     facilitators=facilitators,
                     clients=clients,
                     languages=languages,
-                    paper_sizes=PAPER_SIZES,
                     workshop_languages=WORKSHOP_LANGUAGES,
                     include_all_facilitators=include_all,
                     participants_count=participants_count,
@@ -363,7 +356,6 @@ def new_session(current_user):
                     facilitators=facilitators,
                     clients=clients,
                     languages=languages,
-                    paper_sizes=PAPER_SIZES,
                     workshop_languages=WORKSHOP_LANGUAGES,
                     include_all_facilitators=include_all,
                     participants_count=participants_count,
@@ -518,7 +510,6 @@ def new_session(current_user):
             daily_start_time=time.fromisoformat("08:00"),
             daily_end_time=time.fromisoformat("17:00"),
             language=default_lang,
-            paper_size="A4",
             workshop_language="en",
             timezone=tz,
             capacity=16,
@@ -528,7 +519,6 @@ def new_session(current_user):
         facilitators=facilitators,
         clients=clients,
         languages=languages,
-        paper_sizes=PAPER_SIZES,
         workshop_languages=WORKSHOP_LANGUAGES,
         include_all_facilitators=include_all,
         participants_count=0,
@@ -623,9 +613,6 @@ def edit_session(session_id: int, current_user):
         )
         sess.delivery_type = request.form.get("delivery_type") or None
         sess.region = request.form.get("region") or None
-        ps_val = request.form.get("paper_size")
-        if ps_val in PAPER_SIZES:
-            sess.paper_size = ps_val
         wl_val = request.form.get("workshop_language")
         if wl_val in [c for c, _ in WORKSHOP_LANGUAGES]:
             sess.workshop_language = wl_val
@@ -644,7 +631,6 @@ def edit_session(session_id: int, current_user):
                     languages=languages,
                     extra_language=extra_language,
                     clients=clients,
-                    paper_sizes=PAPER_SIZES,
                     workshop_languages=WORKSHOP_LANGUAGES,
                     include_all_facilitators=include_all,
                     participants_count=participants_count,
@@ -671,7 +657,6 @@ def edit_session(session_id: int, current_user):
                     languages=languages,
                     extra_language=extra_language,
                     clients=clients,
-                    paper_sizes=PAPER_SIZES,
                     workshop_languages=WORKSHOP_LANGUAGES,
                     include_all_facilitators=include_all,
                     participants_count=participants_count,
@@ -884,7 +869,6 @@ def edit_session(session_id: int, current_user):
         languages=languages,
         extra_language=extra_language,
         clients=clients,
-        paper_sizes=PAPER_SIZES,
         workshop_languages=WORKSHOP_LANGUAGES,
         include_all_facilitators=include_all,
         participants_count=participants_count,

--- a/app/templates/sessions/form.html
+++ b/app/templates/sessions/form.html
@@ -78,13 +78,6 @@
         {% endif %}
       </select>
     </label></div>
-    <div><label>Paper size*
-      <select name="paper_size" required>
-        {% for opt in paper_sizes %}
-        <option value="{{ opt }}" {% if session.paper_size==opt %}selected{% endif %}>{{ opt }}</option>
-        {% endfor %}
-      </select>
-    </label></div>
     <div><label>Workshop language*
       <select name="workshop_language" required>
         {% for code,label in workshop_languages %}

--- a/tests/test_new_session_required.py
+++ b/tests/test_new_session_required.py
@@ -41,7 +41,6 @@ def test_new_session_requires_fields(app):
             "workshop_type_id": str(wt_id),
             "delivery_type": "Onsite",
             "language": "English",
-            "paper_size": "A4",
             "workshop_language": "en",
             "capacity": "16",
             "start_date": "2100-01-01",
@@ -64,7 +63,6 @@ def test_new_session_requires_fields(app):
             "workshop_type_id": str(wt_id),
             "delivery_type": "Onsite",
             "language": "English",
-            "paper_size": "A4",
             "workshop_language": "en",
             "capacity": "16",
             "start_date": "2100-01-01",
@@ -87,5 +85,4 @@ def test_new_session_form_shows_language_and_delivery(app):
     assert resp.status_code == 200
     assert b"Delivery Type" in resp.data
     assert b"Language" in resp.data
-    assert b"Paper size" in resp.data
     assert b"Workshop language" in resp.data

--- a/tests/test_session_date_rules.py
+++ b/tests/test_session_date_rules.py
@@ -42,7 +42,6 @@ def _base_form(client_id, wt_id):
         "workshop_type_id": str(wt_id),
         "delivery_type": "Onsite",
         "language": "English",
-        "paper_size": "A4",
         "workshop_language": "en",
         "capacity": "16",
         "daily_start_time": "09:00",

--- a/tests/test_simulation_outlines.py
+++ b/tests/test_simulation_outlines.py
@@ -50,7 +50,6 @@ def test_simulation_outline_dropdown_and_save(app):
         "workshop_type_id": str(wt_id),
         "delivery_type": "Onsite",
         "language": "English",
-        "paper_size": "A4",
         "workshop_language": "en",
         "capacity": "10",
         "start_date": future_start.isoformat(),


### PR DESCRIPTION
## Summary
- Derive certificate template size from session region and log template path
- Remove paper size selection from session form and ignore `paper_size` POST data
- Document region→paper mapping and asset location in CONTEXT

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb4ec6d660832e8515d904f887b30b