### PR TITLE
Polish dense table layout and print styles

### DIFF
--- a/app/static/css/print.css
+++ b/app/static/css/print.css
@@ -1,35 +1,36 @@
 @media print {
-  /* Hide navigation and chrome */
-  .kt-sidebar,
-  nav,
   header,
+  nav,
+  .kt-sidebar,
+  .side-nav,
+  .flash,
   .flashes,
+  .btn,
+  .pagination,
   .view-banner {
     display: none !important;
   }
 
   body {
-    margin: 0;
     color: #000;
     background: #fff;
   }
 
-  .content {
-    padding: 0;
-  }
-
-  a {
-    color: #000;
-    text-decoration: underline;
-  }
-
-  /* Ensure tables print cleanly */
   .kt-table {
-    overflow: visible;
+    border-collapse: collapse;
   }
 
   .kt-table th,
   .kt-table td {
-    border: 1px solid #000;
+    border: 1px solid var(--kt-border);
+    padding: 6px 8px;
+  }
+
+  .col-actions {
+    display: none;
+  }
+
+  a[href]::after {
+    content: "";
   }
 }

--- a/app/static/css/table.css
+++ b/app/static/css/table.css
@@ -45,4 +45,22 @@
 
 .kt-table .col-actions .btn {
   margin-left: .25rem;
+  padding: 4px 10px;
+  font-size: .9rem;
+}
+
+.kt-table .col-actions .btn:first-child {
+  margin-left: 0;
+}
+
+.cell-nowrap {
+  white-space: nowrap;
+}
+
+.cell-ellipsis {
+  max-width: 48ch;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  display: block;
 }

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -12,7 +12,6 @@
   <link rel="stylesheet" href="{{ url_for('static', filename='css/cards.css') }}">
   <link rel="stylesheet" href="{{ url_for('static', filename='css/alerts.css') }}">
   <link rel="stylesheet" href="{{ url_for('static', filename='css/pills.css') }}">
-  <link rel="stylesheet" href="{{ url_for('static', filename='css/print.css') }}" media="print">
   <link rel="stylesheet" href="{{ url_for('static', filename='css/tabs.css') }}">
   <link rel="stylesheet" href="{{ url_for('static', filename='css/pagination.css') }}">
   <link rel="stylesheet" href="{{ url_for('static', filename='css/chips.css') }}">
@@ -20,6 +19,7 @@
   <link rel="stylesheet" href="{{ url_for('static', filename='css/skeleton.css') }}">
   <link rel="stylesheet" href="{{ url_for('static', filename='css/utilities.css') }}">
   <link rel="stylesheet" href="{{ url_for('static', filename='css/tooltips.css') }}">
