### PR TITLE
Persist resource uploads under /srv

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -343,7 +343,8 @@ Two separate tables by design; emails unique per table. If both tables hold the 
 - Resources include an optional rich-text **Description** stored as sanitized HTML and entered in Settings via a Trix editor; on **My Resources** the resource title toggles a collapsible panel whose expanded state shows the link/file tile followed by the sanitized description.
 - Workshop types are de-duplicated by ID in application code to avoid SQL `DISTINCT` on JSON columns such as `supported_languages`.
 - `/my-resources` gracefully renders an empty state when no resources are available (never 500s).
-- Files under `/resources/<title-as-filename>`; links download directly.
+- Uploaded files persist under `/srv/resources/<resource_id>/<sanitized_filename>` and are publicly served by Caddy at `/resources/<resource_id>/<sanitized_filename>`; filenames are sanitized (slugged + short hash) to avoid traversal/collisions. Certificate and badge storage paths remain unchanged.
+- Settings → Resources edit view surfaces the current uploaded file with a download link when present; My Resources prefers the file tile when a stored file URL exists and falls back to the external link otherwise.
 
 ---
 

--- a/app/forms/resource_forms.py
+++ b/app/forms/resource_forms.py
@@ -1,19 +1,11 @@
 from __future__ import annotations
 
 import os
-import re
 from typing import Iterable
 
 from ..shared.html import sanitize_html
 
 ALLOWED_EXTENSIONS = {".pdf", ".docx", ".xlsx", ".pptx", ".csv", ".txt", ".html"}
-
-
-def slugify_filename(name: str, filename: str) -> str:
-    base, ext = os.path.splitext(filename)
-    ext = ext.lower()
-    slug = re.sub(r"[^a-z0-9]+", "-", name.lower()).strip("-")
-    return f"{slug}{ext}"
 
 
 def validate_resource_form(data: dict, files: dict, *, require_file: bool = False) -> tuple[list[str], dict]:

--- a/app/shared/storage_resources.py
+++ b/app/shared/storage_resources.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import hashlib
+import os
+import re
+import shutil
+import unicodedata
+from typing import Optional
+
+from flask import current_app
+
+_RESOURCE_DIR_NAME = "resources"
+
+
+def _site_root() -> str:
+    """Resolve the site root (default `/srv`)."""
+    try:
+        site_root = current_app.config.get("SITE_ROOT", "/srv")
+    except RuntimeError:
+        site_root = "/srv"
+    return site_root or "/srv"
+
+
+def resources_root() -> str:
+    """Return the absolute path to the resources root directory."""
+    return os.path.join(_site_root(), _RESOURCE_DIR_NAME)
+
+
+def resource_fs_dir(resource_id: int) -> str:
+    """Return the filesystem directory for a resource's stored files."""
+    return os.path.join(resources_root(), str(resource_id))
+
+
+def resource_fs_path(resource_id: int, filename: str) -> str:
+    """Return the absolute filesystem path for a specific resource file."""
+    safe_name = filename.strip("/\\")
+    return os.path.join(resource_fs_dir(resource_id), safe_name)
+
+
+def resource_web_url(resource_id: int, filename: str) -> str:
+    """Return the public URL for the stored resource file."""
+    safe_name = filename.strip("/\\")
+    return f"/{_RESOURCE_DIR_NAME}/{resource_id}/{safe_name}"
+
+
+def sanitize_filename(name: str) -> str:
+    """Normalize an uploaded filename to a safe ASCII form."""
+    raw_name = os.path.basename(name or "")
+    if not raw_name:
+        raw_name = "resource"
+
+    normalized = unicodedata.normalize("NFKD", raw_name)
+    ascii_name = normalized.encode("ascii", "ignore").decode("ascii") or raw_name
+
+    base, ext = os.path.splitext(ascii_name)
+    ext = re.sub(r"[^A-Za-z0-9]", "", ext).lower()
+    if ext:
+        ext = f".{ext}"
+
+    base = base.replace(".", "-")
+    base = re.sub(r"[^A-Za-z0-9_-]+", "-", base).strip("-_")
+    if not base:
+        base = "resource"
+    base = base[:64]
+
+    digest = hashlib.sha1((ascii_name or raw_name).encode("utf-8")).hexdigest()[:8]
+    return f"{base}-{digest}{ext}"
+
+
+def resource_path_from_value(resource_id: int, stored_value: Optional[str]) -> Optional[str]:
+    """Derive the filesystem path from a stored resource value."""
+    if not stored_value:
+        return None
+
+    value = stored_value.strip()
+    if not value:
+        return None
+
+    prefix = f"/{_RESOURCE_DIR_NAME}/"
+    if value.startswith(prefix):
+        rel = value[len(prefix) :]
+        parts = rel.split("/", 1)
+        if len(parts) == 2:
+            rid, filename = parts
+            if rid == str(resource_id):
+                return resource_fs_path(resource_id, filename)
+            return os.path.join(resources_root(), rel)
+        return os.path.join(resources_root(), rel)
+
+    if value.startswith("/"):
+        return os.path.join(_site_root(), value.lstrip("/"))
+
+    if value.startswith(("http://", "https://")):
+        return None
+
+    if "/" in value or "\\" in value:
+        return os.path.join(resources_root(), value.strip("/\\"))
+
+    return os.path.join(resources_root(), value)
+
+
+def remove_resource_file(resource_id: int, stored_value: Optional[str]) -> None:
+    """Delete a stored resource file if it exists."""
+    path = resource_path_from_value(resource_id, stored_value)
+    if path and os.path.isfile(path):
+        try:
+            os.remove(path)
+        except FileNotFoundError:
+            pass
+
+
+def remove_resource_dir(resource_id: int) -> None:
+    """Delete the resource directory for an id (ignore if missing)."""
+    dir_path = resource_fs_dir(resource_id)
+    if os.path.isdir(dir_path):
+        shutil.rmtree(dir_path, ignore_errors=True)

