### PR TITLE
Serve KT theme via static kt.css and secure sitemap

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -353,6 +353,8 @@ Two separate tables by design; emails unique per table. If both tables hold the 
 
 # 15. KT Theme & Sitemap
 
+KT theme stylesheet is served from Flask static (`/static/kt.css`) and linked in `app/templates/base.html` after existing styles; do not remove prior CSS. Sitemap is admin-only.
+
 ## 15.1 Theme tokens
 
 CSS tokens live in `app/static/css/kt-theme.css` and are included via `app/templates/base.html`.

--- a/app/routes/settings_sitemap.py
+++ b/app/routes/settings_sitemap.py
@@ -157,5 +157,6 @@ def write_snapshot() -> Response:
 
 @bp.get("/snapshot")
 def snapshot_file() -> Response:
+    _current_user()
     root = Path(current_app.root_path).parent
     return send_from_directory(root, "SITE_MAP.md", as_attachment=False)

--- a/app/static/kt.css
+++ b/app/static/kt.css
@@ -1,0 +1,111 @@
+:root {
+  --kt-blue: #0060AC;
+  --kt-blue-600: #005494;
+  --kt-lightblue: #00A2DD;
+  --kt-orange: #F6932D;
+  --kt-red: #E94737;
+  --kt-yellow: #F4E501;
+  --kt-green: #A9D168;
+  --kt-text: #111111;
+  --kt-muted: #4B5563;
+  --kt-border: #E5E7EB;
+  --kt-bg: #FFFFFF;
+  --kt-font-family: Inter, system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+}
+
+body {
+  font-family: var(--kt-font-family);
+  color: var(--kt-text);
+  background: var(--kt-bg);
+  font-size: 16px;
+}
+
+h1 { font-size: 32px; margin-bottom: 16px; }
+h2 { font-size: 24px; margin: 24px 0 12px; }
+h3 { font-size: 20px; margin: 20px 0 8px; }
+
+button, .button {
+  background: var(--kt-blue);
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+  padding: 8px 12px;
+  cursor: pointer;
+}
+
+button.secondary, .button.secondary {
+  background: var(--kt-lightblue);
+  color: var(--kt-text);
+}
+
+button:hover, .button:hover {
+  background: var(--kt-blue-600);
+}
+
+button.secondary:hover, .button.secondary:hover {
+  background: var(--kt-lightblue);
+  opacity: 0.9;
+}
+
+a {
+  color: var(--kt-blue);
+}
+
+a:hover {
+  text-decoration: underline;
+  color: var(--kt-blue-600);
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  background: var(--kt-bg);
+  margin: 16px 0;
+}
+
+th, td {
+  border: 1px solid var(--kt-border);
+  padding: 8px 12px;
+  text-align: left;
+}
+
+form {
+  background: var(--kt-bg);
+  border: 1px solid var(--kt-border);
+  padding: 16px;
+  border-radius: 6px;
+  margin: 16px 0;
+}
+
+form > div {
+  margin-bottom: 12px;
+}
+
+.sidebar a,
+.sidebar .nav-link {
+  display: block;
+  margin: 4px 0;
+  padding: 8px 12px;
+  text-decoration: none;
+  color: var(--kt-muted);
+  border-radius: 4px;
+  font-weight: 500;
+}
+
+.sidebar a:hover,
+.sidebar a.active,
+.sidebar .nav-link:hover,
+.sidebar .nav-link.active {
+  background: var(--kt-blue);
+  color: #fff;
+}
+
+.view-banner {
+  background: var(--kt-yellow);
+  padding: 8px 12px;
+  margin-bottom: 16px;
+  border: 1px solid var(--kt-border);
+}
+
+.flashes li.error { color: var(--kt-red); font-weight:700; }
+.flashes li.success { color: var(--kt-green); font-weight:600; }

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -3,6 +3,7 @@
 <head>
   <title>{% block title %}CBS{% endblock %}</title>
   <link rel="stylesheet" href="{{ url_for('static', filename='css/kt-theme.css') }}">
+  <link rel="stylesheet" href="{{ url_for('static', filename='kt.css') }}">
   {% block extra_head %}{% endblock %}
 </head>
 <body>


### PR DESCRIPTION
## Summary
- Load KT theme from new `/static/kt.css` after existing styles
- Limit sitemap snapshot to Sys Admin/Admin users only
- Document static theme file and sitemap access in CONTEXT.md

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c070ee344c832e899bba6ca8c500b0