### PR TITLE
Fix certificate join and visibility logic

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -102,9 +102,11 @@ Every functional change must update this file **in the same PR**.
 - **CSA (Session Admin)** — **participant account**, not a user  
   `Home • My Sessions • My Workshops • My Resources • My Profile • Logout`
 
-- **Participant / Learner**  
-  `Home • My Workshops • My Resources • My Profile • Logout`  
+- **Participant / Learner**
+  `Home • My Workshops • My Resources • My Profile • Logout`
   - **My Certificates**: no persistent menu item; a link/section appears only if they have ≥1 certificate.
+
+- Staff "My Profile → My Certificates" appears only when the staff user has certificates issued as a participant.
 
 > Staff view switcher exists for **User** accounts (Sys Admin/Admin/CRM/Delivery/Contractor). **Participants/CSAs** do not see a switcher.
 
@@ -300,13 +302,14 @@ Two separate tables by design; emails unique per table. If both tables hold the 
 - `pdf_path` stores the relative path `YYYY/session_id/filename.pdf`. Generation overwrites existing files atomically.
 - Download endpoint reads the stored path and serves the file; if the row or file is missing it returns `404` and logs `[CERT-MISSING]`.
 - Staff session detail pages left-join `certificates` on `(session_id, participant_id)` and link directly to `/certificates/<pdf_path>` for each participant with a stored path (no id-based proxy).
+- Learner and staff profile certificate listings resolve the current account's `participants` and join `certificates` on `participant_id`, linking to `/certificates/<pdf_path>` without recomputing filenames.
 - Older builds used `YYYY/<workshop_code>/…`; these paths are legacy.
 - Maintenance CLI `purge_orphan_certs` scans the certificates root and deletes files lacking a `certificates` table row. Filenames may vary; presence is determined by DB record.
 - `--dry-run` lists candidate paths and a summary without deleting.
 - In production, set `ALLOW_CERT_PURGE=1` to enable deletions.
 - One-off CLI `backfill_cert_paths` (run: `python manage.py backfill_cert_paths`) updates legacy `YYYY/<workshop_code>/…` rows when a `YYYY/session_id/…` file exists. Safe to skip if not needed.
 - Workshop line at 102 mm; date line at 83 mm in `d Month YYYY` using session end date.
-- Learner sees **My Certificates** only if they own ≥1 certificate.
+- Learner nav shows **My Certificates** only if they own ≥1 certificate; staff see **My Profile → My Certificates** only when they have certificates as participants.
 
 ---
 

--- a/FUNCTIONALITY_MAP.txt
+++ b/FUNCTIONALITY_MAP.txt
@@ -21,6 +21,7 @@ Routes and Code Pages
 - **My Sessions** – Personalized session list for staff or participants. File: `app/routes/my_sessions.py`. Uses learner `login_required`【F:app/routes/my_sessions.py†L29-L31】
 
 - **Learner Portal** – Participant workshop lists, resources, prework, certificates, profile. File: `app/routes/learner.py`. All endpoints require `login_required`【F:app/routes/learner.py†L45-L60】
+- **My Certificates** – Lists and links certificate PDFs for the current account. Route: `app/routes/learner.py::my_certs`. Requires `login_required`【F:app/routes/learner.py†L293-L313】
 
 - **Sessions** – Staff session listing, creation, editing, participants, prework, certificate generation. Participant list links to stored certificate PDFs when available. File: `app/routes/sessions.py`. Protected by `staff_required` (Admin, CRM, Delivery, Contractor)【F:app/routes/sessions.py†L172-L186】
 

--- a/app/shared/nav.py
+++ b/app/shared/nav.py
@@ -1,6 +1,7 @@
 from typing import Any, Dict, List
 
 from flask import session as flask_session, has_request_context
