### PR TITLE
Add region/language selects and full materials form to material-only orders

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -243,6 +243,7 @@ Two separate tables by design; emails unique per table. If both tables hold the 
 - Materials order view shows **Workshop Type** and **Delivery Type** above Order Type.
 - **Workshop Type** settings include a **Default Materials Type** used to pre-fill the Materials order for newly created sessions.
 - **Material Only Order** single-page create lives at `/materials-only` and makes a hidden session (`materials_only = true`) for logistics. These sessions appear only on the **Material Dashboard**.
+- Region and Language are selects showing human-readable labels while storing codes. Changing Language filters Workshop Type options immediately, and the full Materials form renders on first load (no pre-save gating).
 - When `materials_only = true`, Training-session features (participants, prework, certificates) are hidden/denied.
 - Default Materials-only **Order Type** = “Client-run Bulk order”; after selecting Order Type, the session's Workshop Type default pre-fills **Materials Type**.
 - **Material Sets** integer field (hidden only when Order Type = Simulation).

--- a/app/routes/materials_only.py
+++ b/app/routes/materials_only.py
@@ -2,29 +2,82 @@ from __future__ import annotations
 
 from datetime import date
 
-from flask import Blueprint, render_template, request, redirect, url_for, flash, session as flask_session, abort
+from flask import (
+    Blueprint,
+    abort,
+    flash,
+    jsonify,
+    redirect,
+    render_template,
+    request,
+    session as flask_session,
+    url_for,
+)
 
 from ..app import db, User
-from ..models import Session, SessionShipping, Client, WorkshopType
+from ..models import (
+    Client,
+    ClientShippingLocation,
+    MaterialsOption,
+    Session,
+    SessionShipping,
+    WorkshopType,
+)
+from ..utils.languages import get_language_options
+from ..utils.materials import PHYSICAL_COMPONENTS, material_format_choices
+from ..utils.regions import get_region_options
+from .materials import ORDER_TYPES
 
-bp = Blueprint('materials_only', __name__)
+bp = Blueprint("materials_only", __name__)
 
-@bp.route('/materials-only', methods=['GET', 'POST'])
+
+def _parse_date(val: str | None):
+    if not val:
+        return None
+    try:
+        return date.fromisoformat(val)
+    except ValueError:
+        return None
+
+
+@bp.get("/materials-only/options")
+def options():
+    order_type = request.args.get("order_type")
+    opts = []
+    if order_type:
+        opts = (
+            MaterialsOption.query.filter_by(order_type=order_type, is_active=True)
+            .order_by(MaterialsOption.title)
+            .all()
+        )
+    return jsonify(options=[{"id": o.id, "title": o.title} for o in opts])
+
+@bp.route("/materials-only", methods=["GET", "POST"])
 def create():
-    user_id = flask_session.get('user_id')
+    user_id = flask_session.get("user_id")
     if not user_id:
-        return redirect(url_for('auth.login'))
+        return redirect(url_for("auth.login"))
     user = db.session.get(User, user_id)
-    if not (user.is_app_admin or user.is_admin or getattr(user, 'is_kcrm', False)):
+    if not (user.is_app_admin or user.is_admin or getattr(user, "is_kcrm", False)):
         abort(403)
-    if request.method == 'POST':
-        title = request.form.get('title')
-        client_id = request.form.get('client_id', type=int)
-        region = request.form.get('region')
-        language = request.form.get('language')
-        workshop_type_id = request.form.get('workshop_type_id', type=int)
+    if request.method == "POST":
+        title = request.form.get("title")
+        client_id = request.form.get("client_id", type=int)
+        region = request.form.get("region")
+        language = request.form.get("language")
+        workshop_type_id = request.form.get("workshop_type_id", type=int)
+        shipping_location_id = request.form.get("shipping_location_id", type=int)
+        order_type = request.form.get("order_type") or "Client-run Bulk order"
+        materials_option_ids = request.form.getlist("materials_option_id")
+        material_format = request.form.get("materials_format") or None
+        components = request.form.getlist("components")
+        arrival_date = _parse_date(request.form.get("arrival_date"))
+        ship_date = _parse_date(request.form.get("ship_date"))
+        material_sets = request.form.get("material_sets", type=int)
+        credits = request.form.get("credits", type=int)
+        po_number = request.form.get("materials_po_number") or None
         if not title or not client_id or not workshop_type_id:
