### PR TITLE
Fix badge chip and certificate download path

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -10,6 +10,7 @@ Every functional change must update this file **in the same PR**.
 - **Proxy**: Caddy → `app:8000`
 - **Docker Compose services**: `cbs-app-1`, `cbs-db-1`, `cbs-caddy-1`
 - **In-container paths**: code at `/app/app/...`; site mount at `/srv` (host `./site`)
+- **Static/badge assets**: Caddy serves `/static` and `/badges` directly from `SITE_ROOT` (config via `SITE_ROOT` env var); certificate downloads use app route `/certificates/<cert_id>`. Badge URLs come from `WorkshopType.badge` → `BadgeImage.filename` and copy to `SITE_ROOT/badges` on demand.
 - **Health**: `GET /healthz` must respond `OK`
 - **Language seeding**: optional `SEED_LANGUAGES=1` at boot inserts the default language set when the table is empty. Idempotent and safe — if languages exist it logs `Languages already present — skipping.`; on insert it logs `Seeded N languages.`; errors log `Language seed failed: <err>`.
 
@@ -295,7 +296,7 @@ Two separate tables by design; emails unique per table. If both tables hold the 
 - Certificates are written to `<certs_root>/<YYYY>/<session_id>/` where `<certs_root>` = `SITE_ROOT/certificates` (default `/srv/certificates`). `YYYY` uses the session start-date year; if missing, use the current year.
 - Filenames: `<workshop_type.code>_<certificate_name_slug>_<YYYY-MM-DD>.pdf`.
 - `pdf_path` stores the relative path `YYYY/session_id/filename.pdf`. Generation overwrites existing files atomically.
-- Download endpoint reads the stored path and serves the file; if the row or file is missing it returns `404` and logs `[CERT-MISSING]`.
+- Downloads are served by `/certificates/<cert_id>` after permission checks; Caddy must proxy this path to the app. The route resolves both relative and absolute `pdf_path` values; missing rows or files return `404` and log `[CERT-MISSING]`.
 - Older builds used `YYYY/<workshop_code>/…`; these paths are legacy.
 - Maintenance CLI `purge_orphan_certs` scans the certificates root and deletes files lacking a `certificates` table row. Filenames may vary; presence is determined by DB record.
 - `--dry-run` lists candidate paths and a summary without deleting.