--- a/app/templates/my_resources.html
+++ b/app/templates/my_resources.html
@@ -9,7 +9,7 @@
       <div class="resource-list">
       {% for r in items %}
         {% set public_url = r.public_url %}
-        {% set filename = r.resource_value.rsplit('/', 1)[-1] if r.resource_value else '' %}
+        {% set filename = r.document_filename or (r.resource_value.rsplit('/', 1)[-1] if r.resource_value else '') %}
         {% set ext = filename.rsplit('.', 1)[-1]|lower if '.' in filename else '' %}
         {% set is_image = ext in ['png', 'jpg', 'jpeg', 'gif', 'bmp', 'svg', 'webp'] %}
         {% set is_pdf = ext == 'pdf' %}
@@ -17,7 +17,7 @@
           <summary class="resource-summary">{{ r.name }}</summary>
           <div class="resource-panel">
             <div class="resource-tile">
-              {% if r.type == 'DOCUMENT' %}
+              {% if r.type == 'DOCUMENT' and public_url %}
                 <a href="{{ public_url }}" download class="resource-file-link">
                   {% if is_image %}
                     <img src="{{ public_url }}" alt="" class="resource-thumb">
@@ -45,7 +45,11 @@
                 </a>
               {% else %}
                 <span class="resource-icon" aria-hidden="true">🔗</span>
-                <a href="{{ r.resource_value }}" target="_blank" rel="noopener" class="btn btn-secondary">Open resource</a>
+                {% if r.resource_value %}
+                  <a href="{{ r.resource_value }}" target="_blank" rel="noopener" class="btn btn-secondary">Open resource</a>
+                {% else %}
+                  <span class="resource-file-name">No file uploaded.</span>
+                {% endif %}
               {% endif %}
             </div>
             {% if r.description_html %}

--- a/app/templates/settings_resources/form.html
+++ b/app/templates/settings_resources/form.html
@@ -18,6 +18,14 @@
   </label><br>
   <label>Link <input type="url" name="link" value="{{ resource.resource_value if resource and resource.type in ['LINK','APP'] else '' }}"></label><br>
   <label>File <input type="file" name="file"></label><br>
+  {% if resource and resource.public_url %}
+    <p class="current-resource-file">
+      Current file:
+      <a href="{{ resource.public_url }}" download>
+        Download {{ resource.document_filename or 'file' }}
+      </a>
+    </p>
+  {% endif %}
   <label>Description</label><br>
   <input type="hidden" id="description" name="description" value="{{ resource.description_html |e if resource else '' }}">
   <trix-editor input="description"></trix-editor><br>

--- a/caddy/Caddyfile
+++ b/caddy/Caddyfile
@@ -9,6 +9,9 @@ cbs.ktapps.net {
   handle /certificates/* {
     file_server
   }
+  handle /resources/* {
+    file_server
+  }
   handle /badges/* {
     file_server
   }


### PR DESCRIPTION
## Summary
- add a storage helper to persist resource uploads under `/srv/resources/<id>` with sanitized filenames and generated download URLs
- update resource create/update flows to use the helper, surface download links in the settings form and My Resources, and clean up replaced/deleted files
- expose `/resources/*` through Caddy, document the new storage convention, and add a smoke test that exercises file upload persistence

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c86ddfdf44832ea06c6ef6b45383ec