### PR TITLE
Add bulk upload for certificate templates and badges

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -292,6 +292,7 @@ Two separate tables by design; emails unique per table. If both tables hold the 
 # 8. Certificates
 
 - Issued post-delivery. Templates are configured under **Settings → Certificate Templates**, where admins define series and map (language, A4/Letter) → PDF and optional badge **filename**. Workshop Types must select one active series and no longer store any badge value. Generation resolves the mapping for the session's type series and language/size; badges reference files under `app/assets/badges`. If any mapping or file is missing, rendering aborts with a clear error (no auto-fallback).
+- The template-mapping page offers bulk upload buttons for certificate template PDFs and badge WEBP files. Uploads overwrite by filename, refresh dropdown options, and never auto-change existing mappings. Badge uploads also copy files to the site root (`/srv/badges`) for static serving. Access is restricted to Sys Admin/Admin.
 - Paper size derives from session Region (North America → Letter; others → A4).
 - Name line: Y=145 mm; italic; auto-shrink 48→32; centered. On **Letter**, the recipient Name text box is narrowed by **2.5 cm** on the left and **2.5 cm** on the right (total horizontal reduction = 5.0 cm).
 - Certificates are written to `<certs_root>/<YYYY>/<session_id>/` where `<certs_root>` = `SITE_ROOT/certificates` (default `/srv/certificates`). `YYYY` uses the session start-date year; if missing, use the current year.

--- a/FUNCTIONALITY_MAP.txt
+++ b/FUNCTIONALITY_MAP.txt
@@ -34,7 +34,7 @@ Routes and Code Pages
 
 - **Settings → Materials Options** – Configure materials choices. File: `app/routes/settings_materials.py`. Requires `admin_required`【F:app/routes/settings_materials.py†L27-L65】
 
-- **Settings → Certificate Templates** – Configure certificate series, template PDFs, and badge filenames per language. File: `app/routes/settings_cert_templates.py`. Requires `manage_users_required`【F:app/routes/settings_cert_templates.py†L14-L29】
+- **Settings → Certificate Templates** – Configure certificate series, template PDFs, badge filenames, and bulk upload template PDFs or badge WEBPs. File: `app/routes/settings_cert_templates.py`. Requires `manage_users_required`【F:app/routes/settings_cert_templates.py†L14-L29】
 
 - **Settings → Mail Settings** – SMTP configuration and test send. File: `app/routes/settings_mail.py`. Requires `app_admin_required`【F:app/routes/settings_mail.py†L14-L50】
 

--- a/app/routes/settings_cert_templates.py
+++ b/app/routes/settings_cert_templates.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import shutil
 from flask import (
     Blueprint,
     abort,
@@ -11,6 +12,7 @@ from flask import (
     url_for,
     current_app,
 )
+from werkzeug.utils import secure_filename
 
 from ..app import db
 from ..models import CertificateTemplateSeries, CertificateTemplate
@@ -119,6 +121,91 @@ def edit_templates(series_id: int, current_user):
         badges=badges,
         badge_mapping=badge_mapping,
     )
