### PR TITLE
Restore base stylesheet includes and append KT theme

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -327,6 +327,7 @@ Two separate tables by design; emails unique per table. If both tables hold the 
 - **Certificates**: generator `app/utils/certificates.py` (region→paper mapping, explicit asset path); templates under `app/assets/`
 - **Utils**: `app/utils/materials.py` (arrival logic), `app/utils/time.py`, `app/utils/acl.py`, `app/utils/languages.py` (`code_to_label` powering global `lang_label` filter)
 - **Ops CLI**: `manage.py account_dupes`
+- **Theme**: `app/static/css/kt-theme.css` appended after existing CSS in `app/templates/base.html`; new brand CSS must not remove prior includes
 
 ---
 
@@ -353,7 +354,7 @@ Two separate tables by design; emails unique per table. If both tables hold the 
 
 # 15. KT Theme & Sitemap
 
-KT theme stylesheet is served from Flask static (`/static/kt.css`) and linked in `app/templates/base.html` after existing styles; do not remove prior CSS. Sitemap is admin-only.
+KT theme stylesheet is served from Flask static (`/static/css/kt-theme.css`) and linked in `app/templates/base.html` after existing styles; do not remove prior CSS. Sitemap is admin-only.
 
 ## 15.1 Theme tokens
 

--- a/app/static/css/kt-theme.css
+++ b/app/static/css/kt-theme.css
@@ -18,38 +18,6 @@ body {
   font-family: var(--kt-font-family);
   color: var(--kt-text);
   background: var(--kt-bg);
-  display: flex;
-  min-height: 100vh;
-}
-
-.sidebar {
-  width: 220px;
-  background: var(--kt-bg);
-  border-right: 1px solid var(--kt-border);
-  padding: 16px;
-  flex-shrink: 0;
-}
-
-.sidebar a,
-.sidebar .nav-link {
-  display: block;
-  margin: 4px 0;
-  padding: 8px 12px;
-  text-decoration: none;
-  color: var(--kt-muted);
-  border-radius: 4px;
-  font-weight: 500;
-}
-
-.sidebar a:hover,
-.sidebar a.active {
-  background: var(--kt-blue);
-  color: #fff;
-}
-
-.content {
-  flex: 1;
-  padding: 16px;
 }
 
 h1 { font-size: 32px; margin-bottom: 16px; }

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -2,8 +2,8 @@
 <html>
 <head>
   <title>{% block title %}CBS{% endblock %}</title>
-  <link rel="stylesheet" href="{{ url_for('static', filename='css/kt-theme.css') }}">
   <link rel="stylesheet" href="{{ url_for('static', filename='kt.css') }}">
+  <link rel="stylesheet" href="{{ url_for('static', filename='css/kt-theme.css') }}">
   {% block extra_head %}{% endblock %}
 </head>
 <body>


### PR DESCRIPTION
## Summary
- Restore original base.html structure and previous CSS link, then append new kt-theme stylesheet
- Trim kt-theme.css to avoid layout overrides and global resets
- Document kt-theme.css path and inclusion rules in CONTEXT

## Testing
- `pytest`
- `DATABASE_URL=sqlite:// python - <<'PY'
from app.app import create_app
app = create_app()
app.config['TESTING'] = True
with app.test_client() as c:
    res = c.get('/static/css/kt-theme.css')
    print('status', res.status_code)
PY`

------
https://chatgpt.com/codex/tasks/task_e_68c0741b12e8832e8b59f8d53bb55df3