### PR TITLE
Add collapsible resource descriptions

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -337,9 +337,10 @@ Two separate tables by design; emails unique per table. If both tables hold the 
 
 # 6. Resources
 
-- Managed at **Settings → Resources**; mapped to Workshop Types.  
+- Managed at **Settings → Resources**; mapped to Workshop Types.
 - Learner/CSA **My Resources** shows only workshop types associated with sessions for that participant **whose start date has passed**.
 - Staff see the “My Resources” navigation link only if they're assigned to at least one session; they may still visit `/my-resources` directly without participant records, and the page returns HTTP 200 with an empty state when no resources apply.
+- Resources include an optional rich-text **Description** stored as sanitized HTML and entered in Settings; the **My Resources** page shows a collapsed “Description” section per item when present.
 - Workshop types are de-duplicated by ID in application code to avoid SQL `DISTINCT` on JSON columns such as `supported_languages`.
 - `/my-resources` gracefully renders an empty state when no resources are available (never 500s).
 - Files under `/resources/<title-as-filename>`; links download directly.

--- a/app/forms/resource_forms.py
+++ b/app/forms/resource_forms.py
@@ -4,6 +4,8 @@ import os
 import re
 from typing import Iterable
 
+from ..shared.html import sanitize_html
+
 ALLOWED_EXTENSIONS = {".pdf", ".docx", ".xlsx", ".pptx", ".csv", ".txt", ".html"}
 
 
@@ -26,7 +28,16 @@ def validate_resource_form(data: dict, files: dict, *, require_file: bool = Fals
     file = files.get("file")
     active = bool(data.get("active"))
     wt_ids = [int(x) for x in data.getlist("workshop_types") if x.isdigit()]
-    cleaned.update(name=name, type=rtype, link=link, file=file, active=active, workshop_type_ids=wt_ids)
+    description = sanitize_html(data.get("description") or "")
+    cleaned.update(
+        name=name,
+        type=rtype,
+        link=link,
+        file=file,
+        active=active,
+        workshop_type_ids=wt_ids,
+        description=description,
+    )
 
     if not name:
         errors.append("Name required")

--- a/app/models/resource.py
+++ b/app/models/resource.py
@@ -29,6 +29,7 @@ class Resource(db.Model):
     name = db.Column(db.String(255), nullable=False)
     type = db.Column(db.String(20), nullable=False)
     resource_value = db.Column(db.String(2048))
+    description_html = db.Column(db.Text)
     active = db.Column(db.Boolean, nullable=False, default=True)
     created_at = db.Column(db.DateTime, server_default=db.func.now())
 

--- a/app/routes/settings_resources.py
+++ b/app/routes/settings_resources.py
@@ -99,6 +99,7 @@ def create_resource():
         name=name,
         type=rtype,
         resource_value=resource_value,
+        description_html=cleaned["description"],
         active=cleaned["active"],
     )
     res.workshop_types = WorkshopType.query.filter(WorkshopType.id.in_(cleaned["workshop_type_ids"])).all()
@@ -154,6 +155,7 @@ def update_resource(res_id: int):
     res.name = name
     res.type = rtype
     res.active = cleaned["active"]
+    res.description_html = cleaned["description"]
     if rtype == "DOCUMENT":
         file = cleaned["file"]
         if file and getattr(file, "filename", ""):

--- a/app/templates/my_resources.html
+++ b/app/templates/my_resources.html
@@ -13,6 +13,12 @@
         {% else %}
           <a href="{{ r.resource_value }}" target="_blank">{{ r.name }}</a>
         {% endif %}
+        {% if r.description_html %}
+          <details>
+            <summary>Description</summary>
+            {{ r.description_html | safe }}
+          </details>
+        {% endif %}
       </li>
     {% endfor %}
     </ul>

--- a/app/templates/settings_resources/form.html
+++ b/app/templates/settings_resources/form.html
@@ -14,6 +14,9 @@
   </label><br>
   <label>Link <input type="url" name="link" value="{{ resource.resource_value if resource and resource.type in ['LINK','APP'] else '' }}"></label><br>
   <label>File <input type="file" name="file"></label><br>
+  <label>Description<br>
+    <textarea name="description" rows="4">{{ resource.description_html | safe if resource else '' }}</textarea>
+  </label><br>
   <fieldset>
     <legend>Workshop Types</legend>
     {% set selected = [] %}

--- a/migrations/versions/0064_resource_description_html.py
+++ b/migrations/versions/0064_resource_description_html.py
@@ -1,0 +1,24 @@
+"""add resource description_html
+
+Revision ID: 0064_resource_description_html
+Revises: 0063_remove_default_materials_option
+Create Date: 2025-09-11 00:00:00.000000
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "0064_resource_description_html"
+down_revision = "0063_remove_default_materials_option"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("resources", sa.Column("description_html", sa.Text()))
+
+
+def downgrade() -> None:
+    op.drop_column("resources", "description_html")
+


### PR DESCRIPTION
## Summary
- allow rich-text resource descriptions with server-side sanitization
- show per-resource collapsible description panels on My Resources
- document resources description behavior

## Testing
- `pytest --disable-warnings | tail -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68c82a19da98832eac1565ba8bcff75a