+
+
+@bp.post("/<int:series_id>/upload-pdfs")
+@manage_users_required
+def upload_pdfs(series_id: int, current_user):
+    series = db.session.get(CertificateTemplateSeries, series_id)
+    if not series:
+        abort(404)
+    files = request.files.getlist("files")
+    assets_dir = os.path.join(current_app.root_path, "assets")
+    os.makedirs(assets_dir, exist_ok=True)
+    max_size = 10 * 1024 * 1024
+    uploaded = replaced = skipped = 0
+    for f in files:
+        filename = secure_filename(f.filename or "")
+        if not filename.lower().endswith(".pdf"):
+            skipped += 1
+            flash(f"Skipped {f.filename}: invalid file type", "error")
+            continue
+        f.stream.seek(0, os.SEEK_END)
+        size = f.stream.tell()
+        f.stream.seek(0)
+        if size > max_size:
+            skipped += 1
+            flash(f"Skipped {filename}: file too large", "error")
+            continue
+        dest = os.path.join(assets_dir, filename)
+        action = "replaced" if os.path.exists(dest) else "uploaded"
+        f.save(dest)
+        current_app.logger.info(
+            "[TEMPLATE-PDF-UPLOAD] user=%s file=%s action=%s",
+            getattr(current_user, "email", ""),
+            filename,
+            action,
+        )
+        if action == "replaced":
+            replaced += 1
+        else:
+            uploaded += 1
+    flash(f"Uploaded {uploaded}, replaced {replaced}, skipped {skipped}.", "success")
+    return redirect(url_for("settings_cert_templates.edit_templates", series_id=series.id))
+
+
+@bp.post("/<int:series_id>/upload-badges")
+@manage_users_required
+def upload_badges(series_id: int, current_user):
+    series = db.session.get(CertificateTemplateSeries, series_id)
+    if not series:
+        abort(404)
+    files = request.files.getlist("files")
+    badge_dir = os.path.join(current_app.root_path, "assets", "badges")
+    site_dir = os.path.join(current_app.config.get("SITE_ROOT", "/srv"), "badges")
+    os.makedirs(badge_dir, exist_ok=True)
+    os.makedirs(site_dir, exist_ok=True)
+    max_size = 5 * 1024 * 1024
+    uploaded = replaced = skipped = 0
+    for f in files:
+        filename = secure_filename(f.filename or "")
+        if not filename.lower().endswith(".webp"):
+            skipped += 1
+            flash(f"Skipped {f.filename}: invalid file type", "error")
+            continue
+        f.stream.seek(0, os.SEEK_END)
+        size = f.stream.tell()
+        f.stream.seek(0)
+        if size > max_size:
+            skipped += 1
+            flash(f"Skipped {filename}: file too large", "error")
+            continue
+        dest = os.path.join(badge_dir, filename)
+        action = "replaced" if os.path.exists(dest) else "uploaded"
+        f.save(dest)
+        shutil.copy2(dest, os.path.join(site_dir, filename))
+        current_app.logger.info(
+            "[BADGE-UPLOAD] user=%s file=%s action=%s",
+            getattr(current_user, "email", ""),
+            filename,
+            action,
+        )
+        if action == "replaced":
+            replaced += 1
+        else:
+            uploaded += 1
+    flash(f"Uploaded {uploaded}, replaced {replaced}, skipped {skipped}.", "success")
+    return redirect(url_for("settings_cert_templates.edit_templates", series_id=series.id))
 
 
 @bp.post("/<int:series_id>/templates")

--- a/app/templates/settings_cert_templates/templates.html
+++ b/app/templates/settings_cert_templates/templates.html
@@ -2,6 +2,16 @@
 {% block title %}Template Mapping{% endblock %}
 {% block content %}
 <h1>Template Mapping for {{ series.name }} ({{ series.code }})</h1>
+<div style="margin-bottom: 1em;">
+  <form method="post" action="{{ url_for('settings_cert_templates.upload_pdfs', series_id=series.id) }}" enctype="multipart/form-data" style="display:inline;">
+    <input type="file" id="pdf_files" name="files" accept=".pdf" multiple style="display:none" onchange="this.form.submit()">
+    <button type="button" onclick="document.getElementById('pdf_files').click()">Upload certificate templates (PDFs)</button>
+  </form>
+  <form method="post" action="{{ url_for('settings_cert_templates.upload_badges', series_id=series.id) }}" enctype="multipart/form-data" style="display:inline; margin-left: 0.5em;">
+    <input type="file" id="badge_files" name="files" accept=".webp" multiple style="display:none" onchange="this.form.submit()">
+    <button type="button" onclick="document.getElementById('badge_files').click()">Upload badges (WEBP)</button>
+  </form>
+</div>
 <form method="post">
   <table border="1" cellpadding="4" cellspacing="0">
     <tr><th>Language</th><th>A4</th><th>Letter</th><th>Badge</th></tr>

--- a/sitemap.txt
+++ b/sitemap.txt
@@ -18,7 +18,9 @@
 # Settings (Admin/SysAdmin)
 /settings                – Landing (cards/links)
   /settings/users        – Manage staff accounts & roles
