### PR TITLE
Use single session language field for certificates

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -119,7 +119,7 @@ Two separate tables; a person may exist in **both** with the same email.
 ## 3.1 Catalog & Sessions
 - `workshop_types` (name, **code**, **simulation_based** bool)
 - `simulation_outlines` (6-digit **number**, **skill** enum: Systematic Troubleshooting/Frontline/Risk/PSDMxp/Refresher/Custom, **descriptor**, **level** enum: Novice/Competent/Advanced)
-- `sessions` (fk workshop_type_id, optional fk simulation_outline_id, start_date, end_date, timezone, location fields, **paper_size** enum A4/LETTER, **workshop_language** enum en/es/fr/ja/de/nl, notes, crm_notes, delivered_at, finalized_at, **no_prework**, **no_material_order**, optional **csa_participant_account_id**)
+- `sessions` (fk workshop_type_id, optional fk simulation_outline_id, start_date, end_date, timezone, location fields, **paper_size** enum A4/LETTER, **workshop_language** enum en/es/fr/ja/de/nl/zh, notes, crm_notes, delivered_at, finalized_at, **no_prework**, **no_material_order**, optional **csa_participant_account_id**)
 - `session_facilitators` (m:n users↔sessions)
 - `session_participants` (m:n participant_accounts↔sessions + per-person status)
 
@@ -200,7 +200,7 @@ Two separate tables; a person may exist in **both** with the same email.
 
 # 8. Certificates
 
-- Issued post-delivery; paper size is derived from session Region (North America → Letter; other regions → A4). Language comes from session `workshop_language`. Templates live under `app/assets/` as `fncert_template_{a4|letter}_{lang}.pdf`; missing template errors list available files.
+- Issued post-delivery; paper size is derived from session Region (North America → Letter; other regions → A4). Session language (`workshop_language` single field) selects certificate template. Templates live under `app/assets/` as `fncert_template_{a4|letter}_{lang}.pdf`; missing template errors list available files.
 - Name line at 145 mm italic, auto-shrink 48→32; Letter adds 1 cm inset left/right before fitting. Workshop line at 102 mm; date at 83 mm in `d Month YYYY`.
 - PDF saved to `/srv/certificates/<year>/<session_id>/<workshop_code>_<certificate_name_slug>_<YYYY-MM-DD>.pdf` (using `workshop_types.code`).
 - Learner sees **My Certificates** only if they own ≥1 certificate.
@@ -241,6 +241,7 @@ Two separate tables; a person may exist in **both** with the same email.
   - Detail: `app/templates/session_detail.html`
   - Prework tab (staff): `app/templates/sessions/prework.html`
   - Materials tab (session): `app/templates/sessions/materials.html`
