### PR TITLE
Add column chooser with persistent table preferences

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -380,7 +380,8 @@ Two separate tables by design; emails unique per table. If both tables hold the 
 - Each Material Item row includes a **Processed** checkbox that records the current user and a `yyyy-mm-dd HH:MM UTC` timestamp when checked; unchecking clears the stamp.
 - Apply Defaults is enabled only when Order Type = “KT-Run Standard materials” and Material Sets > 0 (disabled tooltip: “Select # of Material sets first.”). The action keeps the selected Material format and adds any missing items from defaults using each item's Quantity basis (“Per learner” → Material Sets, “Per order” → 1) without altering existing rows. The Materials selector is a dropdown with no “Show all” checkbox.
 - POST `/sessions/<session_id>/materials/deliver` sets status to **Delivered** (403 on repeat with friendly flash); POST `/sessions/<session_id>/materials/undeliver` reverts to **In progress**.
-- **Sessions list**: sortable columns (Title, Client, Location, Workshop Type, Start Date, Status, Region) with filters for keyword (Title/Client/Location), Status, Region, Delivery Type, and Start-date range; sort/filter state persists within `/sessions`.
+- **Sessions list**: sortable columns with default order **ID, Title, Client, Location, Workshop Type, Start Date, Status, Region, Actions**. Title links to the session detail; the new **ID** column is the integer session id (plain text) and remains the first column. Filters cover keyword (Title/Client/Location), Status, Region, Delivery Type, and Start-date range; sort/filter state persists within `/sessions`.
+- **Sessions column chooser**: the “Columns” button opens a keyboard-accessible popover that lets users toggle optional columns and drag to reorder them. **ID** and **Title** are locked on and remain the first two columns. Choices persist per browser via `localStorage` under `cbs.sessions.columns.<user_id>` (falls back to `cbs.sessions.columns` when no user id is available). Reset clears storage and restores the default order without affecting filters or sort state.
 - **Simulation Outline** shown when Order Type = Simulation or the Workshop Type is simulation-based.
 - Material format is always visible. If **Order Type** = “Simulation” and no value is set, default to **SIM Only**. Non-editable roles see the value read-only.
 - **Order Type** = “KT-Run Modular materials” → **Materials Type** becomes multi-select and all selected modules are shown; other order types remain single-select.
@@ -415,7 +416,8 @@ Two separate tables by design; emails unique per table. If both tables hold the 
 # 9. Materials Dashboard (current behavior)
 
 - **Default sort**: **Latest Arrival Date ascending** (earliest due first).  
-- **Columns**: Session, Client, Workshop Type, Latest Arrival, Format, Physical Components, Status, Ship Date, Courier/Tracking.
+- **Columns**: default order **Order ID, Workshop title, Client, Workshop, Latest Arrival Date, Materials Order type, Materials order status, Workshop status** with a fixed **Order ID** column (SessionShipping id) leading and Title always visible/linking to the materials detail page.
+- **Column chooser**: matches the Workshops dashboard behavior. Optional columns can be hidden or reordered, while **Order ID** and **Workshop title** stay visible and leading. Preferences persist under `localStorage` key `cbs.materials.columns.<user_id>` (fallback `cbs.materials.columns`). Resetting clears the stored preference only; sorting/filtering continue to function normally.
 - **Filters** (currently implemented): status, format. (Future: date range, components, type, facilitator.)  
 - **Row actions** per permissions: Open, Edit, Mark Shipped, Mark Delivered.
 

--- a/app/routes/materials_orders.py
+++ b/app/routes/materials_orders.py
@@ -52,6 +52,7 @@ def list_orders():
         mstatus = sh.status
         rows.append(
             {
+                "order_id": sh.id,
                 "client": client.name if client else "",
                 "title": sess.title,
                 "workshop_type": wt.name if wt else "",
@@ -63,6 +64,7 @@ def list_orders():
             }
         )
     key_funcs = {
+        "order_id": lambda r: r["order_id"],
         "client": lambda r: (r["client"] or "").lower(),
         "title": lambda r: (r["title"] or "").lower(),
         "workshop_type": lambda r: (r["workshop_type"] or "").lower(),

--- a/app/routes/sessions.py
+++ b/app/routes/sessions.py
@@ -268,6 +268,7 @@ def list_sessions(current_user):
     sort = request.args.get("sort", "start_date")
     direction = request.args.get("dir", "asc")
     columns = {
+        "id": Session.id,
         "title": Session.title,
         "client": Client.name,
         "location": Session.location,

--- a/app/static/css/table.css
+++ b/app/static/css/table.css
@@ -64,3 +64,137 @@
   white-space: nowrap;
   display: block;
 }
+
+.kt-table [data-column-hidden] {
+  display: none;
+}
+
+.dashboard-table {
+  position: relative;
+}
+
+.table-toolbar {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--space-2);
+  margin-bottom: var(--space-2);
+  position: relative;
+}
+
+.column-chooser-panel {
+  position: absolute;
+  right: 0;
+  top: calc(100% + var(--space-2));
+  width: min(320px, 90vw);
+  background: var(--kt-bg);
+  border: 1px solid var(--kt-border);
+  border-radius: var(--radius-md);
+  box-shadow: 0 12px 24px rgba(0, 0, 0, 0.15);
+  padding: var(--space-3);
+  z-index: 20;
+}
+
+.column-chooser__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: var(--space-2);
+  margin-bottom: var(--space-2);
+}
+
+.column-chooser__title {
+  font-size: 1rem;
+  margin: 0;
+}
+
+.column-chooser__hint {
+  margin: 0 0 var(--space-2) 0;
+  font-size: 0.9rem;
+  color: var(--kt-muted);
+}
+
+.column-chooser__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  max-height: 18rem;
+  overflow-y: auto;
+}
+
+.column-chooser__item {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-1) var(--space-2);
+  border-radius: var(--radius-md);
+  background: transparent;
+}
+
+.column-chooser__item[data-required='true'] {
+  opacity: 0.75;
+}
+
+.column-chooser__item.is-drag-over {
+  outline: 2px dashed var(--kt-info);
+}
+
+.column-chooser__item.is-dragging {
+  opacity: 0.6;
+}
+
+.column-chooser__drag {
+  font-size: 1rem;
+  color: var(--kt-muted);
+  cursor: grab;
+}
+
+.column-chooser__item[data-required='true'] .column-chooser__drag {
+  cursor: not-allowed;
+  color: var(--kt-border);
+}
+
+.column-chooser__check {
+  margin: 0;
+}
+
+.column-chooser__label {
+  flex: 1;
+}
+
+.column-chooser__moves {
+  display: flex;
+  gap: var(--space-1);
+  margin-left: auto;
+}
+
+.column-chooser__move {
+  border: 1px solid var(--kt-border);
+  background: var(--kt-bg);
+  border-radius: var(--radius-md);
+  padding: 2px 6px;
+  cursor: pointer;
+}
+
+.column-chooser__move span {
+  display: inline-block;
+  min-width: 0.75rem;
+}
+
+.column-chooser__move[disabled] {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.column-chooser__footer {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: var(--space-2);
+}
+
+.column-chooser__reset {
+  padding: 0;
+  font-size: 0.9rem;
+}

--- a/app/static/js/column_chooser.js
+++ b/app/static/js/column_chooser.js
@@ -1,0 +1,645 @@
+(function () {
+  'use strict';
+
+  var cssEscape = window.CSS && window.CSS.escape
+    ? window.CSS.escape.bind(window.CSS)
+    : function (value) {
+        return String(value).replace(/[\s!"#$%&'()*+,./:;<=>?@[\\\]^`{|}~]/g, '\\$&');
+      };
+
+  function storageAvailable() {
+    try {
+      var testKey = '__cbs__';
+      window.localStorage.setItem(testKey, testKey);
+      window.localStorage.removeItem(testKey);
+      return true;
+    } catch (err) {
+      return false;
+    }
+  }
+
+  var canUseStorage = storageAvailable();
+
+  function TableColumnChooser(container) {
+    this.container = container;
+    this.table = container.querySelector('table');
+    this.toggleButton = container.querySelector('[data-column-chooser-toggle]');
+    if (!this.table || !this.toggleButton) {
+      return;
+    }
+
+    this.panelId = 'column-chooser-' + Math.random().toString(36).slice(2, 9);
+    this.label = container.getAttribute('data-chooser-label') || 'Choose columns';
+    this.storageKey = container.getAttribute('data-storage-key') || '';
+
+    this.columns = this.collectColumns();
+    if (!this.columns.length) {
+      return;
+    }
+
+    this.requiredKeys = this.columns
+      .filter(function (col) {
+        return col.required;
+      })
+      .map(function (col) {
+        return col.key;
+      });
+    this.optionalKeys = this.columns
+      .filter(function (col) {
+        return !col.required;
+      })
+      .map(function (col) {
+        return col.key;
+      });
+    this.optionalDefaultOrder = this.optionalKeys.slice();
+    this.defaultHidden = new Set(
+      this.columns
+        .filter(function (col) {
+          return !col.required && col.defaultHidden;
+        })
+        .map(function (col) {
+          return col.key;
+        })
+    );
+
+    this.state = this.loadState();
+    this.controlMap = new Map();
+    this.draggedItem = null;
+    this.draggedKey = null;
+
+    this.buildPanel();
+    this.syncListToState(this.state);
+    this.applyState(this.state);
+    this.bindEvents();
+    container.dataset.columnChooserInitialized = 'true';
+  }
+
+  TableColumnChooser.prototype.collectColumns = function () {
+    var headerRow = this.table.querySelector('thead tr');
+    if (!headerRow) {
+      return [];
+    }
+    var headers = headerRow.querySelectorAll('[data-column-key]');
+    var columns = [];
+    headers.forEach(function (th) {
+      var key = th.getAttribute('data-column-key');
+      if (!key) {
+        return;
+      }
+      columns.push({
+        key: key,
+        label: th.getAttribute('data-column-label') || th.textContent.trim(),
+        required: th.getAttribute('data-column-required') === 'true',
+        defaultHidden: th.getAttribute('data-column-default-hidden') === 'true',
+      });
+    });
+    return columns;
+  };
+
+  TableColumnChooser.prototype.loadState = function () {
+    var state = {
+      order: [],
+      hidden: new Set(this.defaultHidden),
+    };
+    if (!canUseStorage || !this.storageKey) {
+      return state;
+    }
+    try {
+      var raw = window.localStorage.getItem(this.storageKey);
+      if (!raw) {
+        return state;
+      }
+      var data = JSON.parse(raw);
+      if (Array.isArray(data.order)) {
+        state.order = data.order.filter(
+          function (key) {
+            return this.optionalKeys.indexOf(key) !== -1;
+          }.bind(this)
+        );
+      }
+      if (Array.isArray(data.hidden)) {
+        state.hidden = new Set(
+          data.hidden.filter(
+            function (key) {
+              return this.optionalKeys.indexOf(key) !== -1;
+            }.bind(this)
+          )
+        );
+      }
+    } catch (err) {
+      // ignore malformed storage
+    }
+    return state;
+  };
+
+  TableColumnChooser.prototype.saveState = function () {
+    if (!canUseStorage || !this.storageKey) {
+      return;
+    }
+    var payload = {
+      order: this.state.order.filter(
+        function (key) {
+          return this.optionalKeys.indexOf(key) !== -1;
+        }.bind(this)
+      ),
+      hidden: Array.from(this.state.hidden),
+    };
+    try {
+      window.localStorage.setItem(this.storageKey, JSON.stringify(payload));
+    } catch (err) {
+      // storage full or unavailable; ignore
+    }
+  };
+
+  TableColumnChooser.prototype.effectiveOptionalOrder = function (orderOverride) {
+    var result = [];
+    if (Array.isArray(orderOverride)) {
+      orderOverride.forEach(
+        function (key) {
+          if (this.optionalKeys.indexOf(key) !== -1 && result.indexOf(key) === -1) {
+            result.push(key);
+          }
+        }.bind(this)
+      );
+    }
+    this.optionalDefaultOrder.forEach(function (key) {
+      if (result.indexOf(key) === -1) {
+        result.push(key);
+      }
+    });
+    return result;
+  };
+
+  TableColumnChooser.prototype.applyState = function (state) {
+    var optionalOrder = this.effectiveOptionalOrder(state.order);
+    this.currentOptionalOrder = optionalOrder;
+    var finalOrder = this.requiredKeys.concat(optionalOrder);
+    this.reorderTable(finalOrder);
+    this.columns.forEach(
+      function (col) {
+        var visible = col.required || !state.hidden.has(col.key);
+        this.setColumnVisibility(col.key, visible);
+      }.bind(this)
+    );
+    this.updateControlStates();
+  };
+
+  TableColumnChooser.prototype.reorderTable = function (order) {
+    var headerRow = this.table.querySelector('thead tr');
+    if (headerRow) {
+      var headerFragment = document.createDocumentFragment();
+      order.forEach(function (key) {
+        var cell = headerRow.querySelector('[data-column-key="' + cssEscape(key) + '"]');
+        if (cell) {
+          headerFragment.appendChild(cell);
+        }
+      });
+      headerRow.appendChild(headerFragment);
+    }
+    var bodyRows = this.table.querySelectorAll('tbody tr');
+    bodyRows.forEach(function (row) {
+      var fragment = document.createDocumentFragment();
+      order.forEach(function (key) {
+        var cell = row.querySelector('[data-column-key="' + cssEscape(key) + '"]');
+        if (cell) {
+          fragment.appendChild(cell);
+        }
+      });
+      row.appendChild(fragment);
+    });
+  };
+
+  TableColumnChooser.prototype.setColumnVisibility = function (key, visible) {
+    var selector = '[data-column-key="' + cssEscape(key) + '"]';
+    this.table.querySelectorAll(selector).forEach(function (cell) {
+      if (visible) {
+        cell.removeAttribute('data-column-hidden');
+      } else {
+        cell.setAttribute('data-column-hidden', 'true');
+      }
+    });
+  };
+
+  TableColumnChooser.prototype.buildPanel = function () {
+    var panel = document.createElement('div');
+    panel.className = 'column-chooser-panel';
+    panel.setAttribute('role', 'dialog');
+    panel.setAttribute('aria-label', this.label);
+    panel.id = this.panelId;
+    panel.hidden = true;
+
+    var header = document.createElement('div');
+    header.className = 'column-chooser__header';
+    var title = document.createElement('h2');
+    title.className = 'column-chooser__title';
+    title.textContent = this.label;
+    var closeBtn = document.createElement('button');
+    closeBtn.type = 'button';
+    closeBtn.className = 'column-chooser__close btn btn-secondary btn-sm';
+    closeBtn.textContent = 'Close';
+    closeBtn.addEventListener(
+      'click',
+      function () {
+        this.close();
+      }.bind(this)
+    );
+    header.appendChild(title);
+    header.appendChild(closeBtn);
+    panel.appendChild(header);
+
+    var hint = document.createElement('p');
+    hint.className = 'column-chooser__hint';
+    hint.textContent = 'Select columns to show or hide. Drag optional columns to change their order.';
+    panel.appendChild(hint);
+
+    var list = document.createElement('ul');
+    list.className = 'column-chooser__list';
+    panel.appendChild(list);
+    this.list = list;
+
+    this.columns.forEach(
+      function (col) {
+        var item = this.createListItem(col);
+        list.appendChild(item);
+      }.bind(this)
+    );
+
+    var footer = document.createElement('div');
+    footer.className = 'column-chooser__footer';
+    var resetBtn = document.createElement('button');
+    resetBtn.type = 'button';
+    resetBtn.className = 'column-chooser__reset btn btn-link';
+    resetBtn.textContent = 'Reset to defaults';
+    resetBtn.addEventListener(
+      'click',
+      function () {
+        this.reset();
+      }.bind(this)
+    );
+    footer.appendChild(resetBtn);
+    panel.appendChild(footer);
+
+    this.panel = panel;
+    this.toggleButton.setAttribute('aria-controls', this.panelId);
+    var toolbar = this.container.querySelector('.table-toolbar');
+    if (toolbar) {
+      toolbar.appendChild(panel);
+    } else {
+      this.container.insertBefore(panel, this.container.querySelector('.kt-table-wrapper'));
+    }
+  };
+
+  TableColumnChooser.prototype.createListItem = function (col) {
+    var item = document.createElement('li');
+    item.className = 'column-chooser__item';
+    item.setAttribute('data-column-key', col.key);
+    if (col.required) {
+      item.setAttribute('data-required', 'true');
+    }
+
+    var drag = document.createElement('span');
+    drag.className = 'column-chooser__drag';
+    drag.setAttribute('aria-hidden', 'true');
+    drag.textContent = '≡';
+    item.appendChild(drag);
+
+    var checkbox = document.createElement('input');
+    checkbox.type = 'checkbox';
+    checkbox.id = this.panelId + '-' + col.key;
+    checkbox.className = 'column-chooser__check';
+    checkbox.checked = true;
+    if (col.required) {
+      checkbox.disabled = true;
+      checkbox.setAttribute('disabled', 'disabled');
+    }
+    checkbox.addEventListener(
+      'change',
+      function (event) {
+        this.onCheckboxChange(col, event.target.checked);
+      }.bind(this)
+    );
+
+    var label = document.createElement('label');
+    label.className = 'column-chooser__label';
+    label.setAttribute('for', checkbox.id);
+    label.textContent = col.label;
+
+    item.appendChild(checkbox);
+    item.appendChild(label);
+
+    var moveUp = null;
+    var moveDown = null;
+
+    if (!col.required) {
+      item.setAttribute('draggable', 'true');
+      item.addEventListener(
+        'dragstart',
+        function (event) {
+          this.onDragStart(event, item, col.key);
+        }.bind(this)
+      );
+      item.addEventListener(
+        'dragover',
+        function (event) {
+          this.onDragOver(event, item);
+        }.bind(this)
+      );
+      item.addEventListener(
+        'dragleave',
+        function () {
+          item.classList.remove('is-drag-over');
+        }
+      );
+      item.addEventListener(
+        'drop',
+        function (event) {
+          this.onDrop(event, item);
+        }.bind(this)
+      );
+      item.addEventListener(
+        'dragend',
+        function () {
+          this.onDragEnd();
+        }.bind(this)
+      );
+
+      var moveWrapper = document.createElement('div');
+      moveWrapper.className = 'column-chooser__moves';
+
+      moveUp = document.createElement('button');
+      moveUp.type = 'button';
+      moveUp.className = 'column-chooser__move';
+      moveUp.setAttribute('aria-label', 'Move ' + col.label + ' left');
+      moveUp.innerHTML = '<span aria-hidden="true">←</span>';
+      moveUp.addEventListener(
+        'click',
+        function () {
+          this.moveColumn(col.key, -1);
+        }.bind(this)
+      );
+
+      moveDown = document.createElement('button');
+      moveDown.type = 'button';
+      moveDown.className = 'column-chooser__move';
+      moveDown.setAttribute('aria-label', 'Move ' + col.label + ' right');
+      moveDown.innerHTML = '<span aria-hidden="true">→</span>';
+      moveDown.addEventListener(
+        'click',
+        function () {
+          this.moveColumn(col.key, 1);
+        }.bind(this)
+      );
+
+      moveWrapper.appendChild(moveUp);
+      moveWrapper.appendChild(moveDown);
+      item.appendChild(moveWrapper);
+    }
+
+    this.controlMap.set(col.key, {
+      checkbox: checkbox,
+      item: item,
+      moveUp: moveUp,
+      moveDown: moveDown,
+      required: col.required,
+    });
+
+    return item;
+  };
+
+  TableColumnChooser.prototype.onCheckboxChange = function (col, visible) {
+    if (col.required) {
+      return;
+    }
+    if (!visible) {
+      this.state.hidden.add(col.key);
+    } else {
+      this.state.hidden.delete(col.key);
+    }
+    this.applyState(this.state);
+    this.saveState();
+  };
+
+  TableColumnChooser.prototype.onDragStart = function (event, item, key) {
+    this.draggedItem = item;
+    this.draggedKey = key;
+    item.classList.add('is-dragging');
+    if (event.dataTransfer) {
+      event.dataTransfer.effectAllowed = 'move';
+      event.dataTransfer.setData('text/plain', key);
+    }
+  };
+
+  TableColumnChooser.prototype.onDragOver = function (event, item) {
+    if (!this.draggedItem || item === this.draggedItem || item.dataset.required) {
+      return;
+    }
+    event.preventDefault();
+    if (event.dataTransfer) {
+      event.dataTransfer.dropEffect = 'move';
+    }
+    item.classList.add('is-drag-over');
+  };
+
+  TableColumnChooser.prototype.onDrop = function (event, item) {
+    if (!this.draggedItem || item === this.draggedItem || item.dataset.required) {
+      return;
+    }
+    event.preventDefault();
+    item.classList.remove('is-drag-over');
+    var optionalItems = Array.from(this.list.children).filter(function (el) {
+      return !el.dataset.required;
+    });
+    var draggedIndex = optionalItems.indexOf(this.draggedItem);
+    var targetIndex = optionalItems.indexOf(item);
+    if (draggedIndex === -1 || targetIndex === -1) {
+      return;
+    }
+    if (draggedIndex < targetIndex) {
+      this.list.insertBefore(this.draggedItem, item.nextSibling);
+    } else {
+      this.list.insertBefore(this.draggedItem, item);
+    }
+    this.updateStateFromList();
+  };
+
+  TableColumnChooser.prototype.onDragEnd = function () {
+    if (this.draggedItem) {
+      this.draggedItem.classList.remove('is-dragging');
+    }
+    this.draggedItem = null;
+    this.draggedKey = null;
+    this.list.querySelectorAll('.is-drag-over').forEach(function (el) {
+      el.classList.remove('is-drag-over');
+    });
+  };
+
+  TableColumnChooser.prototype.updateStateFromList = function () {
+    var order = Array.from(this.list.children)
+      .filter(function (el) {
+        return !el.dataset.required;
+      })
+      .map(function (el) {
+        return el.getAttribute('data-column-key');
+      });
+    this.state.order = order;
+    this.applyState(this.state);
+    this.saveState();
+  };
+
+  TableColumnChooser.prototype.moveColumn = function (key, delta) {
+    var optionalOrder = this.effectiveOptionalOrder(this.state.order);
+    var index = optionalOrder.indexOf(key);
+    if (index === -1) {
+      return;
+    }
+    var newIndex = index + delta;
+    if (newIndex < 0 || newIndex >= optionalOrder.length) {
+      return;
+    }
+    optionalOrder.splice(index, 1);
+    optionalOrder.splice(newIndex, 0, key);
+    this.state.order = optionalOrder.filter(
+      function (colKey) {
+        return this.optionalKeys.indexOf(colKey) !== -1;
+      }.bind(this)
+    );
+    this.syncListToState(this.state);
+    this.applyState(this.state);
+    this.saveState();
+  };
+
+  TableColumnChooser.prototype.updateControlStates = function () {
+    var hidden = this.state.hidden;
+    var optionalOrder = this.effectiveOptionalOrder(this.state.order);
+    var firstOptional = optionalOrder[0];
+    var lastOptional = optionalOrder[optionalOrder.length - 1];
+    this.controlMap.forEach(function (control, key) {
+      var visible = control.required || !hidden.has(key);
+      control.checkbox.checked = visible;
+      if (control.moveUp) {
+        control.moveUp.disabled = key === firstOptional || optionalOrder.length <= 1;
+      }
+      if (control.moveDown) {
+        control.moveDown.disabled = key === lastOptional || optionalOrder.length <= 1;
+      }
+    });
+  };
+
+  TableColumnChooser.prototype.syncListToState = function (state) {
+    if (!this.list) {
+      return;
+    }
+    var itemsByKey = new Map();
+    Array.from(this.list.children).forEach(function (item) {
+      itemsByKey.set(item.getAttribute('data-column-key'), item);
+    });
+    var order = this.requiredKeys.concat(this.effectiveOptionalOrder(state.order));
+    var fragment = document.createDocumentFragment();
+    order.forEach(function (key) {
+      var item = itemsByKey.get(key);
+      if (item) {
+        fragment.appendChild(item);
+      }
+    });
+    this.list.appendChild(fragment);
+  };
+
+  TableColumnChooser.prototype.open = function () {
+    if (!this.panel.hidden) {
+      return;
+    }
+    this.previousFocus = document.activeElement;
+    this.panel.hidden = false;
+    this.toggleButton.setAttribute('aria-expanded', 'true');
+    var focusTarget = this.panel.querySelector('input:not([disabled])') || this.panel.querySelector('button');
+    if (focusTarget) {
+      focusTarget.focus();
+    }
+    document.addEventListener('click', this.boundDocumentClick, true);
+    document.addEventListener('keydown', this.boundKeydown, true);
+  };
+
+  TableColumnChooser.prototype.close = function () {
+    if (this.panel.hidden) {
+      return;
+    }
+    this.panel.hidden = true;
+    this.toggleButton.setAttribute('aria-expanded', 'false');
+    document.removeEventListener('click', this.boundDocumentClick, true);
+    document.removeEventListener('keydown', this.boundKeydown, true);
+    if (this.previousFocus && typeof this.previousFocus.focus === 'function') {
+      this.previousFocus.focus();
+    } else {
+      this.toggleButton.focus();
+    }
+  };
+
+  TableColumnChooser.prototype.toggle = function () {
+    if (this.panel.hidden) {
+      this.open();
+    } else {
+      this.close();
+    }
+  };
+
+  TableColumnChooser.prototype.reset = function () {
+    if (canUseStorage && this.storageKey) {
+      try {
+        window.localStorage.removeItem(this.storageKey);
+      } catch (err) {
+        // ignore
+      }
+    }
+    this.state = {
+      order: [],
+      hidden: new Set(this.defaultHidden),
+    };
+    this.syncListToState(this.state);
+    this.applyState(this.state);
+  };
+
+  TableColumnChooser.prototype.onDocumentClick = function (event) {
+    if (!this.panel.contains(event.target) && !this.toggleButton.contains(event.target)) {
+      this.close();
+    }
+  };
+
+  TableColumnChooser.prototype.onKeydown = function (event) {
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      this.close();
+    }
+  };
+
+  TableColumnChooser.prototype.bindEvents = function () {
+    this.boundDocumentClick = this.onDocumentClick.bind(this);
+    this.boundKeydown = this.onKeydown.bind(this);
+    this.toggleButton.addEventListener(
+      'click',
+      function () {
+        this.toggle();
+      }.bind(this)
+    );
+  };
+
+  function initAll() {
+    document.querySelectorAll('[data-column-chooser]').forEach(function (container) {
+      if (container.dataset.columnChooserInitialized === 'true') {
+        return;
+      }
+      new TableColumnChooser(container);
+    });
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', initAll);
+  } else {
+    initAll();
+  }
+
+  window.CBS = window.CBS || {};
+  window.CBS.ColumnChooser = {
+    init: initAll,
+    TableColumnChooser: TableColumnChooser,
+  };
+})();

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -74,4 +74,5 @@ document.addEventListener('click', function(e){
   }
 });
 </script>
+{% block extra_js %}{% endblock %}
 </html>

--- a/app/templates/materials_orders.html
+++ b/app/templates/materials_orders.html
@@ -30,6 +30,8 @@
     </select>
   </label>
   <button type="submit">Filter</button>
+  <input type="hidden" name="sort" value="{{ sort }}">
+  <input type="hidden" name="dir" value="{{ dir }}">
 </form>
 <p>
   {% if show_closed %}
@@ -43,28 +45,54 @@
 {% if order_type %}{% set base = base + '&order_type=' + order_type|urlencode %}{% endif %}
 {% if status %}{% set base = base + '&status=' + status %}{% endif %}
 {% if show_closed %}{% set base = base + '&closed=1' %}{% endif %}
-<div class="kt-table-wrapper">
-<table class="kt-table">
-  <tr>
-    <th><a href="?sort=title{{ base }}">Workshop title</a></th>
-    <th><a href="?sort=client{{ base }}">Client</a></th>
-    <th><a href="?sort=workshop_type{{ base }}">Workshop</a></th>
-    <th><a href="?sort=arrival_date{{ base }}">Latest Arrival Date</a></th>
-    <th><a href="?sort=order_type{{ base }}">Materials Order type</a></th>
-    <th><a href="?sort=materials_status{{ base }}">Materials order status</a></th>
-    <th><a href="?sort=session_status{{ base }}">Workshop status</a></th>
-  </tr>
-  {% for row in rows %}
-  <tr>
-    <td><a href="{{ url_for('materials.materials_view', session_id=row.session_id)}}">{{ row.title }}</a></td>
-    <td>{{ row.client }}</td>
-    <td>{{ row.workshop_type }}</td>
-    <td>{{ row.arrival_date }}</td>
-    <td>{{ row.order_type }}</td>
-    <td><span class="pill pill--{{ row.materials_status|lower|replace(' ', '') }}">{{ row.materials_status }}</span></td>
-    <td><span class="pill pill--{{ row.session_status|lower|replace(' ', '') }}">{{ row.session_status }}</span></td>
-  </tr>
-  {% endfor %}
-</table>
+{% if current_user and current_user.id %}
+  {% set storage_key = 'cbs.materials.columns.' ~ current_user.id %}
+{% else %}
+  {% set storage_key = 'cbs.materials.columns' %}
+{% endif %}
+<div class="dashboard-table" data-column-chooser data-storage-key="{{ storage_key }}" data-chooser-label="Choose columns">
+  <div class="table-toolbar">
+    <button type="button" class="btn btn-secondary btn-sm" data-column-chooser-toggle aria-haspopup="dialog" aria-expanded="false">Columns</button>
+  </div>
+  <div class="kt-table-wrapper">
+    <table class="kt-table">
+      <thead>
+        <tr>
+          {% macro sort_link(label, field) -%}
+            {% set is_sorted = sort == field %}
+            {% set next_dir = 'desc' if is_sorted and dir == 'asc' else 'asc' %}
+            <a href="?sort={{ field }}&dir={{ next_dir }}{{ base }}">{{ label }}</a>
+          {%- endmacro %}
+          <th scope="col" data-column-key="order_id" data-column-label="Order ID" data-column-required="true" class="cell-nowrap">{{ sort_link('Order ID','order_id') }}</th>
+          <th scope="col" data-column-key="title" data-column-label="Workshop title" data-column-required="true">{{ sort_link('Workshop title','title') }}</th>
+          <th scope="col" data-column-key="client" data-column-label="Client">{{ sort_link('Client','client') }}</th>
+          <th scope="col" data-column-key="workshop_type" data-column-label="Workshop">{{ sort_link('Workshop','workshop_type') }}</th>
+          <th scope="col" data-column-key="arrival_date" data-column-label="Latest Arrival Date" class="cell-nowrap">{{ sort_link('Latest Arrival Date','arrival_date') }}</th>
+          <th scope="col" data-column-key="order_type" data-column-label="Materials Order type">{{ sort_link('Materials Order type','order_type') }}</th>
+          <th scope="col" data-column-key="materials_status" data-column-label="Materials order status">{{ sort_link('Materials order status','materials_status') }}</th>
+          <th scope="col" data-column-key="session_status" data-column-label="Workshop status">{{ sort_link('Workshop status','session_status') }}</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for row in rows %}
+        <tr>
+          <td data-column-key="order_id" class="cell-nowrap">{{ row.order_id }}</td>
+          <td data-column-key="title"><a href="{{ url_for('materials.materials_view', session_id=row.session_id)}}">{{ row.title }}</a></td>
+          <td data-column-key="client">{{ row.client }}</td>
+          <td data-column-key="workshop_type">{{ row.workshop_type }}</td>
+          <td data-column-key="arrival_date" class="cell-nowrap">{{ row.arrival_date }}</td>
+          <td data-column-key="order_type">{{ row.order_type }}</td>
+          <td data-column-key="materials_status"><span class="pill pill--{{ row.materials_status|lower|replace(' ', '') }}">{{ row.materials_status }}</span></td>
+          <td data-column-key="session_status"><span class="pill pill--{{ row.session_status|lower|replace(' ', '') }}">{{ row.session_status }}</span></td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
 </div>
