### PR TITLE
Serve badges statically and fix learner certificate links

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -216,7 +216,7 @@ Two separate tables by design; emails unique per table. If both tables hold the 
   - If prework enabled → sees **Prework** for that workshop.  
   - **My Resources** hidden (unless prior workshops started).  
 - **From start → before delivered**: **My Resources** visible for that session (plus any past sessions).  
-- **After delivered/finalized**: **My Certificates** section/link appears if ≥1 cert exists.
+ - **After delivered/finalized**: **My Certificates** section/link appears if ≥1 cert exists. Certificates are listed by joining `certificates.participant_id` → `participants.id` for the signed-in account, and each link uses the stored `pdf_path` under `/certificates/<YYYY>/<session_id>/<file>.pdf`.
 
 ## 4.2 CSA (participant)
 - **My Sessions**: only sessions where this participant account is CSA; link opens participant management.  
@@ -295,6 +295,7 @@ Two separate tables by design; emails unique per table. If both tables hold the 
 - Certificates are written to `<certs_root>/<YYYY>/<session_id>/` where `<certs_root>` = `SITE_ROOT/certificates` (default `/srv/certificates`). `YYYY` uses the session start-date year; if missing, use the current year.
 - Filenames: `<workshop_type.code>_<certificate_name_slug>_<YYYY-MM-DD>.pdf`.
 - `pdf_path` stores the relative path `YYYY/session_id/filename.pdf`. Generation overwrites existing files atomically.
+- Learner page lists certificates by joining `certificates.participant_id` → `participants.id`; links render `/certificates/<pdf_path>`.
 - Download endpoint reads the stored path and serves the file; if the row or file is missing it returns `404` and logs `[CERT-MISSING]`.
 - Older builds used `YYYY/<workshop_code>/…`; these paths are legacy.
 - Maintenance CLI `purge_orphan_certs` scans the certificates root and deletes files lacking a `certificates` table row. Filenames may vary; presence is determined by DB record.
@@ -345,7 +346,7 @@ The repo is organized **feature-first**. Top-level packages:
 - `shared/` – cross-cutting concerns (see below)
 
 
-Badge images and their management UI live under `routes/settings_badges.py` with templates in `templates/settings_badges/`. Uploaded badge files are stored in `app/assets/badges` and copied to `SITE_ROOT/badges` (default `/srv/badges`) on first use so they can be served from `/badges/<slug>.<ext>`.
+Badge images and their management UI live under `routes/settings_badges.py` with templates in `templates/settings_badges/`. Uploaded badge files are stored in `app/assets/badges` and copied to `SITE_ROOT/badges` (default `/srv/badges`) on first use so they can be served from `/badges/<slug>.<ext>` by a static handle (not `handle_path`).
 
 Each feature package contains `routes/`, `models/`, `services/` (business rules), `forms/`, `templates/`, and a `README.md` noting scope and owner.
 

--- a/Caddyfile
+++ b/Caddyfile
@@ -7,7 +7,8 @@ cbs.ktapps.net {
     handle_path /certificates/* {
         file_server
     }
-    handle_path /badges/* {
+    handle /badges/* {
+        root * /srv
         file_server
     }
     @health path /healthz

--- a/app/app.py
+++ b/app/app.py
@@ -16,7 +16,7 @@ from flask import (
     abort,
 )
 from flask_sqlalchemy import SQLAlchemy
-from sqlalchemy import or_, text, func
+from sqlalchemy import or_, text, func, exists
 
 db = SQLAlchemy()
 
@@ -144,12 +144,18 @@ def create_app():
                 .first()
                 is not None
             )
+            participant_filter = (
+                Participant.account_id == account_id
+                if account_id
+                else func.lower(Participant.email) == email
+            )
             show_certificates_nav = show_certificates_nav or (
-                db.session.query(Certificate.id)
-                .join(Participant, Certificate.participant_id == Participant.id)
-                .filter(func.lower(Participant.email) == email)
-                .first()
-                is not None
+                db.session.query(
+                    exists().where(
+                        (Certificate.participant_id == Participant.id)
+                        & participant_filter
+                    )
+                ).scalar()
             )
         active_view = get_active_view(user, request, is_csa)
         nav_menu = build_menu(user, active_view, show_resources_nav, is_csa)

--- a/app/routes/learner.py
+++ b/app/routes/learner.py
@@ -292,18 +292,24 @@ def prework_download(assignment_id: int):
 @bp.get("/my-certificates")
 @login_required
 def my_certs():
-    if flask_session.get("user_id"):
-        user = db.session.get(User, flask_session.get("user_id"))
+    account_id = flask_session.get("participant_account_id")
+    user_id = flask_session.get("user_id")
+    email = ""
+    if user_id:
+        user = db.session.get(User, user_id)
         email = (user.email or "").lower()
-    else:
-        account = db.session.get(
-            ParticipantAccount, flask_session.get("participant_account_id")
-        )
+    elif account_id:
+        account = db.session.get(ParticipantAccount, account_id)
         email = (account.email or "").lower() if account else ""
+    cert_filter = (
+        Participant.account_id == account_id
+        if account_id
+        else func.lower(Participant.email) == email
+    )
     certs = (
         db.session.query(Certificate)
         .join(Participant, Certificate.participant_id == Participant.id)
-        .filter(db.func.lower(Participant.email) == email)
+        .filter(cert_filter)
         .options(joinedload(Certificate.session).joinedload(Session.workshop_type))
         .all()
     )

--- a/app/templates/my_certificates.html
+++ b/app/templates/my_certificates.html
@@ -5,16 +5,12 @@
 <ul>
 {% for c in certs %}
   <li>
-    <a href="{{ url_for('learner.download_certificate', cert_id=c.id) }}">{{ c.workshop_name }} - {{ c.workshop_date }}</a>
-    {% set badge_name = c.session.workshop_type.badge if c.session and c.session.workshop_type else None %}
-    {% if badge_name %}
-      {% set badge_url = best_badge_url(badge_name) %}
-      {% if badge_url %}
-        <a href="{{ badge_url }}" download><img src="{{ badge_url }}" alt="{{ badge_name }} badge" style="height:20px;width:auto;vertical-align:middle;"></a>
-        <a href="{{ badge_url }}" download>Badge</a>
-      {% else %}
-        Badge
-      {% endif %}
+    {{ c.workshop_name }} - {{ c.workshop_date }}
+    <a href="/certificates/{{ c.pdf_path }}" download>Certificate</a>
+    {% set badge_slug = c.session.workshop_type.badge if c.session and c.session.workshop_type else None %}
+    {% if badge_slug %}
+      <a href="/badges/{{ badge_slug }}.webp" download><img src="/badges/{{ badge_slug }}.webp" alt="{{ badge_slug }} badge" style="height:20px;width:auto;vertical-align:middle;"></a>
+      <a href="/badges/{{ badge_slug }}.webp" download>Badge</a>
     {% endif %}
   </li>
 {% endfor %}


### PR DESCRIPTION
## Summary
- Serve badge images directly from `/srv/badges` without prefix stripping in Caddy
- Join participants when querying learner certificates and expose stored `pdf_path`
- Link certificates and badges directly in learner view and document behavior

## Testing
- `pytest -m smoke`


------
https://chatgpt.com/codex/tasks/task_e_68c1a5f74770832ea7b05dff3904aed2