### PR TITLE
Use pdf_path for session certificate links

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -299,6 +299,7 @@ Two separate tables by design; emails unique per table. If both tables hold the 
 - Filenames: `<workshop_type.code>_<certificate_name_slug>_<YYYY-MM-DD>.pdf`.
 - `pdf_path` stores the relative path `YYYY/session_id/filename.pdf`. Generation overwrites existing files atomically.
 - Download endpoint reads the stored path and serves the file; if the row or file is missing it returns `404` and logs `[CERT-MISSING]`.
+- Staff session detail pages link directly to `/certificates/<pdf_path>` for each participant's certificate (no id-based proxy).
 - Older builds used `YYYY/<workshop_code>/…`; these paths are legacy.
 - Maintenance CLI `purge_orphan_certs` scans the certificates root and deletes files lacking a `certificates` table row. Filenames may vary; presence is determined by DB record.
 - `--dry-run` lists candidate paths and a summary without deleting.

--- a/app/templates/session_detail.html
+++ b/app/templates/session_detail.html
@@ -112,7 +112,7 @@
             <a href="{{ badge_url }}" download><img src="{{ badge_url }}" alt="badge" style="height:20px;width:auto;vertical-align:middle;"></a>
             <a href="{{ badge_url }}" download>Badge</a>
           {% endif %}
-          <a href="{{ url_for('learner.download_certificate', cert_id=row.certificate.id) }}">Download Certificate</a>
+          <a href="/certificates/{{ row.certificate.pdf_path }}">Certificate</a>
         {% endif %}
       </td>
       <td>
@@ -173,7 +173,7 @@
             <a href="{{ badge_url }}" download><img src="{{ badge_url }}" alt="badge" style="height:20px;width:auto;vertical-align:middle;"></a>
             <a href="{{ badge_url }}" download>Badge</a>
           {% endif %}
-          <a href="{{ url_for('learner.download_certificate', cert_id=row.certificate.id) }}">Download Certificate</a>
+          <a href="/certificates/{{ row.certificate.pdf_path }}">Certificate</a>
         {% endif %}
       </td>
       <td>

--- a/tests/test_certificates_flow.py
+++ b/tests/test_certificates_flow.py
@@ -92,7 +92,8 @@ def test_badge_image_and_label(app):
     html = resp.data.decode()
     assert '<img src="/badges/foundations.webp"' in html
     assert "Badge" in html
-    assert "Download Certificate" in html
+    assert f'href="/certificates/{cert.pdf_path}"' in html
+    assert "Certificate" in html
 
 
 def test_badge_hidden_when_missing(app):

--- a/tests/test_csa_permissions.py
+++ b/tests/test_csa_permissions.py
@@ -151,4 +151,6 @@ def test_csa_can_see_certificate(app):
     client = app.test_client()
     _login_csa(client, csa_account_id)
     resp = client.get(f"/sessions/{session_id}")
-    assert b"Download Certificate" in resp.data
+    html = resp.data.decode()
+    assert 'href="/certificates/dummy.pdf"' in html
+    assert "Certificate" in html


### PR DESCRIPTION
## Summary
- Fetch certificates with pdf_path when building session detail participants list
- Link participant certificates directly via `/certificates/<pdf_path>`
- Document direct certificate links in CONTEXT

## Testing
- `pytest -m smoke`
- `PYTHONPATH=. pytest tests/test_csa_permissions.py::test_csa_can_see_certificate tests/test_certificates_flow.py::test_badge_image_and_label -q`


------
https://chatgpt.com/codex/tasks/task_e_68c1f3f06ac8832e9f106c42499d1396