+{% endblock %}
+
+{% block extra_js %}
+  {{ super() }}
+  <script src="{{ url_for('static', filename='js/column_chooser.js') }}" defer></script>
 {% endblock %}

--- a/app/templates/sessions.html
+++ b/app/templates/sessions.html
@@ -51,55 +51,78 @@
   <a href="{{ url_for('sessions.list_sessions') }}">Clear</a>
 </form><br>
 
-<div class="kt-table-wrapper">
-<table class="kt-table">
-  <tr>
-    {% macro sort_link(label, field) -%}
-      {% set dir = 'desc' if sort==field and direction=='asc' else 'asc' %}
-      <a href="{{ url_for('sessions.list_sessions', sort=field, dir=dir, **base_params) }}">{{ label }}</a>
-    {%- endmacro %}
-    <th>{{ sort_link('Title','title') }}</th>
-    <th>{{ sort_link('Client','client') }}</th>
-    <th>{{ sort_link('Location','location') }}</th>
-    <th>{{ sort_link('Workshop Type','workshop_type') }}</th>
-    <th class="cell-nowrap">{{ sort_link('Start Date','start_date') }}</th>
-    <th class="cell-nowrap">{{ sort_link('Status','status') }}</th>
-    <th class="cell-nowrap">{{ sort_link('Region','region') }}</th>
-    <th class="col-actions">Actions</th>
-  </tr>
-  {% for s in sessions %}
-  <tr>
-    <td>
-      <span class="cell-ellipsis" title="{{ s.title }}">
-        <a href="{{ url_for('sessions.session_detail', session_id=s.id) }}">{{ s.title }}</a>
-      </span>
-    </td>
-    <td>
-      {% if s.client %}
-        <span class="cell-ellipsis" title="{{ s.client.name }}">{{ s.client.name }}</span>
-      {% endif %}
-    </td>
-    <td>
-      {% if s.location %}
-        <span class="cell-ellipsis" title="{{ s.location }}">{{ s.location }}</span>
-      {% endif %}
-    </td>
-    <td>
-      {% if s.workshop_type %}
-        {% set workshop_label = s.workshop_type.code ~ ' — ' ~ s.workshop_type.name %}
-        <span class="cell-ellipsis" title="{{ workshop_label }}">{{ workshop_label }}</span>
-      {% endif %}
-    </td>
-    <td class="cell-nowrap">{{ s.start_date }}</td>
-    <td class="cell-nowrap">{{ s.computed_status }}</td>
-    <td class="cell-nowrap">{{ s.region }}</td>
-    <td class="col-actions">
-      {% if current_user and (current_user.is_app_admin or current_user.is_admin or current_user.is_kt_delivery or current_user.is_kt_contractor) %}
-        <a class="btn btn-primary btn-sm" href="{{ url_for('sessions.session_prework', session_id=s.id) }}">Prework</a>
-      {% endif %}
-    </td>
-  </tr>
-  {% endfor %}
-</table>
+{% if current_user and current_user.id %}
+  {% set storage_key = 'cbs.sessions.columns.' ~ current_user.id %}
+{% else %}
+  {% set storage_key = 'cbs.sessions.columns' %}
+{% endif %}
+<div class="dashboard-table" data-column-chooser data-storage-key="{{ storage_key }}" data-chooser-label="Choose columns">
+  <div class="table-toolbar">
+    <button type="button" class="btn btn-secondary btn-sm" data-column-chooser-toggle aria-haspopup="dialog" aria-expanded="false">Columns</button>
+  </div>
+  <div class="kt-table-wrapper">
+    <table class="kt-table">
+      <thead>
+        <tr>
+          {% macro sort_link(label, field) -%}
+            {% set dir = 'desc' if sort==field and direction=='asc' else 'asc' %}
+            <a href="{{ url_for('sessions.list_sessions', sort=field, dir=dir, **base_params) }}">{{ label }}</a>
+          {%- endmacro %}
+          <th scope="col" data-column-key="id" data-column-label="ID" data-column-required="true" class="cell-nowrap">{{ sort_link('ID','id') }}</th>
+          <th scope="col" data-column-key="title" data-column-label="Title" data-column-required="true">
+            {{ sort_link('Title','title') }}
+          </th>
+          <th scope="col" data-column-key="client" data-column-label="Client">{{ sort_link('Client','client') }}</th>
+          <th scope="col" data-column-key="location" data-column-label="Location">{{ sort_link('Location','location') }}</th>
+          <th scope="col" data-column-key="workshop_type" data-column-label="Workshop Type">{{ sort_link('Workshop Type','workshop_type') }}</th>
+          <th scope="col" data-column-key="start_date" data-column-label="Start Date" class="cell-nowrap">{{ sort_link('Start Date','start_date') }}</th>
+          <th scope="col" data-column-key="status" data-column-label="Status" class="cell-nowrap">{{ sort_link('Status','status') }}</th>
+          <th scope="col" data-column-key="region" data-column-label="Region" class="cell-nowrap">{{ sort_link('Region','region') }}</th>
+          <th scope="col" data-column-key="actions" data-column-label="Actions" class="col-actions">Actions</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for s in sessions %}
+        <tr>
+          <td data-column-key="id" class="cell-nowrap">{{ s.id }}</td>
+          <td data-column-key="title">
+            <span class="cell-ellipsis" title="{{ s.title }}">
+              <a href="{{ url_for('sessions.session_detail', session_id=s.id) }}">{{ s.title }}</a>
+            </span>
+          </td>
+          <td data-column-key="client">
+            {% if s.client %}
+              <span class="cell-ellipsis" title="{{ s.client.name }}">{{ s.client.name }}</span>
+            {% endif %}
+          </td>
+          <td data-column-key="location">
+            {% if s.location %}
+              <span class="cell-ellipsis" title="{{ s.location }}">{{ s.location }}</span>
+            {% endif %}
+          </td>
+          <td data-column-key="workshop_type">
+            {% if s.workshop_type %}
+              {% set workshop_label = s.workshop_type.code ~ ' — ' ~ s.workshop_type.name %}
+              <span class="cell-ellipsis" title="{{ workshop_label }}">{{ workshop_label }}</span>
+            {% endif %}
+          </td>
+          <td data-column-key="start_date" class="cell-nowrap">{{ s.start_date }}</td>
+          <td data-column-key="status" class="cell-nowrap">{{ s.computed_status }}</td>
+          <td data-column-key="region" class="cell-nowrap">{{ s.region }}</td>
+          <td data-column-key="actions" class="col-actions">
+            {% if current_user and (current_user.is_app_admin or current_user.is_admin or current_user.is_kt_delivery or current_user.is_kt_contractor) %}
+              <a class="btn btn-primary btn-sm" href="{{ url_for('sessions.session_prework', session_id=s.id) }}">Prework</a>
+            {% endif %}
+          </td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
 </div>
