### PR TITLE
fix: restore base layout and layer KT theme

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -354,7 +354,7 @@ Two separate tables by design; emails unique per table. If both tables hold the 
 
 # 15. KT Theme & Sitemap
 
-KT theme stylesheet is served from Flask static (`/static/css/kt-theme.css`) and linked in `app/templates/base.html` after existing styles; do not remove prior CSS. Sitemap is admin-only.
+KT theme stylesheet is served from Flask static (`/static/css/kt-theme.css`) and linked in `app/templates/base.html` after existing styles; do not remove prior CSS. Base layout rules live in `/static/kt.css` (body flex, `.sidebar`, `.content`); missing these caused an unstyled left nav and pages. Brand CSS must layer on top of the existing site CSS, not replace it. Sitemap is admin-only.
 
 ## 15.1 Theme tokens
 

--- a/app/static/kt.css
+++ b/app/static/kt.css
@@ -14,10 +14,13 @@
 }
 
 body {
+  margin: 0;
   font-family: var(--kt-font-family);
   color: var(--kt-text);
   background: var(--kt-bg);
   font-size: 16px;
+  display: flex;
+  min-height: 100vh;
 }
 
 h1 { font-size: 32px; margin-bottom: 16px; }
@@ -90,6 +93,24 @@ form > div {
   color: var(--kt-muted);
   border-radius: 4px;
   font-weight: 500;
+}
+
+.sidebar {
+  width: 220px;
+  background: var(--kt-bg);
+  border-right: 1px solid var(--kt-border);
+  padding: 16px;
+  flex-shrink: 0;
+}
+
+.sidebar ul {
+  list-style: none;
+  padding-left: 0;
+}
+
+.content {
+  flex: 1;
+  padding: 16px;
 }
 
 .sidebar a:hover,


### PR DESCRIPTION
## Summary
- restore base layout rules in `kt.css` for sidebar and page structure
- document theme layering and regression cause

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c078fb4c98832e855ad15d7a1bd872