-  /settings/cert-templates – Certificate template series and mappings (PDFs, badge filenames)
+  /settings/cert-templates – Certificate template series and mappings (PDFs, badge filenames, bulk uploads)
+    /settings/cert-templates/<series_id>/upload-pdfs – Upload certificate template PDFs
+    /settings/cert-templates/<series_id>/upload-badges – Upload badge WEBPs
   /settings/workshop-types – CRUD workshop types
   /settings/clients      – Clients list
   /settings/clients/<id>/edit

--- a/tests/test_cert_template_bulk_uploads.py
+++ b/tests/test_cert_template_bulk_uploads.py
@@ -1,0 +1,89 @@
+import os
+from io import BytesIO
+
+import pytest
+
+from app.app import create_app, db
+from app.models import CertificateTemplateSeries, Language, User
+
+
+@pytest.fixture
+def app():
+    os.environ["DATABASE_URL"] = "sqlite:///:memory:"
+    os.makedirs("/srv", exist_ok=True)
+    app = create_app()
+    with app.app_context():
+        db.create_all()
+        yield app
+        db.session.remove()
+
+
+def login(client, user_id):
+    with client.session_transaction() as sess:
+        sess["user_id"] = user_id
+
+
+@pytest.mark.smoke
+def test_upload_cert_template_pdfs(app):
+    with app.app_context():
+        lang = Language(name="English", sort_order=1)
+        series = CertificateTemplateSeries(code="SER", name="Series")
+        admin = User(email="admin@example.com", is_admin=True)
+        db.session.add_all([lang, series, admin])
+        db.session.commit()
+        series_id = series.id
+        admin_id = admin.id
+
+    client = app.test_client()
+    login(client, admin_id)
+    data = {
+        "files": [
+            (BytesIO(b"PDF1"), "file1.pdf"),
+            (BytesIO(b"PDF2"), "file2.pdf"),
+        ]
+    }
+    resp = client.post(
+        f"/settings/cert-templates/{series_id}/upload-pdfs",
+        data=data,
+        content_type="multipart/form-data",
+        follow_redirects=True,
+    )
+    assert resp.status_code == 200
+    assets_dir = os.path.join(app.root_path, "assets")
+    assert os.path.isfile(os.path.join(assets_dir, "file1.pdf"))
+    assert os.path.isfile(os.path.join(assets_dir, "file2.pdf"))
+    resp = client.get(f"/settings/cert-templates/{series_id}/templates")
+    html = resp.data.decode()
+    assert "file1.pdf" in html
+    assert "file2.pdf" in html
+
+
+@pytest.mark.smoke
+def test_upload_badge_webps(app):
+    with app.app_context():
+        lang = Language(name="English", sort_order=1)
+        series = CertificateTemplateSeries(code="SER", name="Series")
+        admin = User(email="admin@example.com", is_admin=True)
+        db.session.add_all([lang, series, admin])
+        db.session.commit()
+        series_id = series.id
+        admin_id = admin.id
+
+    client = app.test_client()
+    login(client, admin_id)
+    data = {"files": [(BytesIO(b"WEBP"), "newbadge.webp")]}
+    resp = client.post(
+        f"/settings/cert-templates/{series_id}/upload-badges",
+        data=data,
+        content_type="multipart/form-data",
+        follow_redirects=True,
+    )
+    assert resp.status_code == 200
+    badge_path = os.path.join(app.root_path, "assets", "badges", "newbadge.webp")
+    site_path = os.path.join(app.config["SITE_ROOT"], "badges", "newbadge.webp")
+    assert os.path.isfile(badge_path)
+    assert os.path.isfile(site_path)
+    resp = client.get("/badges/newbadge.webp")
+    assert resp.status_code == 200
+    resp = client.get(f"/settings/cert-templates/{series_id}/templates")
+    assert b"newbadge.webp" in resp.data


### PR DESCRIPTION
## Summary
- add PDF and WEBP bulk upload endpoints for certificate template mapping
- expose upload buttons on template mapping page
- document certificate template/badge uploads and add tests

## Testing
- `PYTHONWARNINGS=ignore pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c1ed562974832ea9d89ec3282299df