+{% endblock %}
+
+{% block extra_js %}
+  {{ super() }}
+  <script src="{{ url_for('static', filename='js/column_chooser.js') }}" defer></script>
 {% endblock %}

--- a/tests/test_column_chooser_ui.py
+++ b/tests/test_column_chooser_ui.py
@@ -1,0 +1,110 @@
+import json
+
+import pytest
+
+pytestmark = pytest.mark.smoke
+
+
+class ColumnChooserHarness:
+    """Simulates the front-end column chooser state machine."""
+
+    def __init__(self, columns, storage, storage_key):
+        self.columns = columns
+        self.storage = storage
+        self.storage_key = storage_key
+        self.required_keys = [col["key"] for col in columns if col.get("required")]
+        self.optional_keys = [col["key"] for col in columns if not col.get("required")]
+        self.optional_default_order = list(self.optional_keys)
+        state = self._load_state()
+        self.hidden = state["hidden"]
+        self.order_override = state["order"]
+        self.visible = {
+            col["key"]: (col.get("required") or col["key"] not in self.hidden)
+            for col in columns
+        }
+        self.column_order = self._effective_order()
+
+    def _effective_optional_order(self):
+        ordered = []
+        for key in self.order_override:
+            if key in self.optional_keys and key not in ordered:
+                ordered.append(key)
+        for key in self.optional_default_order:
+            if key not in ordered:
+                ordered.append(key)
+        return ordered
+
+    def _effective_order(self):
+        return self.required_keys + self._effective_optional_order()
+
+    def _load_state(self):
+        raw = self.storage.get(self.storage_key)
+        if not raw:
+            return {"order": [], "hidden": set()}
+        data = json.loads(raw)
+        order = [key for key in data.get("order", []) if key in self.optional_keys]
+        hidden = {key for key in data.get("hidden", []) if key in self.optional_keys}
+        return {"order": order, "hidden": hidden}
+
+    def toggle(self, key, visible):
+        if key in self.required_keys:
+            return
+        if visible:
+            self.hidden.discard(key)
+        else:
+            self.hidden.add(key)
+        self.visible[key] = visible
+        self._persist()
+
+    def reset(self):
+        self.hidden = set()
+        self.order_override = []
+        self.visible = {
+            col["key"]: col.get("required", False) or col["key"] not in self.hidden
+            for col in self.columns
+        }
+        self.column_order = self._effective_order()
+        self._persist()
+
+    def _persist(self):
+        payload = json.dumps(
+            {
+                "order": self.order_override,
+                "hidden": sorted(self.hidden),
+            }
+        )
+        self.storage[self.storage_key] = payload
+        self.column_order = self._effective_order()
+        for key in self.optional_keys:
+            self.visible[key] = key not in self.hidden
+
+
+def test_column_visibility_persists_after_reload():
+    columns = [
+        {"key": "id", "required": True},
+        {"key": "title", "required": True},
+        {"key": "client"},
+        {"key": "location"},
+        {"key": "workshop_type"},
+    ]
+    storage = {}
+    storage_key = "cbs.sessions.columns.42"
+
+    chooser = ColumnChooserHarness(columns, storage, storage_key)
+    assert chooser.column_order[:2] == ["id", "title"]
+    assert chooser.visible["client"] is True
+
+    chooser.toggle("client", False)
+    assert chooser.visible["client"] is False
+    persisted = json.loads(storage[storage_key])
+    assert persisted["hidden"] == ["client"]
+
+    # Simulate a fresh load that reuses stored preferences.
+    new_instance = ColumnChooserHarness(columns, storage, storage_key)
+    assert new_instance.visible["client"] is False
+    assert new_instance.column_order[:2] == ["id", "title"]
+
+    new_instance.toggle("client", True)
+    assert new_instance.visible["client"] is True
+    persisted_again = json.loads(storage[storage_key])
+    assert persisted_again["hidden"] == []


### PR DESCRIPTION
## Summary
- add mandatory ID column and per-user column chooser controls to the sessions and materials dashboards
- implement reusable JavaScript + styles to handle column toggling, drag reordering, persistence, and reset
- document the behavior in CONTEXT.md and add a smoke test that simulates persistence across reloads

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c886eedfa8832e9f30e1ef9c3a8220