-            flash('Title, Client, and Workshop Type required', 'error')
+            flash("Title, Client, and Workshop Type required", "error")
         else:
             sess = Session(
                 title=title,
@@ -32,24 +85,73 @@ def create():
                 region=region,
                 workshop_language=language,
                 workshop_type_id=workshop_type_id,
-                delivery_type='Material Order',
+                delivery_type="Material Order",
                 start_date=date.today(),
                 end_date=date.today(),
                 materials_only=True,
+                shipping_location_id=shipping_location_id,
             )
             db.session.add(sess)
             db.session.flush()
             shipment = SessionShipping(
                 session_id=sess.id,
-                order_type='Client-run Bulk order',
-                status='New',
-                credits=2,
-                material_sets=0,
+                order_type=order_type,
+                status="New",
+                credits=credits if credits is not None else 2,
+                material_sets=material_sets if material_sets is not None else 0,
+                materials_format=material_format
+                or ("SIM_ONLY" if order_type == "Simulation" else None),
+                materials_po_number=po_number,
+                ship_date=ship_date,
+                arrival_date=arrival_date,
             )
+            if shipping_location_id:
+                shipment.client_shipping_location_id = shipping_location_id
+            if components:
+                shipment.materials_components = components
+            if materials_option_ids:
+                if order_type == "KT-Run Modular materials":
+                    opts = (
+                        MaterialsOption.query.filter(
+                            MaterialsOption.id.in_(materials_option_ids)
+                        )
+                        .order_by(MaterialsOption.id)
+                        .all()
+                    )
+                    shipment.materials_options = opts
+                else:
+                    first_id = materials_option_ids[0]
+                    shipment.materials_option_id = int(first_id) if first_id else None
+            else:
+                wt = db.session.get(WorkshopType, workshop_type_id)
+                if wt and wt.default_materials_option_id:
+                    if order_type == "KT-Run Modular materials":
+                        opt = db.session.get(
+                            MaterialsOption, wt.default_materials_option_id
+                        )
+                        if opt:
+                            shipment.materials_options = [opt]
+                    else:
+                        shipment.materials_option_id = wt.default_materials_option_id
             db.session.add(shipment)
             db.session.commit()
-            flash('Saved', 'info')
-            return redirect(url_for('materials.materials_view', session_id=sess.id))
+            flash("Saved", "info")
+            return redirect(url_for("materials_only.create"))
     clients = Client.query.order_by(Client.name).all()
     workshop_types = WorkshopType.query.order_by(WorkshopType.name).all()
-    return render_template('materials_only.html', clients=clients, workshop_types=workshop_types)
+    shipping_locations = (
+        ClientShippingLocation.query.filter_by(is_active=True)
+        .order_by(ClientShippingLocation.client_id)
+        .all()
+    )
+    return render_template(
+        "materials_only.html",
+        clients=clients,
+        workshop_types=workshop_types,
+        regions=get_region_options(),
+        languages=get_language_options(),
+        order_types=ORDER_TYPES,
+        material_formats=material_format_choices(),
+        physical_components=PHYSICAL_COMPONENTS,
+        shipping_locations=shipping_locations,
+    )

--- a/app/templates/materials_only.html
+++ b/app/templates/materials_only.html
@@ -3,26 +3,192 @@
 {% block content %}
 <h1>Material Only Order</h1>
 <form method="post">