--- a/Caddyfile
+++ b/Caddyfile
@@ -1,13 +1,10 @@
 cbs.ktapps.net {
     encode zstd gzip
-    root * /srv
-    handle_path /static/* {
+    root * {$SITE_ROOT}
+    handle /static/* {
         file_server
     }
-    handle_path /certificates/* {
-        file_server
-    }
-    handle_path /badges/* {
+    handle /badges/* {
         file_server
     }
     @health path /healthz

--- a/app/app.py
+++ b/app/app.py
@@ -83,7 +83,6 @@ def create_app():
 
         site_root = app.config.get("SITE_ROOT", "/srv")
         site_dir = os.path.join(site_root, "badges")
-        site_dir = "/srv/badges"
         asset_dir = os.path.join(app.root_path, "assets", "badges")
         site_path = os.path.join(site_dir, filename)
         if os.path.isfile(site_path):

--- a/app/routes/learner.py
+++ b/app/routes/learner.py
@@ -428,11 +428,20 @@ def download_certificate(cert_id: int):
         abort(403)
     site_root = current_app.config.get("SITE_ROOT", "/srv")
     cert_root = os.path.join(site_root, "certificates")
-    rel_path = (cert.pdf_path or "").lstrip("/")
-    if rel_path.startswith("certificates/"):
-        rel_path = rel_path.split("/", 1)[1]
-    full_path = os.path.join(cert_root, rel_path)
+    pdf_path = cert.pdf_path or ""
+    if os.path.isabs(pdf_path):
+        full_path = pdf_path
+    else:
+        rel_path = pdf_path.lstrip("/")
+        if rel_path.startswith("certificates/"):
+            rel_path = rel_path.split("/", 1)[1]
+        full_path = os.path.join(cert_root, rel_path)
     if not os.path.isfile(full_path):
         current_app.logger.warning("[CERT-MISSING] id=%s path=%s", cert.id, full_path)
         abort(404)
-    return send_file(full_path, as_attachment=True, mimetype="application/pdf")
+    return send_file(
+        full_path,
+        as_attachment=True,
+        mimetype="application/pdf",
+        download_name=os.path.basename(full_path),
+    )

--- a/app/shared/badges.py
+++ b/app/shared/badges.py
@@ -5,6 +5,10 @@ import shutil
 
 
 from flask import current_app, url_for
+from sqlalchemy import func
+
+from ..models import BadgeImage
+
 
 def slug_for_badge(name: str) -> str:
     return (name or "").replace(" ", "").lower()
@@ -13,27 +17,38 @@ def slug_for_badge(name: str) -> str:
 def best_badge_url(name: str | None) -> str | None:
     if not name:
         return None
-    slug = slug_for_badge(name)
-    if not slug:
-        return None
 
     site_root = current_app.config.get("SITE_ROOT", "/srv")
     site_dir = os.path.join(site_root, "badges")
     asset_dir = os.path.join(current_app.root_path, "assets", "badges")
     os.makedirs(site_dir, exist_ok=True)
-    for ext in ("webp", "png"):
-        filename = f"{slug}.{ext}"
-        site_path = os.path.join(site_dir, filename)
-        asset_path = os.path.join(asset_dir, filename)
-        if os.path.isfile(site_path):
 
+    filename = None
+    badge = BadgeImage.query.filter(func.lower(BadgeImage.name) == name.lower()).first()
+    if badge:
+        filename = badge.filename
+
+    candidates: list[str]
+    if filename:
+        candidates = [filename]
+    else:
+        slug = slug_for_badge(name)
+        if not slug:
+            return None
+        candidates = [f"{slug}.webp", f"{slug}.png"]
+
+    for fn in candidates:
+        site_path = os.path.join(site_dir, fn)
+        asset_path = os.path.join(asset_dir, fn)
+        slug = os.path.splitext(fn)[0]
+        ext = os.path.splitext(fn)[1][1:]
+        if os.path.isfile(site_path):
             return url_for("badge_file", slug=slug, ext=ext)
         if os.path.isfile(asset_path):
             try:
                 shutil.copyfile(asset_path, site_path)
             except OSError:
                 pass
-
             return url_for("badge_file", slug=slug, ext=ext)
 
     return None

--- a/app/templates/my_certificates.html
+++ b/app/templates/my_certificates.html
@@ -10,10 +10,12 @@
     {% if badge_name %}
       {% set badge_url = best_badge_url(badge_name) %}
       {% if badge_url %}
-        <a href="{{ badge_url }}" download><img src="{{ badge_url }}" alt="{{ badge_name }} badge" style="height:20px;width:auto;vertical-align:middle;"></a>
-        <a href="{{ badge_url }}" download>Badge</a>
+        <a href="{{ badge_url }}" download style="display:inline-flex;align-items:center;gap:4px;">
+          <img src="{{ badge_url }}" alt="{{ badge_name }}" style="height:20px;width:auto;vertical-align:middle;">
+          {{ badge_name }}
+        </a>
       {% else %}
-        Badge
+        {{ badge_name }}
       {% endif %}
     {% endif %}
   </li>

--- a/app/templates/session_detail.html
+++ b/app/templates/session_detail.html
@@ -111,13 +111,15 @@
           {% if badge_name %}
             {% set badge_url = best_badge_url(badge_name) %}
             {% if badge_url %}
-              <img src="{{ badge_url }}" alt="{{ badge_name }} badge" style="height:20px;width:auto;vertical-align:middle;">
-              <a href="{{ badge_url }}" download>Badge</a>
+              <a href="{{ badge_url }}" download style="display:inline-flex;align-items:center;gap:4px;">
+                <img src="{{ badge_url }}" alt="{{ badge_name }}" style="height:20px;width:auto;vertical-align:middle;">
+                {{ badge_name }}
+              </a>
             {% else %}
-              Badge
+              {{ badge_name }}
             {% endif %}
           {% endif %}
-          {% set cert_url = '/certificates/' + row.certificate.pdf_path %}
+          {% set cert_url = url_for('learner.download_certificate', cert_id=row.certificate.id) %}
           <a href="{{ cert_url }}" download>Certificate</a>
         {% endif %}
       </td>
@@ -178,13 +180,15 @@
           {% if badge_name %}
             {% set badge_url = best_badge_url(badge_name) %}
             {% if badge_url %}
-              <img src="{{ badge_url }}" alt="{{ badge_name }} badge" style="height:20px;width:auto;vertical-align:middle;">
-              <a href="{{ badge_url }}" download>Badge</a>
+              <a href="{{ badge_url }}" download style="display:inline-flex;align-items:center;gap:4px;">
+                <img src="{{ badge_url }}" alt="{{ badge_name }}" style="height:20px;width:auto;vertical-align:middle;">
+                {{ badge_name }}
+              </a>
             {% else %}
-              Badge
+              {{ badge_name }}
             {% endif %}
           {% endif %}
-          {% set cert_url = '/certificates/' + row.certificate.pdf_path %}
+          {% set cert_url = url_for('learner.download_certificate', cert_id=row.certificate.id) %}
           <a href="{{ cert_url }}" download>Certificate</a>
         {% endif %}
       </td>

--- a/tests/test_badges.py
+++ b/tests/test_badges.py
@@ -6,6 +6,7 @@ sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from app.app import create_app, db
 from app.shared.badges import best_badge_url
+from app.models import BadgeImage
 
 
 @pytest.fixture
@@ -51,3 +52,15 @@ def test_best_badge_respects_site_root(tmp_path, monkeypatch):
             assert url == "/badges/foundations.webp"
     assert (tmp_path / "badges" / "foundations.webp").is_file()
 
+
+def test_badge_lookup_via_badge_image(app):
+    with app.app_context():
+        db.session.add(
+            BadgeImage(
+                name="Foundations badge", language="en", filename="foundations.webp"
+            )
+        )
+        db.session.commit()
+        with app.test_request_context():
+            url = best_badge_url("Foundations badge")
+            assert url == "/badges/foundations.webp"


### PR DESCRIPTION
## Summary
- point Caddy's root to `$SITE_ROOT` so badge/static URLs aren't truncated
- resolve certificate downloads for both relative and absolute `pdf_path` values and supply the real filename
- render badge chips with image and label on session detail and My Certificates pages

## Testing
- `PYTHONPATH=. pytest tests/test_badges.py tests/test_certificates_flow.py::test_badge_image_and_label tests/test_certificates_flow.py::test_badge_label_without_image tests/test_certificates_flow.py::test_download_success_and_missing_file tests/test_certificates_flow.py::test_download_absolute_path -q`

------
https://chatgpt.com/codex/tasks/task_e_68c1b35ab318832ea8f7eac30618b6fd