### PR TITLE
Add admin-only Badges placeholder in Settings

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -81,7 +81,7 @@ Every functional change must update this file **in the same PR**.
 
 - **Sys Admin** (default view: Admin)
   `Home • My Sessions • Training Sessions • Material Only Order • Material Dashboard • Surveys • My Resources • Settings ▾ • My Profile • Logout`
-  **Settings ▾**: `Users • Certificate Templates • Workshop Types • Resources • Simulation Outlines`
+  **Settings ▾**: `Users • Certificate Templates • Badges • Workshop Types • Resources • Simulation Outlines`
 
 - **Admin** (default view: Admin)  
   Same as Sys Admin. (System-wide toggles reserved for Sys Admin if any.)
@@ -124,6 +124,8 @@ Every functional change must update this file **in the same PR**.
 |-------------------------------------------------------|:-------:|:-----:|:---:|:--------:|:----------:|:---------------------------------:|:--------------------------:|
 | Settings – System settings                            |   ✓     |   –   |  –  |    –     |     –      |                –                  |            –               |
 | Settings – Certificate Templates                      |   ✓     |   ✓   |  –  |    –     |     –      |                –                  |            –               |
+| Settings – Badges (placeholder)                       |   ✓     |   ✓   |  –  |    –     |     –      |                –
+            |            –               |
 | Settings – Languages / Workshop Types / Matrix        |   ✓     |   ✓   |  –  |    –     |     –      |                –                  |            –               |
 | Users – Create/Edit/Disable                           |   ✓     |   ✓   |  –  |    –     |     –      |                –                  |            –               |
 | Users – Toggle SysAdmin                               |   ✓     |   –   |  –  |    –     |     –      |                –                  |            –               |

--- a/FUNCTIONALITY_MAP.txt
+++ b/FUNCTIONALITY_MAP.txt
@@ -38,7 +38,7 @@ Routes and Code Pages
 
 - **Settings → Mail Settings** – SMTP configuration and test send. File: `app/routes/settings_mail.py`. Requires `app_admin_required`【F:app/routes/settings_mail.py†L14-L50】
 
-- **Settings → Badges** – Manage badge images. File: `app/routes/settings_badges.py`. Requires `admin_required`【F:app/routes/settings_badges.py†L41-L64】
+- **Settings → Badges** – Placeholder for badge management. File: `app/routes/settings_badges.py`. Requires `admin_required`【F:app/routes/settings_badges.py†L1-L11】
 
 - **Settings → Resources** – Manage downloadable/linked resources. File: `app/routes/settings_resources.py`. `_current_user` allows App Admin/Admin/Delivery/Facilitator/Contractor view; editing limited to App Admin/Admin/Delivery【F:app/routes/settings_resources.py†L26-L44】【F:app/routes/settings_resources.py†L61-L79】
 

--- a/app/app.py
+++ b/app/app.py
@@ -359,6 +359,7 @@ def create_app():
     from .routes.settings_resources import bp as settings_resources_bp
     from .routes.settings_roles import bp as settings_roles_bp
     from .routes.settings_cert_templates import bp as settings_cert_templates_bp
+    from .routes.settings_badges import bp as settings_badges_bp
 
     app.register_blueprint(auth_bp)
     app.register_blueprint(settings_mail_bp)
@@ -380,6 +381,7 @@ def create_app():
     app.register_blueprint(settings_resources_bp)
     app.register_blueprint(settings_roles_bp)
     app.register_blueprint(settings_cert_templates_bp)
+    app.register_blueprint(settings_badges_bp)
 
     @app.get("/surveys")
     def surveys():

--- a/app/routes/settings_badges.py
+++ b/app/routes/settings_badges.py
@@ -1,0 +1,11 @@
+from flask import Blueprint, render_template
+
+from ..shared.rbac import admin_required
+
+bp = Blueprint('settings_badges', __name__, url_prefix='/settings/badges')
+
+
+@bp.get('/')
+@admin_required
+def placeholder(current_user):
+    return render_template('settings_badges/placeholder.html')

--- a/app/shared/nav.py
+++ b/app/shared/nav.py
@@ -55,6 +55,7 @@ def _staff_base_menu(user, show_resources: bool) -> List[MenuItem]:
         settings_children.extend([
             {'id': 'users', 'label': 'Users', 'endpoint': 'users.list_users'},
             {'id': 'certificate_templates', 'label': 'Certificate Templates', 'endpoint': 'settings_cert_templates.list_series'},
+            {'id': 'badges', 'label': 'Badges', 'endpoint': 'settings_badges.placeholder'},
             {'id': 'mail', 'label': 'Mail Settings', 'endpoint': 'settings_mail.settings'},
         ])
     if settings_children:

--- a/app/templates/settings_badges/placeholder.html
+++ b/app/templates/settings_badges/placeholder.html
@@ -1,0 +1,6 @@
+{% extends 'base.html' %}
+{% block title %}Badges{% endblock %}
+{% block content %}
+<h1>Badges (placeholder)</h1>
+<p>Badge management coming soon.</p>
+{% endblock %}

--- a/sitemap.txt
+++ b/sitemap.txt
@@ -27,6 +27,7 @@
   /settings/materials    – Materials Options (by order_type; languages, formats)
   /settings/languages    – Languages list (active, sort)
   /settings/mail         – SMTP + From mapping + test send
+  /settings/badges       – Badge management (placeholder)
   /settings/resources    – Manage resources (name, type, link/file, workshop types)
 
 # Badges & cert files

--- a/tests/test_settings_badges.py
+++ b/tests/test_settings_badges.py
@@ -1,0 +1,46 @@
+import os
+import pytest
+
+from app.app import create_app, db
+from app.models import User
+
+
+@pytest.fixture
+def app():
+    os.environ["DATABASE_URL"] = "sqlite:///:memory:"
+    os.makedirs("/srv", exist_ok=True)
+    app = create_app()
+    with app.app_context():
+        db.create_all()
+        yield app
+        db.session.remove()
+
+
+def login(client, user_id):
+    with client.session_transaction() as sess:
+        sess["user_id"] = user_id
+
+
+def test_badges_admin_access(app):
+    with app.app_context():
+        admin = User(email="admin@example.com", is_admin=True)
+        db.session.add(admin)
+        db.session.commit()
+        admin_id = admin.id
+    client = app.test_client()
+    login(client, admin_id)
+    resp = client.get("/settings/badges")
+    assert resp.status_code == 200
+    assert b"Badges (placeholder)" in resp.data
+
+
+def test_badges_blocked_for_crm(app):
+    with app.app_context():
+        crm = User(email="crm@example.com", is_kcrm=True)
+        db.session.add(crm)
+        db.session.commit()
+        crm_id = crm.id
+    client = app.test_client()
+    login(client, crm_id)
+    resp = client.get("/settings/badges")
+    assert resp.status_code == 403


### PR DESCRIPTION
## Summary
- add Settings → Badges nav item and placeholder page limited to Sys Admin/Admin
- document new Badges section and update sitemap and functionality map
- test that only admins can access /settings/badges

## Testing
- `pytest -q -m smoke`


------
https://chatgpt.com/codex/tasks/task_e_68c1bf622200832ead006fc2a5ba6a1a