+  <link rel="stylesheet" href="{{ url_for('static', filename='css/print.css') }}" media="print">
   <style>
     body {
       margin:0;

--- a/app/templates/sessions.html
+++ b/app/templates/sessions.html
@@ -62,23 +62,40 @@
     <th>{{ sort_link('Client','client') }}</th>
     <th>{{ sort_link('Location','location') }}</th>
     <th>{{ sort_link('Workshop Type','workshop_type') }}</th>
-    <th>{{ sort_link('Start Date','start_date') }}</th>
-    <th>{{ sort_link('Status','status') }}</th>
-    <th>{{ sort_link('Region','region') }}</th>
+    <th class="cell-nowrap">{{ sort_link('Start Date','start_date') }}</th>
+    <th class="cell-nowrap">{{ sort_link('Status','status') }}</th>
+    <th class="cell-nowrap">{{ sort_link('Region','region') }}</th>
     <th class="col-actions">Actions</th>
   </tr>
   {% for s in sessions %}
   <tr>
-    <td><a href="{{ url_for('sessions.session_detail', session_id=s.id) }}">{{ s.title }}</a></td>
-    <td>{% if s.client %}{{ s.client.name }}{% endif %}</td>
-    <td>{{ s.location }}</td>
-    <td>{% if s.workshop_type %}{{ s.workshop_type.code }} — {{ s.workshop_type.name }}{% endif %}</td>
-    <td>{{ s.start_date }}</td>
-    <td>{{ s.computed_status }}</td>
-    <td>{{ s.region }}</td>
+    <td>
+      <span class="cell-ellipsis" title="{{ s.title }}">
+        <a href="{{ url_for('sessions.session_detail', session_id=s.id) }}">{{ s.title }}</a>
+      </span>
+    </td>
+    <td>
+      {% if s.client %}
+        <span class="cell-ellipsis" title="{{ s.client.name }}">{{ s.client.name }}</span>
+      {% endif %}
+    </td>
+    <td>
+      {% if s.location %}
+        <span class="cell-ellipsis" title="{{ s.location }}">{{ s.location }}</span>
+      {% endif %}
+    </td>
+    <td>
+      {% if s.workshop_type %}
+        {% set workshop_label = s.workshop_type.code ~ ' — ' ~ s.workshop_type.name %}
+        <span class="cell-ellipsis" title="{{ workshop_label }}">{{ workshop_label }}</span>
+      {% endif %}
+    </td>
+    <td class="cell-nowrap">{{ s.start_date }}</td>
+    <td class="cell-nowrap">{{ s.computed_status }}</td>
+    <td class="cell-nowrap">{{ s.region }}</td>
     <td class="col-actions">
       {% if current_user and (current_user.is_app_admin or current_user.is_admin or current_user.is_kt_delivery or current_user.is_kt_contractor) %}
-        <a class="btn btn-sm" href="{{ url_for('sessions.session_prework', session_id=s.id) }}">Prework</a>
+        <a class="btn btn-primary btn-sm" href="{{ url_for('sessions.session_prework', session_id=s.id) }}">Prework</a>
       {% endif %}
     </td>
   </tr>

--- a/app/templates/settings_languages/list.html
+++ b/app/templates/settings_languages/list.html
@@ -6,16 +6,16 @@
 <p><a href="{{ url_for('settings_languages.new_lang') }}">New language</a></p>
 {% if langs %}
 <table class="kt-table">
-  <tr><th>Name</th><th>Sort Order</th><th>Status</th><th class="col-actions"></th></tr>
+  <tr><th>Name</th><th class="cell-nowrap">Sort Order</th><th class="cell-nowrap">Status</th><th class="col-actions"></th></tr>
   {% for lang in langs %}
   <tr>
     <td>{{ lang.name }}</td>
-    <td>{{ lang.sort_order }}</td>
-    <td>{{ 'Active' if lang.is_active else 'Inactive' }}</td>
+    <td class="cell-nowrap">{{ lang.sort_order }}</td>
+    <td class="cell-nowrap">{{ 'Active' if lang.is_active else 'Inactive' }}</td>
     <td class="col-actions">
-      <a class="btn btn-sm" href="{{ url_for('settings_languages.edit_lang', lang_id=lang.id) }}">Edit</a>
+      <a class="btn btn-primary btn-sm" href="{{ url_for('settings_languages.edit_lang', lang_id=lang.id) }}">Edit</a>
       <form method="post" action="{{ url_for('settings_languages.toggle_lang', lang_id=lang.id) }}" style="display:inline">
-        <button class="btn btn-sm" type="submit">{{ 'Deactivate' if lang.is_active else 'Activate' }}</button>
+        <button class="btn btn-primary btn-sm" type="submit">{{ 'Deactivate' if lang.is_active else 'Activate' }}</button>
       </form>
     </td>
   </tr>

--- a/app/templates/settings_materials/list.html
+++ b/app/templates/settings_materials/list.html
@@ -5,18 +5,20 @@
 <h1 class="kt-card-title">{{ label }} Materials</h1>
 <p><a href="{{ url_for('settings_materials.new_option', slug=slug) }}">New option</a></p>
 <table class="kt-table">
-  <tr><th>Title</th><th>Languages</th><th>Formats</th><th>Qty basis</th><th>Status</th><th class="col-actions"></th></tr>
+  <tr><th>Title</th><th>Languages</th><th>Formats</th><th class="cell-nowrap">Qty basis</th><th class="cell-nowrap">Status</th><th class="col-actions"></th></tr>
   {% for opt in options %}
   <tr>
-    <td>{{ opt.title }}</td>
-    <td>{{ opt.languages | map(attribute='name') | join(', ') }}</td>
-    <td>{{ opt.formats|join(', ') }}</td>
-    <td>{{ opt.quantity_basis }}</td>
-    <td>{{ 'Active' if opt.is_active else 'Inactive' }}</td>
+    <td><span class="cell-ellipsis" title="{{ opt.title }}">{{ opt.title }}</span></td>
+    {% set language_list = opt.languages | map(attribute='name') | join(', ') %}
+    <td><span class="cell-ellipsis" title="{{ language_list }}">{{ language_list }}</span></td>
+    {% set format_list = opt.formats|join(', ') %}
+    <td><span class="cell-ellipsis" title="{{ format_list }}">{{ format_list }}</span></td>
+    <td class="cell-nowrap">{{ opt.quantity_basis }}</td>
+    <td class="cell-nowrap">{{ 'Active' if opt.is_active else 'Inactive' }}</td>
     <td class="col-actions">
-      <a class="btn btn-sm" href="{{ url_for('settings_materials.edit_option', slug=slug, opt_id=opt.id) }}">Edit</a>
+      <a class="btn btn-primary btn-sm" href="{{ url_for('settings_materials.edit_option', slug=slug, opt_id=opt.id) }}">Edit</a>
       <form method="post" action="{{ url_for('settings_materials.toggle_option', slug=slug, opt_id=opt.id) }}" style="display:inline">
-        <button class="btn btn-sm" type="submit">{{ 'Deactivate' if opt.is_active else 'Activate' }}</button>
+        <button class="btn btn-primary btn-sm" type="submit">{{ 'Deactivate' if opt.is_active else 'Activate' }}</button>
       </form>
     </td>
   </tr>


### PR DESCRIPTION
## Summary
- tighten the actions column styles and add helpers for nowrap/ellipsis cells
- tag languages, materials, and session tables to use the new classes and smaller action buttons
- refresh print-only styles and load them after other component CSS so overrides apply

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68c8809c3d08832eb1f2df252095d38c