### PR TITLE
fix: load base CSS before theme across pages

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -322,6 +322,7 @@ Two separate tables by design; emails unique per table. If both tables hold the 
 - **Certificate Templates**: `app/routes/settings_cert_templates.py`, `app/templates/settings_cert_templates/*.html`
 - **Materials (dashboard & orders)**: `app/routes/materials.py`, `app/routes/materials_orders.py`, templates `app/templates/materials/*.html`, `app/templates/materials_orders.html`
 - **Material Only Order**: `app/routes/materials_only.py`, template `app/templates/materials_only.html`
+- **Settings – Password**: route `/settings/password` in `app/app.py`, template `app/templates/password.html`
 - **Users & Role Matrix**: `app/routes/users.py`, `app/templates/users/*.html` (matrix modal `app/templates/users/role_matrix.html`)
 - **Email**: `app/emailer.py`, `app/templates/email/*.html|.txt`
 - **Certificates**: generator `app/utils/certificates.py` (region→paper mapping, explicit asset path); templates under `app/assets/`
@@ -354,7 +355,7 @@ Two separate tables by design; emails unique per table. If both tables hold the 
 
 # 15. KT Theme & Sitemap
 
-KT theme stylesheet is served from Flask static (`/static/css/kt-theme.css`) and linked in `app/templates/base.html` after existing styles; do not remove prior CSS. Base layout rules live in `/static/kt.css` (body flex, `.sidebar`, `.content`); missing these caused an unstyled left nav and pages. Brand CSS must layer on top of the existing site CSS, not replace it. Sitemap is admin-only.
+KT theme stylesheet is served from Flask static (`/static/css/kt-theme.css`) and linked in `app/templates/base.html` after existing styles; do not remove prior CSS. Base layout rules live in `/static/kt.css` (body flex, `.sidebar`, `.content`); a missing file once returned 404 and left pages unstyled. Restoring `app/static/kt.css` and ensuring every template extends `base.html` makes `/static/kt.css` load before `/static/css/kt-theme.css` on all pages. Brand CSS must layer on top of the existing site CSS, not replace it. Sitemap is admin-only.
 
 `app/templates/base.html` provides a `body_class` block so pages can scope layout tweaks. A legacy standalone `login.html` bypassed the base template and was removed; the remaining login template sets `body_class="login-page"` and scopes its CSS to that class to avoid global overrides.
 

--- a/app/templates/dashboard.html
+++ b/app/templates/dashboard.html
@@ -1,9 +1,10 @@
-<!doctype html>
-<title>Dashboard</title>
+{% extends "base.html" %}
+{% block title %}Dashboard{% endblock %}
+{% block content %}
 {% with messages = get_flashed_messages() %}
   {% for message in messages %}
     <p>{{ message }}</p>
   {% endfor %}
 {% endwith %}
-{% include 'nav.html' %}
 <p>Welcome, {{ email }}</p>
+{% endblock %}

--- a/app/templates/password.html
+++ b/app/templates/password.html
@@ -1,8 +1,10 @@
-<!doctype html>
-<title>Set Password</title>
-{% include 'nav.html' %}
-{% if error %}<p>{{ error }}</p>{% endif %}
+{% extends "base.html" %}
+{% block title %}Set Password{% endblock %}
+{% block content %}
+<h1>Set Password</h1>
+{% if error %}<p class="error">{{ error }}</p>{% endif %}
 <form method="post">
-  <input type="password" name="password" placeholder="New password" required>
-  <button type="submit">Save</button>
+  <div><input type="password" name="password" placeholder="New password" required></div>
+  <div><button type="submit">Save</button></div>
 </form>
+{% endblock %}

--- a/app/templates/prework_download.html
+++ b/app/templates/prework_download.html
@@ -1,7 +1,14 @@
-<!doctype html>
-<html>
-<head><title>Prework</title></head>
-<body>
+{% extends "base.html" %}
+{% block title %}Prework{% endblock %}
+{% block body_class %}print-page{% endblock %}
+{% block extra_head %}
+<style>
+  body.print-page { justify-content:flex-start; }
+  body.print-page .sidebar { display:none; }
+  body.print-page .content { flex:1; }
+</style>
+{% endblock %}
+{% block content %}
 <h1>Prework for {{ assignment.session.title if assignment.session else '' }}</h1>
 {% for q in questions %}
 <div>
@@ -18,5 +25,4 @@
 </div>
 {% endfor %}
 <script>window.print()</script>
-</body>
-</html>
+{% endblock %}


### PR DESCRIPTION
## Summary
- extend base layout to password and prework print pages so /static/kt.css loads before KT theme
- ensure all pages inherit base.html for consistent nav and styling
- document base vs brand CSS layering and settings password location

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c07e9ba4a0832e9cc548224596a13a