### PR TITLE
Tidy inline form spacing and button link contrast

### DIFF
--- a/app/static/css/buttons.css
+++ b/app/static/css/buttons.css
@@ -118,6 +118,34 @@ input[type="reset"]:disabled,
   border-color: color-mix(in srgb, var(--kt-accent-green) 70%, black);
 }
 
+a.btn,
+a.btn:link,
+a.btn:visited {
+  color: #fff;
+  text-decoration: none;
+}
+
+a.btn:hover,
+a.btn:active,
+a.btn:focus {
+  color: #fff;
+  text-decoration: none;
+}
+
+.btn a,
+.btn a:link,
+.btn a:visited {
+  color: #fff;
+  text-decoration: none;
+}
+
+.btn a:hover,
+.btn a:active,
+.btn a:focus {
+  color: #fff;
+  text-decoration: none;
+}
+
 .btn-sm {
   padding: var(--space-1) var(--space-2);
   font-size: 0.875rem;

--- a/app/static/css/forms.css
+++ b/app/static/css/forms.css
@@ -67,6 +67,16 @@ select:focus {
   outline-offset: 2px;
 }
 
+select[multiple],
+.form-multiselect {
+  height: auto;
+  min-height: 200px; /* ~8 rows */
+  padding: 8px 12px;
+  line-height: 1.3;
+  overflow-y: auto;
+  border-radius: inherit;
+}
+
 input[type="date"],
 input[type="time"],
 input[type="datetime-local"] {
@@ -186,12 +196,19 @@ input[type="checkbox"] + label {
 }
 
 .filters,
-.filter-row,
-.field-row {
+.filter-row {
   display: flex;
   flex-wrap: wrap;
   column-gap: var(--gap-x);
   row-gap: var(--gap-y);
+}
+
+.field-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  column-gap: 10px;
+  row-gap: 8px;
 }
 
 .field-row .form-group {

--- a/app/templates/sessions/form.html
+++ b/app/templates/sessions/form.html
@@ -18,20 +18,23 @@
       <span>CRM: <span id="crm-display">{% if session and session.client and session.client.crm %}{{ session.client.crm.full_name or session.client.crm.email }}{% endif %}</span></span>
     </label>
     </div>
-    <div><label class="field-row">Region*
-      <select name="region" required>
-        <option value="">--Select--</option>
-        {% for opt in ['NA','EU','SEA','Other'] %}
-        <option value="{{ opt }}" {% if session and session.region==opt %}selected{% endif %}>{{ opt }}</option>
-        {% endfor %}
-      </select>
-      <span>Workshop language*</span>
-      <select name="workshop_language" required>
-        {% for code,label in workshop_languages %}
-        <option value="{{ code }}" {% if session.workshop_language==code %}selected{% endif %}>{{ label }}</option>
-        {% endfor %}
-      </select>
-    </label></div>
+    <div class="field-row">
+      <label>Region*
+        <select name="region" required>
+          <option value="">--Select--</option>
+          {% for opt in ['NA','EU','SEA','Other'] %}
+          <option value="{{ opt }}" {% if session and session.region==opt %}selected{% endif %}>{{ opt }}</option>
+          {% endfor %}
+        </select>
+      </label>
+      <label>Workshop language*
+        <select name="workshop_language" required>
+          {% for code,label in workshop_languages %}
+          <option value="{{ code }}" {% if session.workshop_language==code %}selected{% endif %}>{{ label }}</option>
+          {% endfor %}
+        </select>
+      </label>
+    </div>
     <div style="margin-top:8px;">
       <button type="submit" id="materials-only-btn" name="action" value="materials_only">No workshop, material order only</button>
     </div>
@@ -64,15 +67,17 @@
         {% endfor %}
       </select>
     </label></div>
-    <div><label class="field-row">Workshop Location
-      <select name="workshop_location_id" id="workshop-location-select">
-        <option value=""></option>
-        {% for loc in workshop_locations %}
-        <option value="{{ loc.id }}" {% if session.workshop_location_id==loc.id %}selected{% endif %}>{{ loc.label }}</option>
-        {% endfor %}
-      </select>
+    <div class="field-row">
+      <label>Workshop Location
+        <select name="workshop_location_id" id="workshop-location-select">
+          <option value=""></option>
+          {% for loc in workshop_locations %}
+          <option value="{{ loc.id }}" {% if session.workshop_location_id==loc.id %}selected{% endif %}>{{ loc.label }}</option>
+          {% endfor %}
+        </select>
+      </label>
       <a href="#" id="add-workshop-location">Add</a>
-    </label></div>
+    </div>
     <div><label>Capacity* <input type="number" name="capacity" value="{{ session.capacity or 16 }}" required></label></div>
     <div class="field-row"><label>Start Date* <input type="date" id="start-date" name="start_date" value="{{ session.start_date or '' }}" required></label>
     <input type="hidden" name="ack_past" id="ack-past" value="{{ form.ack_past if form else '' }}">

--- a/app/templates/sessions/materials.html
+++ b/app/templates/sessions/materials.html
@@ -42,13 +42,13 @@
           <input type="url" name="sfc_link" value="{{ sess.client.sfc_link or '' }}">
         {% endif %}
       </div>
-      <div>Order date: {{ shipment.created_at.date() if shipment.created_at else '' }}</div>
       <div>Latest arrival date:
         {% if can_edit_materials_header('arrival_date', current_user, shipment) and not readonly %}
           <input type="date" name="arrival_date" value="{{ form.get('arrival_date') if form else (shipment.arrival_date.isoformat() if shipment.arrival_date else '') }}">
         {% else %}{{ shipment.arrival_date|default('', true) }}{% endif %}
       </div>
     </div>
+    <div>Order date: {{ shipment.created_at.date() if shipment.created_at else '' }}</div>
   </div>
   <div class="kt-card">
     <h2 class="kt-card-title">Shipping details</h2>
@@ -130,12 +130,12 @@
           {% else %}{{ fmt|default('', true) }}{% endif %}
         </label>
       </div>
+      <div id="material-sets" {% if shipment.order_type=='Simulation' %}style="display:none"{% endif %}>
+        <label>Material Sets
+          <input type="number" name="material_sets" min="0" value="{{ form.get('material_sets') if form else (shipment.material_sets or 0) }}">
+        </label>
+      </div>
     </div>
-  <div id="material-sets" {% if shipment.order_type=='Simulation' %}style="display:none"{% endif %}>
-    <label>Material Sets
-      <input type="number" name="material_sets" min="0" value="{{ form.get('material_sets') if form else (shipment.material_sets or 0) }}">
-    </label>
-  </div>
   <div id="credits-field" data-sim="{{ 1 if sim_base else 0 }}" {% if not show_credits %}style="display:none"{% endif %}>
     <label># of credits (2 teams per credit)
       <input type="number" name="credits" min="0" value="{{ form.get('credits') if form else (shipment.credits or 2) }}">


### PR DESCRIPTION
## Summary
- add `.field-row` flex utility for consistent inline control gaps and taller `<select multiple>` styling
- ensure anchor buttons and links within buttons always render white, un-underlined text
- wrap session and materials form groups with `.field-row` for readable spacing

## Testing
- `pytest -m smoke -v`


------
https://chatgpt.com/codex/tasks/task_e_68c80d6a2b34832eb5ef88e9ef37341f