+from sqlalchemy import func
 
 from .acl import (
     can_manage_users,
@@ -14,86 +15,312 @@ from .acl import (
 MenuItem = Dict[str, Any]
 
 
+def _has_certificates(user) -> bool:
+    if not has_request_context():
+        return False
+    from ..app import db
+    from ..models import ParticipantAccount, Participant, Certificate
+
+    account_id = flask_session.get("participant_account_id")
+    if not account_id and user is not None:
+        email = (getattr(user, "email", "") or "").lower()
+        account = (
+            db.session.query(ParticipantAccount)
+            .filter(func.lower(ParticipantAccount.email) == email)
+            .one_or_none()
+        )
+        account_id = account.id if account else None
+    if not account_id:
+        return False
+    return (
+        db.session.query(Certificate.id)
+        .join(Participant, Certificate.participant_id == Participant.id)
+        .filter(Participant.account_id == account_id)
+        .first()
+        is not None
+    )
+
+
 def _staff_base_menu(user, show_resources: bool) -> List[MenuItem]:
     items: List[MenuItem] = []
-    items.append({'id': 'home', 'label': 'Home', 'endpoint': 'home'})
-    items.append({'id': 'my_sessions', 'label': 'My Sessions', 'endpoint': 'my_sessions.list_my_sessions'})
+    items.append({"id": "home", "label": "Home", "endpoint": "home"})
+    items.append(
+        {
+            "id": "my_sessions",
+            "label": "My Sessions",
+            "endpoint": "my_sessions.list_my_sessions",
+        }
+    )
     if is_admin(user):
-        sess_args = flask_session.get('sessions_list_args') if has_request_context() else None
-        items.append({'id': 'sessions', 'label': 'Training Sessions', 'endpoint': 'sessions.list_sessions', 'args': sess_args})
+        sess_args = (
+            flask_session.get("sessions_list_args") if has_request_context() else None
+        )
+        items.append(
+            {
+                "id": "sessions",
+                "label": "Training Sessions",
+                "endpoint": "sessions.list_sessions",
+                "args": sess_args,
+            }
+        )
     if is_admin(user) or is_kcrm(user):
-        items.append({'id': 'materials_only', 'label': 'Material Only Order', 'endpoint': 'materials_only.create'})
+        items.append(
+            {
+                "id": "materials_only",
+                "label": "Material Only Order",
+                "endpoint": "materials_only.create",
+            }
+        )
     if is_admin(user) or is_kcrm(user) or is_delivery(user) or is_contractor(user):
-        items.append({'id': 'materials', 'label': 'Material Dashboard', 'endpoint': 'materials_orders.list_orders'})
-    items.append({'id': 'surveys', 'label': 'Surveys', 'endpoint': 'surveys'})
+        items.append(
+            {
+                "id": "materials",
+                "label": "Material Dashboard",
+                "endpoint": "materials_orders.list_orders",
+            }
+        )
+    items.append({"id": "surveys", "label": "Surveys", "endpoint": "surveys"})
     if show_resources:
-        items.append({'id': 'my_resources', 'label': 'My Resources', 'endpoint': 'learner.my_resources'})
+        items.append(
+            {
+                "id": "my_resources",
+                "label": "My Resources",
+                "endpoint": "learner.my_resources",
+            }
+        )
     profile_children = [
-        {'id': 'profile_details', 'label': 'My Profile', 'endpoint': 'learner.profile'},
-        {'id': 'profile_certs', 'label': 'My Certificates', 'endpoint': 'learner.my_certs'},
+        {"id": "profile_details", "label": "My Profile", "endpoint": "learner.profile"},
     ]
-    items.append({'id': 'profile', 'label': 'My Profile', 'children': profile_children})
+    if _has_certificates(user):
+        profile_children.append(
+            {
+                "id": "profile_certs",
+                "label": "My Certificates",
+                "endpoint": "learner.my_certs",
+            }
+        )
+    if len(profile_children) > 1:
+        items.append(
+            {"id": "profile", "label": "My Profile", "children": profile_children}
+        )
+    else:
+        items.append(
+            {"id": "profile", "label": "My Profile", "endpoint": "learner.profile"}
+        )
     settings_children: List[MenuItem] = []
     if can_manage_users(user):
-        settings_children.extend([
-            {'id': 'clients', 'label': 'Clients', 'endpoint': 'clients.list_clients'},
-            {'id': 'workshop_types', 'label': 'Workshop Types', 'endpoint': 'workshop_types.list_types'},
-            {'id': 'materials_settings', 'label': 'Material settings', 'children': [
-                {'id': 'standard', 'label': 'Standard', 'endpoint': 'settings_materials.list_options', 'args': {'slug': 'standard'}},
-                {'id': 'modular', 'label': 'Modular', 'endpoint': 'settings_materials.list_options', 'args': {'slug': 'modular'}},
-                {'id': 'ldi', 'label': 'LDI', 'endpoint': 'settings_materials.list_options', 'args': {'slug': 'ldi'}},
-                {'id': 'bulk', 'label': 'Bulk Order', 'endpoint': 'settings_materials.list_options', 'args': {'slug': 'bulk'}},
-                {'id': 'simulation', 'label': 'Simulation', 'endpoint': 'settings_materials.list_options', 'args': {'slug': 'simulation'}},
-            ]},
-            {'id': 'languages', 'label': 'Languages', 'endpoint': 'settings_languages.list_langs'},
-        ])
-    if is_admin(user) or is_delivery(user) or getattr(user, 'is_kt_facilitator', False) or is_contractor(user):
-        settings_children.append({'id': 'resources', 'label': 'Resources', 'endpoint': 'settings_resources.list_resources'})
+        settings_children.extend(
+            [
+                {
+                    "id": "clients",
+                    "label": "Clients",
+                    "endpoint": "clients.list_clients",
+                },
+                {
+                    "id": "workshop_types",
+                    "label": "Workshop Types",
+                    "endpoint": "workshop_types.list_types",
+                },
+                {
+                    "id": "materials_settings",
+                    "label": "Material settings",
+                    "children": [
+                        {
+                            "id": "standard",
+                            "label": "Standard",
+                            "endpoint": "settings_materials.list_options",
+                            "args": {"slug": "standard"},
+                        },
+                        {
+                            "id": "modular",
+                            "label": "Modular",
+                            "endpoint": "settings_materials.list_options",
+                            "args": {"slug": "modular"},
+                        },
+                        {
+                            "id": "ldi",
+                            "label": "LDI",
+                            "endpoint": "settings_materials.list_options",
+                            "args": {"slug": "ldi"},
+                        },
+                        {
+                            "id": "bulk",
+                            "label": "Bulk Order",
+                            "endpoint": "settings_materials.list_options",
+                            "args": {"slug": "bulk"},
+                        },
+                        {
+                            "id": "simulation",
+                            "label": "Simulation",
+                            "endpoint": "settings_materials.list_options",
+                            "args": {"slug": "simulation"},
+                        },
+                    ],
+                },
+                {
+                    "id": "languages",
+                    "label": "Languages",
+                    "endpoint": "settings_languages.list_langs",
+                },
+            ]
+        )
+    if (
+        is_admin(user)
+        or is_delivery(user)
+        or getattr(user, "is_kt_facilitator", False)
+        or is_contractor(user)
+    ):
+        settings_children.append(
+            {
+                "id": "resources",
+                "label": "Resources",
+                "endpoint": "settings_resources.list_resources",
+            }
+        )
     if is_kt_staff(user) or is_contractor(user):
-        settings_children.append({'id': 'simulation_outlines', 'label': 'Simulation Outlines', 'endpoint': 'settings_simulations.list_simulations'})
+        settings_children.append(
+            {
+                "id": "simulation_outlines",
+                "label": "Simulation Outlines",
+                "endpoint": "settings_simulations.list_simulations",
+            }
+        )
     if can_manage_users(user):
-        settings_children.extend([
-            {'id': 'users', 'label': 'Users', 'endpoint': 'users.list_users'},
-            {'id': 'certificate_templates', 'label': 'Certificate Templates', 'endpoint': 'settings_cert_templates.list_series'},
-            {'id': 'badges', 'label': 'Badges', 'endpoint': 'settings_badges.placeholder'},
-            {'id': 'mail', 'label': 'Mail Settings', 'endpoint': 'settings_mail.settings'},
-        ])
+        settings_children.extend(
+            [
+                {"id": "users", "label": "Users", "endpoint": "users.list_users"},
+                {
+                    "id": "certificate_templates",
+                    "label": "Certificate Templates",
+                    "endpoint": "settings_cert_templates.list_series",
+                },
+                {
+                    "id": "badges",
+                    "label": "Badges",
+                    "endpoint": "settings_badges.placeholder",
+                },
+                {
+                    "id": "mail",
+                    "label": "Mail Settings",
+                    "endpoint": "settings_mail.settings",
+                },
+            ]
+        )
     if settings_children:
-        items.append({'id': 'settings', 'label': 'Settings', 'children': settings_children})
-    items.append({'id': 'logout', 'label': 'Logout', 'endpoint': 'auth.logout'})
+        items.append(
+            {"id": "settings", "label": "Settings", "children": settings_children}
+        )
+    items.append({"id": "logout", "label": "Logout", "endpoint": "auth.logout"})
     return items
 
 
 def _participant_menu(show_resources: bool, is_csa: bool) -> List[MenuItem]:
     items: List[MenuItem] = []
-    items.append({'id': 'home', 'label': 'Home', 'endpoint': 'home'})
+    items.append({"id": "home", "label": "Home", "endpoint": "home"})
     if is_csa:
-        items.append({'id': 'my_sessions', 'label': 'My Sessions', 'endpoint': 'csa.my_sessions'})
-        items.append({'id': 'my_workshops', 'label': 'My Workshops', 'endpoint': 'learner.my_workshops'})
+        items.append(
+            {"id": "my_sessions", "label": "My Sessions", "endpoint": "csa.my_sessions"}
+        )
+        items.append(
+            {
+                "id": "my_workshops",
+                "label": "My Workshops",
+                "endpoint": "learner.my_workshops",
+            }
+        )
     else:
-        items.append({'id': 'my_workshops', 'label': 'My Workshops', 'endpoint': 'learner.my_workshops'})
+        items.append(
+            {
+                "id": "my_workshops",
+                "label": "My Workshops",
+                "endpoint": "learner.my_workshops",
+            }
+        )
     if show_resources:
-        items.append({'id': 'my_resources', 'label': 'My Resources', 'endpoint': 'learner.my_resources'})
-    items.append({'id': 'profile', 'label': 'My Profile', 'endpoint': 'learner.profile'})
-    items.append({'id': 'logout', 'label': 'Logout', 'endpoint': 'auth.logout'})
+        items.append(
+            {
+                "id": "my_resources",
+                "label": "My Resources",
+                "endpoint": "learner.my_resources",
+            }
+        )
+    if _has_certificates(None):
+        items.append(
+            {
+                "id": "my_certs",
+                "label": "My Certificates",
+                "endpoint": "learner.my_certs",
+            }
+        )
+    items.append(
+        {"id": "profile", "label": "My Profile", "endpoint": "learner.profile"}
+    )
+    items.append({"id": "logout", "label": "Logout", "endpoint": "auth.logout"})
     return items
 
 
 VIEW_FILTERS = {
-    'ADMIN': {'home', 'my_sessions', 'sessions', 'materials_only', 'materials', 'surveys', 'my_resources', 'profile', 'settings', 'logout'},
-    'SESSION_MANAGER': {'home', 'my_sessions', 'sessions', 'materials_only', 'surveys', 'my_resources', 'profile', 'logout'},
-    'MATERIALS': {'home', 'my_sessions', 'materials_only', 'materials', 'surveys', 'my_resources', 'profile', 'settings', 'logout'},
-    'DELIVERY': {'home', 'my_sessions', 'surveys', 'my_resources', 'profile', 'logout'},
-    'LEARNER': {'home', 'my_workshops', 'my_resources', 'profile', 'logout'},
-    'CSA': {'home', 'my_sessions', 'my_workshops', 'my_resources', 'profile', 'logout'},
+    "ADMIN": {
+        "home",
+        "my_sessions",
+        "sessions",
+        "materials_only",
+        "materials",
+        "surveys",
+        "my_resources",
+        "profile",
+        "settings",
+        "logout",
+    },
+    "SESSION_MANAGER": {
+        "home",
+        "my_sessions",
+        "sessions",
+        "materials_only",
+        "surveys",
+        "my_resources",
+        "profile",
+        "logout",
+    },
+    "MATERIALS": {
+        "home",
+        "my_sessions",
+        "materials_only",
+        "materials",
+        "surveys",
+        "my_resources",
+        "profile",
+        "settings",
+        "logout",
+    },
+    "DELIVERY": {"home", "my_sessions", "surveys", "my_resources", "profile", "logout"},
+    "LEARNER": {
+        "home",
+        "my_workshops",
+        "my_resources",
+        "my_certs",
+        "profile",
+        "logout",
+    },
+    "CSA": {
+        "home",
+        "my_sessions",
+        "my_workshops",
+        "my_resources",
+        "my_certs",
+        "profile",
+        "logout",
+    },
 }
 
 
-def build_menu(current_user, active_view: str, show_resources: bool, is_csa: bool = False) -> List[MenuItem]:
+def build_menu(
+    current_user, active_view: str, show_resources: bool, is_csa: bool = False
+) -> List[MenuItem]:
     if current_user:
         menu = _staff_base_menu(current_user, show_resources)
     else:
         menu = _participant_menu(show_resources, is_csa)
-    allowed = VIEW_FILTERS.get(active_view, VIEW_FILTERS['LEARNER'])
-    filtered = [item for item in menu if item['id'] in allowed]
+    allowed = VIEW_FILTERS.get(active_view, VIEW_FILTERS["LEARNER"])
+    filtered = [item for item in menu if item["id"] in allowed]
     return filtered

--- a/app/templates/my_certificates.html
+++ b/app/templates/my_certificates.html
@@ -2,10 +2,12 @@
 {% block title %}My Certificates{% endblock %}
 {% block content %}
 <h1>My Certificates</h1>
+{% if certs %}
 <ul>
 {% for c in certs %}
   <li>
-    <a href="{{ url_for('learner.download_certificate', cert_id=c.id) }}">{{ c.workshop_name }} - {{ c.workshop_date }}</a>
+    {{ c.workshop_name }} - {{ c.workshop_date }}
+    <a href="{{ '/certificates/' ~ c.pdf_path }}">Certificate</a>
     {% set badge_file = cert_badges.get(c.id) %}
     {% if badge_file %}
       {% set badge_url = '/badges/' ~ badge_file %}
@@ -15,4 +17,7 @@
   </li>
 {% endfor %}
 </ul>
+{% else %}
+<p>No certificates available.</p>
+{% endif %}
 {% endblock %}


### PR DESCRIPTION
## Summary
- Resolve certificates via participants.account_id and join on participant_id
- Show "My Certificates" menu items only when the account has certificates
- Link certificate downloads directly through `/certificates/<pdf_path>` and document nav rules

## Testing
- `pytest -m smoke`


------
https://chatgpt.com/codex/tasks/task_e_68c1fbb3a4a8832eb60ccc487412d867