-  <div><label>Title <input type="text" name="title" required></label></div>
-  <div><label>Client
-    <select name="client_id" required>
-      <option value=""></option>
-      {% for c in clients %}
-        <option value="{{ c.id }}">{{ c.name }}</option>
+  <fieldset>
+    <legend>Session Info</legend>
+    <div><label>Title <input type="text" name="title" required></label></div>
+    <div><label>Client
+      <select name="client_id" id="client-select" required>
+        <option value=""></option>
+        {% for c in clients %}
+          <option value="{{ c.id }}">{{ c.name }}</option>
+        {% endfor %}
+      </select>
+    </label></div>
+    <div><label>Region
+      <select name="region" required>
+        <option value=""></option>
+        {% for code,label in regions %}
+          <option value="{{ code }}">{{ label }}</option>
+        {% endfor %}
+      </select>
+    </label></div>
+    <div><label>Language
+      <select name="language" id="lang-select" required>
+        {% for code,label in languages %}
+          <option value="{{ code }}" {% if code=='en' %}selected{% endif %}>{{ label }}</option>
+        {% endfor %}
+      </select>
+    </label></div>
+    <div><label>Workshop Type
+      <select name="workshop_type_id" id="wt-select" required>
+        <option value=""></option>
+        {% for wt in workshop_types %}
+          <option value="{{ wt.id }}" data-langs="{{ wt.supported_languages|join(' ') if wt.supported_languages else '' }}" data-sim="{{ 1 if wt.simulation_based else 0 }}" data-default-material="{{ wt.default_materials_option_id or '' }}">{{ wt.name }}</option>
+        {% endfor %}
+      </select>
+    </label></div>
+    <div>Delivery Type: Material Order</div>
+  </fieldset>
+  <fieldset>
+    <legend>Materials</legend>
+    <div><label>Shipping location
+      <select name="shipping_location_id" id="shipping-location-select">
+        <option value=""></option>
+        {% for loc in shipping_locations %}
+          <option value="{{ loc.id }}" data-client="{{ loc.client_id }}">{{ loc.display_name() }}</option>
+        {% endfor %}
+      </select>
+    </label></div>
+    <div><label>Order Type
+      <select name="order_type" data-options-url="{{ url_for('materials_only.options') }}">
+        {% for ot in order_types %}
+          <option value="{{ ot }}" {% if ot=='Client-run Bulk order' %}selected{% endif %}>{{ ot }}</option>
+        {% endfor %}
+      </select>
+    </label></div>
+    <div id="materials-type" style="display:none">Materials type:
+      <select name="materials_option_id" id="materials-option"></select>
+      <div id="materials-option-info" style="font-size:smaller"></div>
+    </div>
+    <div>
+      <label>Material format
+        <select name="materials_format" id="materials-format">
+          <option value=""></option>
+          {% for key,label in material_formats %}
+            <option value="{{ key }}">{{ label }}</option>
+          {% endfor %}
+        </select>
+      </label>
+    </div>
+    <fieldset class="components">
+      <legend>Physical components</legend>
+      {% for key,label in physical_components %}
+        <label><input type="checkbox" name="components" value="{{ key }}"> {{ label }}</label><br>
       {% endfor %}
-    </select>
-  </label></div>
-  <div><label>Region <input type="text" name="region"></label></div>
-  <div><label>Language <input type="text" name="language" value="en"></label></div>
-  <div><label>Workshop Type
-    <select name="workshop_type_id" required>
-      <option value=""></option>
-      {% for wt in workshop_types %}
-        <option value="{{ wt.id }}">{{ wt.name }}</option>
-      {% endfor %}
-    </select>
-  </label></div>
-  <div>Delivery Type: Material Order</div>
+    </fieldset>
+    <div>Latest arrival date: <input type="date" name="arrival_date"></div>
+    <div>Ship date: <input type="date" name="ship_date"></div>
+    <div>PO Number: <input type="text" name="materials_po_number"></div>
+    <div id="material-sets"><label>Material Sets <input type="number" name="material_sets" min="0" value="0"></label></div>
+    <div id="credits-field" style="display:none"><label># of credits (2 teams per credit) <input type="number" name="credits" min="0" value="2"></label></div>
+  </fieldset>
   <button type="submit">Save</button>
 </form>