+- **Session language**: field on sessions form/route (`app/templates/sessions/form.html`, `app/routes/sessions.py`); consumed by `app/utils/certificates.py`
 - **Learner**: routes `app/routes/learner.py`
   - My Workshops: `app/templates/my_sessions.html`
   - My Certificates: `app/templates/my_certificates.html`

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -286,7 +286,7 @@ class Session(db.Model):
         server_default="A4",
     )
     workshop_language = db.Column(
-        db.Enum("en", "es", "fr", "ja", "de", "nl", name="workshop_language"),
+        db.Enum("en", "es", "fr", "ja", "de", "nl", "zh", name="workshop_language"),
         nullable=False,
         default="en",
         server_default="en",

--- a/app/templates/session_detail.html
+++ b/app/templates/session_detail.html
@@ -14,7 +14,7 @@
   {% for fac in session.facilitators %}{% set _ = facs.append(fac) %}{% endfor %}
   {% for u in facs %}{{ u.full_name or u.email }} ({{ u.email }}){% if not loop.last %}, {% endif %}{% endfor %}<br>
   Dates:         {{ session.start_date }} to {{ session.end_date }}; {{ session.daily_start_time|fmt_time_range_with_tz(session.daily_end_time, session.timezone) }}<br>
-  Language:      {{ session.language }}<br>
+  Workshop language: {{ session.workshop_language }}<br>
   Delivery Type: {{ session.delivery_type }}<br>
   Workshop Location: {% if session.workshop_location %}{% if session.workshop_location.is_virtual %}{{ session.workshop_location.label }}{% else %}{{ session.workshop_location.address_line1 }}{% if session.workshop_location.address_line2 %}, {{ session.workshop_location.address_line2 }}{% endif %}, {{ session.workshop_location.city }} {{ session.workshop_location.state }} {{ session.workshop_location.postal_code }}, {{ session.workshop_location.country }}{% endif %}{% endif %}<br>
   Shipping Location: {{ session.shipping_location.display_name() if session.shipping_location else '' }}<br>

--- a/app/templates/sessions/form.html
+++ b/app/templates/sessions/form.html
@@ -68,16 +68,6 @@
         {% endfor %}
       </select>
     </label></div>
-    <div><label>Language*
-      <select name="language" required>
-        {% for lang in languages %}
-        <option value="{{ lang.name }}" {% if session.language==lang.name %}selected{% endif %}>{{ lang.name }}</option>
-        {% endfor %}
-        {% if extra_language %}
-        <option value="{{ extra_language }}" selected>{{ extra_language }}</option>
-        {% endif %}
-      </select>
-    </label></div>
     <div><label>Workshop language*
       <select name="workshop_language" required>
         {% for code,label in workshop_languages %}

--- a/migrations/versions/0042_certificate_fields.py
+++ b/migrations/versions/0042_certificate_fields.py
@@ -15,7 +15,7 @@ depends_on = None
 
 
 PAPER_ENUM = sa.Enum("A4", "LETTER", name="paper_size")
-LANG_ENUM = sa.Enum("en", "es", "fr", "ja", "de", "nl", name="workshop_language")
+LANG_ENUM = sa.Enum("en", "es", "fr", "ja", "de", "nl", "zh", name="workshop_language")
 
 
 def upgrade() -> None:

--- a/tests/test_new_session_required.py
+++ b/tests/test_new_session_required.py
@@ -40,7 +40,6 @@ def test_new_session_requires_fields(app):
             "region": "NA",
             "workshop_type_id": str(wt_id),
             "delivery_type": "Onsite",
-            "language": "English",
             "workshop_language": "en",
             "capacity": "16",
             "start_date": "2100-01-01",
@@ -62,7 +61,6 @@ def test_new_session_requires_fields(app):
             "region": "NA",
             "workshop_type_id": str(wt_id),
             "delivery_type": "Onsite",
-            "language": "English",
             "workshop_language": "en",
             "capacity": "16",
             "start_date": "2100-01-01",
@@ -84,5 +82,5 @@ def test_new_session_form_shows_language_and_delivery(app):
     resp = client.get("/sessions/new")
     assert resp.status_code == 200
     assert b"Delivery Type" in resp.data
-    assert b"Language" in resp.data
     assert b"Workshop language" in resp.data
+    assert b"<label>Language" not in resp.data

--- a/tests/test_session_date_rules.py
+++ b/tests/test_session_date_rules.py
@@ -41,7 +41,6 @@ def _base_form(client_id, wt_id):
         "region": "NA",
         "workshop_type_id": str(wt_id),
         "delivery_type": "Onsite",
-        "language": "English",
         "workshop_language": "en",
         "capacity": "16",
         "daily_start_time": "09:00",

--- a/tests/test_simulation_outline_visibility.py
+++ b/tests/test_simulation_outline_visibility.py
@@ -89,7 +89,6 @@ def test_outline_persists_when_saved_from_session_form(app):
             "region": "NA",
             "workshop_type_id": 1,
             "delivery_type": "Onsite",
-            "language": "English",
             "capacity": "10",
             "start_date": date.today().isoformat(),
             "end_date": date.today().isoformat(),

--- a/tests/test_simulation_outlines.py
+++ b/tests/test_simulation_outlines.py
@@ -5,7 +5,7 @@ from datetime import date, timedelta
 import pytest
 
 from app.app import create_app, db
-from app.models import User, WorkshopType, Session, SimulationOutline, Client, Language, SessionShipping
+from app.models import User, WorkshopType, Session, SimulationOutline, Client, SessionShipping
 from app.utils.materials import latest_arrival_date
 
 
@@ -30,9 +30,8 @@ def setup_basic(app):
         admin.set_password("x")
         wt = WorkshopType(code="WT", name="WT", simulation_based=True)
         client = Client(name="C1")
-        lang = Language(name="English")
         sim = SimulationOutline(number="123456", skill="Risk", descriptor="Desc", level="Novice")
-        db.session.add_all([admin, wt, client, lang, sim])
+        db.session.add_all([admin, wt, client, sim])
         db.session.commit()
         return admin.id, wt.id, client.id, sim.id
 
@@ -49,7 +48,6 @@ def test_simulation_outline_dropdown_and_save(app):
         "region": "NA",
         "workshop_type_id": str(wt_id),
         "delivery_type": "Onsite",
-        "language": "English",
         "workshop_language": "en",
         "capacity": "10",
         "start_date": future_start.isoformat(),


### PR DESCRIPTION
## Summary
- remove legacy session `language` form field
- persist and display only `workshop_language` (adds zh option)
- document single session language driving certificate templates

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb5270583c832e85fd7ceb4119d491