+<script>
+  var langSelect = document.getElementById('lang-select');
+  var typeSelect = document.getElementById('wt-select');
+  function filterTypes(){
+    if(!langSelect || !typeSelect) return;
+    var lang = langSelect.value;
+    Array.from(typeSelect.options).forEach(function(opt){
+      if(!opt.value) return;
+      var langs = (opt.dataset.langs || '').split(' ');
+      var show = langs.indexOf(lang) !== -1;
+      opt.hidden = !show;
+      if(!show && opt.selected){ opt.selected = false; }
+    });
+    updateCreditsVisibility(orderType.value);
+  }
+  langSelect && langSelect.addEventListener('change', filterTypes);
+  var clientSelect = document.getElementById('client-select');
+  var shipSelect = document.getElementById('shipping-location-select');
+  function filterLocations(){
+    if(!clientSelect || !shipSelect) return;
+    var cid = clientSelect.value;
+    Array.from(shipSelect.options).forEach(function(opt){
+      if(!opt.value) return;
+      var show = !cid || opt.dataset.client === cid;
+      opt.hidden = !show;
+      if(!show && opt.selected){ opt.selected = false; }
+    });
+  }
+  clientSelect && clientSelect.addEventListener('change', filterLocations);
+  var orderType = document.querySelector('select[name="order_type"]');
+  var materialsDiv = document.getElementById('materials-type');
+  var materialsSelect = document.getElementById('materials-option');
+  var materialsInfo = document.getElementById('materials-option-info');
+  var defaultMaterials = {};
+  Array.from(typeSelect.options).forEach(function(opt){ defaultMaterials[opt.value] = opt.dataset.defaultMaterial || ''; });
+  function updateMaterialsInfo(){
+    if(!materialsSelect || !materialsInfo) return;
+    var labels = Array.from(materialsSelect.selectedOptions).map(o=>o.textContent);
+    materialsInfo.textContent = labels.join(', ');
+  }
+  function applyDefaultMaterial(){
+    if(materialsSelect.dataset.touched) return;
+    var wtId = typeSelect.value;
+    var def = defaultMaterials[wtId];
+    if(def){
+      var opt = Array.from(materialsSelect.options).find(o => o.value == def);
+      if(opt) opt.selected = true;
+    }
+    updateMaterialsInfo();
+  }
+  var materialSetsDiv = document.getElementById('material-sets');
+  var creditsDiv = document.getElementById('credits-field');
+  function updateCreditsVisibility(ot){
+    if(!creditsDiv) return;
+    var opt = typeSelect.options[typeSelect.selectedIndex];
+    var isSimType = opt && opt.dataset.sim === '1';
+    var show = (ot === 'Simulation') || isSimType;
+    creditsDiv.style.display = show ? 'block' : 'none';
+  }
+  function toggleExtras(ot){
+    if(materialSetsDiv){ materialSetsDiv.style.display = (ot === 'Simulation') ? 'none' : 'block'; }
+    updateCreditsVisibility(ot);
+  }
+  function loadOptions(ot){
+    if(!materialsSelect) return;
+    materialsSelect.innerHTML = '';
+    materialsSelect.multiple = (ot === 'KT-Run Modular materials');
+    if(ot !== 'KT-Run Modular materials'){
+      var empty = document.createElement('option'); empty.value=''; materialsSelect.appendChild(empty);
+    }
+    fetch(orderType.dataset.optionsUrl + '?order_type=' + encodeURIComponent(ot))
+      .then(r => r.json())
+      .then(data => {
+        data.options.forEach(function(opt){
+          var o = document.createElement('option');
+          o.value = opt.id; o.textContent = opt.title;
+          materialsSelect.appendChild(o);
+        });
+        if(materialsDiv){ materialsDiv.style.display = ot ? 'block' : 'none'; }
+        applyDefaultMaterial();
+        updateMaterialsInfo();
+      });
+    toggleExtras(ot);
+  }
+  materialsSelect && materialsSelect.addEventListener('change', function(){ this.dataset.touched='1'; updateMaterialsInfo(); });
+  typeSelect && typeSelect.addEventListener('change', function(){ applyDefaultMaterial(); updateCreditsVisibility(orderType.value); });
+  orderType && orderType.addEventListener('change', function(){ loadOptions(this.value); });
+  var fmtSel = document.getElementById('materials-format');
+  var boxes = Array.from(document.querySelectorAll('input[name="components"]'));
+  function applyComponentState(){
+    var fmt = fmtSel.value;
+    var disable = (fmt === 'ALL_DIGITAL' || fmt === 'SIM_ONLY');
+    boxes.forEach(b => { b.disabled = disable; if(disable){ b.checked = false; } });
+    if(fmt === 'ALL_PHYSICAL') boxes.forEach(b => b.checked = true);
+  }
+  function applyAutoFormat(){
+    if(orderType.value === 'Simulation' && !fmtSel.value){ fmtSel.value = 'SIM_ONLY'; }
+    applyComponentState();
+  }
+  fmtSel && fmtSel.addEventListener('change', applyComponentState);
+  orderType && orderType.addEventListener('change', applyAutoFormat);
+  filterTypes();
+  filterLocations();
+  loadOptions(orderType.value);
+  applyAutoFormat();
+  updateCreditsVisibility(orderType.value);
+</script>
 {% endblock %}

--- a/app/utils/regions.py
+++ b/app/utils/regions.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from typing import List, Tuple
+
+# Mapping of region codes to human-readable names
+REGION_CODE_NAMES: dict[str, str] = {
+    "NA": "North America",
+    "EU": "Europe",
+    "SEA": "Southeast Asia",
+    "Other": "Other",
+}
+
+NAME_TO_CODE = {v: k for k, v in REGION_CODE_NAMES.items()}
+
+
+def get_region_options() -> List[Tuple[str, str]]:
+    """Return region code/name pairs in display order."""
+    order = ["NA", "EU", "SEA", "Other"]
+    return [(code, REGION_CODE_NAMES[code]) for code in order]
+
+
+def code_to_label(code: str) -> str:
+    """Return human-readable region name for a code."""
+    return REGION_CODE_NAMES.get(code, code)


### PR DESCRIPTION
## Summary
- add central region code->label mapping
- replace Material Only Order text inputs with region and language selects
- render full materials order form on initial page load with language-driven workshop type filtering

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c0543f04d0832eb33039162faad6be