### PR TITLE
Align sessions and materials forms

### DIFF
--- a/app/static/css/forms.css
+++ b/app/static/css/forms.css
@@ -136,6 +136,75 @@ label {
   margin-top: 4px;
 }
 
+/* Scoped form alignment utility */
+.form-align {
+  --form-align-label-width: 220px;
+  --form-align-gap: 12px;
+}
+
+.form-align .form-align__row {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  margin-bottom: var(--gap-y, 8px);
+}
+
+.form-align .form-align__row--top {
+  align-items: flex-start;
+}
+
+.form-align .form-align__label {
+  flex: 0 0 var(--form-align-label-width);
+  max-width: var(--form-align-label-width);
+  text-align: right;
+  padding-right: var(--form-align-gap);
+}
+
+.form-align .form-align__control {
+  display: block;
+}
+
+.form-align .form-align__note {
+  margin-left: 8px;
+}
+
+.form-align > .form-help,
+.form-align .form-align__help {
+  margin-left: calc(var(--form-align-label-width) + var(--form-align-gap));
+}
+
+.form-align .form-align__row--checkbox {
+  align-items: center;
+  padding-left: calc(var(--form-align-label-width) + var(--form-align-gap));
+}
+
+.form-align .form-align__row--checkbox .form-align__control {
+  display: inline-block;
+}
+
+@media (max-width: 720px) {
+  .form-align .form-align__row {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .form-align .form-align__label {
+    flex: 0 0 auto;
+    width: 100%;
+    max-width: 100%;
+    text-align: left;
+    padding-right: 0;
+    margin-bottom: 4px;
+  }
+
+  .form-align > .form-help,
+  .form-align .form-align__help,
+  .form-align .form-align__row--checkbox {
+    margin-left: 0;
+    padding-left: 0;
+  }
+}
+
 .error,
 .invalid-feedback {
   color: var(--kt-accent-red);

--- a/app/templates/sessions/form.html
+++ b/app/templates/sessions/form.html
@@ -6,34 +6,47 @@
   <fieldset>
     <legend>Order Information</legend>
     {% set _title = title_override if title_override is not none else session.title %}
-    <div><label>Title* <input type="text" name="title" value="{{ _title or '' }}" required></label></div>
-    <div><label>Client*
-      <select name="client_id" id="client-select" required>
-        <option value="">--Select--</option>
-        {% for c in clients %}
-        <option value="{{ c.id }}" {% if session and session.client_id==c.id %}selected{% endif %} data-crm="{% if c.crm %}{{ c.crm.full_name or c.crm.email }}{% endif %}">{{ c.name }}</option>
-        {% endfor %}
-      </select>
-      <a href="#" id="add-client" class="button">Add Client</a>
-      <span>CRM: <span id="crm-display">{% if session and session.client and session.client.crm %}{{ session.client.crm.full_name or session.client.crm.email }}{% endif %}</span></span>
-    </label>
-    </div>
-    <div>
-      <label>Region*
-        <select name="region" required>
-          <option value="">--Select--</option>
-          {% for opt in ['NA','EU','SEA','Other'] %}
-          <option value="{{ opt }}" {% if session and session.region==opt %}selected{% endif %}>{{ opt }}</option>
-          {% endfor %}
-        </select>
-      </label>
-      <label>Workshop language*
-        <select name="workshop_language" required>
-          {% for code,label in workshop_languages %}
-          <option value="{{ code }}" {% if session.workshop_language==code %}selected{% endif %}>{{ label }}</option>
-          {% endfor %}
-        </select>
-      </label>
+    <div class="form-align">
+      <div class="form-align__row">
+        <label class="form-align__label" for="title">Title*</label>
+        <div class="form-align__control">
+          <input type="text" id="title" name="title" value="{{ _title or '' }}" required>
+        </div>
+      </div>
+      <div class="form-align__row">
+        <label class="form-align__label" for="client-select">Client*</label>
+        <div class="form-align__control">
+          <select name="client_id" id="client-select" required>
+            <option value="">--Select--</option>
+            {% for c in clients %}
+            <option value="{{ c.id }}" {% if session and session.client_id==c.id %}selected{% endif %} data-crm="{% if c.crm %}{{ c.crm.full_name or c.crm.email }}{% endif %}">{{ c.name }}</option>
+            {% endfor %}
+          </select>
+          <a href="#" id="add-client" class="button">Add Client</a>
+          <span class="form-align__note">CRM: <span id="crm-display">{% if session and session.client and session.client.crm %}{{ session.client.crm.full_name or session.client.crm.email }}{% endif %}</span></span>
+        </div>
+      </div>
+      <div class="form-align__row">
+        <label class="form-align__label" for="region">Region*</label>
+        <div class="form-align__control">
+          <select name="region" id="region" required>
+            <option value="">--Select--</option>
+            {% for opt in ['NA','EU','SEA','Other'] %}
+            <option value="{{ opt }}" {% if session and session.region==opt %}selected{% endif %}>{{ opt }}</option>
+            {% endfor %}
+          </select>
+        </div>
+      </div>
+      <div class="form-align__row">
+        <label class="form-align__label" for="workshop-language">Workshop language*</label>
+        <div class="form-align__control">
+          <select name="workshop_language" id="workshop-language" required>
+            {% for code,label in workshop_languages %}
+            <option value="{{ code }}" {% if session.workshop_language==code %}selected{% endif %}>{{ label }}</option>
+            {% endfor %}
+          </select>
+        </div>
+      </div>
     </div>
     <div style="margin-top:8px;">
       <button type="submit" id="materials-only-btn" name="action" value="materials_only">No workshop, material order only</button>
@@ -41,97 +54,148 @@
   </fieldset>
   <fieldset>
     <legend>Workshop details</legend>
-    <div><label>Workshop*
-      <select name="workshop_type_id" required>
-        <option value="">--Select--</option>
-        {% for wt in workshop_types %}
-        <option value="{{ wt.id }}" data-langs="{{ wt.supported_languages|join(' ') if wt.supported_languages else '' }}" data-sim="{{ 1 if wt.simulation_based else 0 }}" {% if session and session.workshop_type_id==wt.id %}selected{% endif %}>{{ wt.code }}</option>
-        {% endfor %}
-      </select>
-    </label></div>
-    <div id="sim-outline" {% if not (workshop_type and workshop_type.simulation_based) %}style="display:none"{% endif %}><label>{% if workshop_type and workshop_type.simulation_based %}Simulation Outline{% endif %}
-      <select name="simulation_outline_id">
-        <option value="">— select —</option>
-        {% for o in simulation_outlines %}
-          {% set so_val = form.simulation_outline_id|int if form else session.simulation_outline_id %}
-          <option value="{{ o.id }}" {% if so_val == o.id %}selected{% endif %}>
-            {{ o.number }} — {{ o.skill }} — {{ o.descriptor }} ({{ o.level }})
-          </option>
-        {% endfor %}
-      </select></label></div>
-    <div><label>Delivery Type*
-      <select name="delivery_type" required>
-        <option value="">--Select--</option>
-        {% for opt in ['Onsite','Virtual','Self-paced','Hybrid'] %}
-        <option value="{{ opt }}" {% if session and session.delivery_type==opt %}selected{% endif %}>{{ opt }}</option>
-        {% endfor %}
-      </select>
-    </label></div>
-    <div>
-      <label>Workshop Location
-        <select name="workshop_location_id" id="workshop-location-select">
-          <option value=""></option>
-          {% for loc in workshop_locations %}
-          <option value="{{ loc.id }}" {% if session.workshop_location_id==loc.id %}selected{% endif %}>{{ loc.label }}</option>
-          {% endfor %}
-        </select>
-      </label>
-      <a href="#" id="add-workshop-location">Add</a>
-    </div>
-    <div><label>Capacity* <input type="number" name="capacity" value="{{ session.capacity or 16 }}" required></label></div>
-    <div>
-      <label>Start Date* <input type="date" id="start-date" name="start_date" value="{{ session.start_date or '' }}" required></label>
-      <input type="hidden" name="ack_past" id="ack-past" value="{{ form.ack_past if form else '' }}">
-      <label>End Date* <input type="date" id="end-date" name="end_date" value="{{ session.end_date or '' }}" min="{{ session.start_date or '' }}" required></label>
-    </div>
-    <div class="form-help">End date must be the same day or after the start date.</div>
-    {% if past_warning %}
-    <div style="color:red;"><label><input type="checkbox" id="ack-past-check" required> The selected start date is in the past. I'm sure.</label></div>
-    {% endif %}
-    <div>
-      <label>Daily Start Time <input type="time" name="daily_start_time" value="{{ daily_start_time_str or '08:00' }}"></label>
-      <label>End Time <input type="time" name="daily_end_time" value="{{ daily_end_time_str or '17:00' }}"></label>
-    </div>
-    <div><label>Timezone
-      <select name="timezone">
-        <option value="">--Select--</option>
-        {% for tz in timezones %}
-        <option value="{{ tz }}" {% if session.timezone==tz %}selected{% endif %}>{{ tz }}</option>
-        {% endfor %}
-      </select>
-    </label></div><br>
-    <div><label>Lead Facilitator
-      <select name="lead_facilitator_id">
-        <option value="">--Select--</option>
-        {% for u in facilitators %}
-        <option value="{{ u.id }}" {% if session and session.lead_facilitator_id==u.id %}selected{% endif %}>{{ u.full_name or u.email }}</option>
-        {% endfor %}
-      </select>
-    </label></div>
-    <div><label><input type="checkbox" id="include-all-fac" {% if include_all_facilitators %}checked{% endif %}> Include out-of-region facilitators</label></div>
-    <div>Additional Facilitators:
-      <div id="additional-facilitators">
-        {% set adds = session.facilitators if session else [] %}
-        {% if adds %}
-          {% for fac in adds %}
-          <select name="additional_facilitators">
+    <div class="form-align">
+      <div class="form-align__row">
+        <label class="form-align__label" for="workshop-type">Workshop*</label>
+        <div class="form-align__control">
+          <select name="workshop_type_id" id="workshop-type" required>
             <option value="">--Select--</option>
-            {% for u in facilitators %}
-            <option value="{{ u.id }}" {% if u.id==fac.id %}selected{% endif %}>{{ u.full_name or u.email }}</option>
+            {% for wt in workshop_types %}
+            <option value="{{ wt.id }}" data-langs="{{ wt.supported_languages|join(' ') if wt.supported_languages else '' }}" data-sim="{{ 1 if wt.simulation_based else 0 }}" {% if session and session.workshop_type_id==wt.id %}selected{% endif %}>{{ wt.code }}</option>
             {% endfor %}
           </select>
-          {% endfor %}
-        {% else %}
-          <select name="additional_facilitators">
-            <option value="">--Select--</option>
-            {% for u in facilitators %}
-            <option value="{{ u.id }}">{{ u.full_name or u.email }}</option>
-            {% endfor %}
-          </select>
-        {% endif %}
+        </div>
       </div>
-      <button type="button" id="add-fac">Add another facilitator</button>
-    </div><br>
+      <div id="sim-outline" class="form-align__row" {% if not (workshop_type and workshop_type.simulation_based) %}style="display:none"{% endif %}>
+        <label class="form-align__label" for="simulation-outline-id">Simulation Outline</label>
+        <div class="form-align__control">
+          <select name="simulation_outline_id" id="simulation-outline-id">
+            <option value="">— select —</option>
+            {% for o in simulation_outlines %}
+              {% set so_val = form.simulation_outline_id|int if form else session.simulation_outline_id %}
+              <option value="{{ o.id }}" {% if so_val == o.id %}selected{% endif %}>
+                {{ o.number }} — {{ o.skill }} — {{ o.descriptor }} ({{ o.level }})
+              </option>
+            {% endfor %}
+          </select>
+        </div>
+      </div>
+      <div class="form-align__row">
+        <label class="form-align__label" for="delivery-type">Delivery Type*</label>
+        <div class="form-align__control">
+          <select name="delivery_type" id="delivery-type" required>
+            <option value="">--Select--</option>
+            {% for opt in ['Onsite','Virtual','Self-paced','Hybrid'] %}
+            <option value="{{ opt }}" {% if session and session.delivery_type==opt %}selected{% endif %}>{{ opt }}</option>
+            {% endfor %}
+          </select>
+        </div>
+      </div>
+      <div class="form-align__row">
+        <label class="form-align__label" for="workshop-location-select">Workshop Location</label>
+        <div class="form-align__control">
+          <select name="workshop_location_id" id="workshop-location-select">
+            <option value=""></option>
+            {% for loc in workshop_locations %}
+            <option value="{{ loc.id }}" {% if session.workshop_location_id==loc.id %}selected{% endif %}>{{ loc.label }}</option>
+            {% endfor %}
+          </select>
+          <a href="#" id="add-workshop-location">Add</a>
+        </div>
+      </div>
+      <div class="form-align__row">
+        <label class="form-align__label" for="capacity">Capacity*</label>
+        <div class="form-align__control">
+          <input type="number" id="capacity" name="capacity" value="{{ session.capacity or 16 }}" required>
+        </div>
+      </div>
+      <div class="form-align__row">
+        <label class="form-align__label" for="start-date">Start Date*</label>
+        <div class="form-align__control">
+          <input type="date" id="start-date" name="start_date" value="{{ session.start_date or '' }}" required>
+          <input type="hidden" name="ack_past" id="ack-past" value="{{ form.ack_past if form else '' }}">
+        </div>
+      </div>
+      <div class="form-align__row">
+        <label class="form-align__label" for="end-date">End Date*</label>
+        <div class="form-align__control">
+          <input type="date" id="end-date" name="end_date" value="{{ session.end_date or '' }}" min="{{ session.start_date or '' }}" required>
+        </div>
+      </div>
+      <div class="form-help">End date must be the same day or after the start date.</div>
+      {% if past_warning %}
+      <div class="form-align__row form-align__row--checkbox" style="color:red;">
+        <div class="form-align__control">
+          <label><input type="checkbox" id="ack-past-check" required> The selected start date is in the past. I'm sure.</label>
+        </div>
+      </div>
+      {% endif %}
+      <div class="form-align__row">
+        <label class="form-align__label" for="daily-start-time">Daily Start Time</label>
+        <div class="form-align__control">
+          <input type="time" id="daily-start-time" name="daily_start_time" value="{{ daily_start_time_str or '08:00' }}">
+        </div>
+      </div>
+      <div class="form-align__row">
+        <label class="form-align__label" for="daily-end-time">End Time</label>
+        <div class="form-align__control">
+          <input type="time" id="daily-end-time" name="daily_end_time" value="{{ daily_end_time_str or '17:00' }}">
+        </div>
+      </div>
+      <div class="form-align__row">
+        <label class="form-align__label" for="timezone">Timezone</label>
+        <div class="form-align__control">
+          <select name="timezone" id="timezone">
+            <option value="">--Select--</option>
+            {% for tz in timezones %}
+            <option value="{{ tz }}" {% if session.timezone==tz %}selected{% endif %}>{{ tz }}</option>
+            {% endfor %}
+          </select>
+        </div>
+      </div>
+      <div class="form-align__row">
+        <label class="form-align__label" for="lead-facilitator">Lead Facilitator</label>
+        <div class="form-align__control">
+          <select name="lead_facilitator_id" id="lead-facilitator">
+            <option value="">--Select--</option>
+            {% for u in facilitators %}
+            <option value="{{ u.id }}" {% if session and session.lead_facilitator_id==u.id %}selected{% endif %}>{{ u.full_name or u.email }}</option>
+            {% endfor %}
+          </select>
+        </div>
+      </div>
+      <div class="form-align__row form-align__row--checkbox">
+        <div class="form-align__control">
+          <label><input type="checkbox" id="include-all-fac" {% if include_all_facilitators %}checked{% endif %}> Include out-of-region facilitators</label>
+        </div>
+      </div>
+      <div class="form-align__row form-align__row--top">
+        <label class="form-align__label" for="additional-facilitators">Additional Facilitators</label>
+        <div class="form-align__control">
+          <div id="additional-facilitators">
+            {% set adds = session.facilitators if session else [] %}
+            {% if adds %}
+              {% for fac in adds %}
+              <select name="additional_facilitators">
+                <option value="">--Select--</option>
+                {% for u in facilitators %}
+                <option value="{{ u.id }}" {% if u.id==fac.id %}selected{% endif %}>{{ u.full_name or u.email }}</option>
+                {% endfor %}
+              </select>
+              {% endfor %}
+            {% else %}
+              <select name="additional_facilitators">
+                <option value="">--Select--</option>
+                {% for u in facilitators %}
+                <option value="{{ u.id }}">{{ u.full_name or u.email }}</option>
+                {% endfor %}
+              </select>
+            {% endif %}
+          </div>
+          <button type="button" id="add-fac">Add another facilitator</button>
+        </div>
+      </div>
+    </div>
     <div><label>Notes & Special instructions<br><textarea name="notes">{{ session.notes or '' }}</textarea></label></div><br>
   </fieldset>
   {% if session.id %}

--- a/app/templates/sessions/materials.html
+++ b/app/templates/sessions/materials.html
@@ -6,9 +6,9 @@
   var simDiv = document.getElementById('sim-outline');
   var simBase = creditsDiv ? creditsDiv.dataset.sim === '1' : false;
   function toggleExtras(ot){
-    if(materialSetsDiv){ materialSetsDiv.style.display = (ot === 'Simulation') ? 'none' : 'inline-block'; }
-    if(creditsDiv){ var showC = (ot === 'Simulation') || simBase; creditsDiv.style.display = showC ? 'block' : 'none'; }
-    if(simDiv){ var showS = (ot === 'Simulation') || simBase; simDiv.style.display = showS ? 'inline-block' : 'none'; }
+    if(materialSetsDiv){ materialSetsDiv.style.display = (ot === 'Simulation') ? 'none' : ''; }
+    if(creditsDiv){ var showC = (ot === 'Simulation') || simBase; creditsDiv.style.display = showC ? '' : 'none'; }
+    if(simDiv){ var showS = (ot === 'Simulation') || simBase; simDiv.style.display = showS ? '' : 'none'; }
   }
   if(orderType){
     orderType.addEventListener('change', function(){ toggleExtras(this.value); });
@@ -34,19 +34,35 @@
     <div>Client : {% if sess.client %}{{ sess.client.name }}{% endif %}{% if sess.region %}, {{ sess.region }}{% endif %}</div>
     <div>CRM &ensp;: {% if sess.client and sess.client.crm %}{{ sess.client.crm.full_name or sess.client.crm.email }}{% endif %}</div>
     <div>Facilitator(s): {% for u in facs %}{{ u.full_name or u.email }}{% if not loop.last %}, {% endif %}{% endfor %}</div>
-    <div>
-      <label>SFC Project link:
-        {% if sess.client and sess.client.sfc_link %}
-          {{ sess.client.sfc_link }}
-        {% elif not csa_view %}
-          <input type="url" name="sfc_link" value="{{ sess.client.sfc_link or '' }}">
+    <div class="form-align">
+      {% set show_sfc_input = (not (sess.client and sess.client.sfc_link)) and not csa_view %}
+      <div class="form-align__row">
+        {% if show_sfc_input %}
+        <label class="form-align__label" for="sfc-link">SFC Project link</label>
+        {% else %}
+        <span class="form-align__label">SFC Project link</span>
         {% endif %}
-      </label>
-      <label>Latest arrival date:
-        {% if can_edit_materials_header('arrival_date', current_user, shipment) and not readonly %}
-          <input type="date" name="arrival_date" value="{{ form.get('arrival_date') if form else (shipment.arrival_date.isoformat() if shipment.arrival_date else '') }}">
-        {% else %}{{ shipment.arrival_date|default('', true) }}{% endif %}
-      </label>
+        <div class="form-align__control">
+          {% if sess.client and sess.client.sfc_link %}
+            {{ sess.client.sfc_link }}
+          {% elif not csa_view %}
+            <input type="url" id="sfc-link" name="sfc_link" value="{{ sess.client.sfc_link or '' }}">
+          {% endif %}
+        </div>
+      </div>
+      {% set show_arrival_input = can_edit_materials_header('arrival_date', current_user, shipment) and not readonly %}
+      <div class="form-align__row">
+        {% if show_arrival_input %}
+        <label class="form-align__label" for="arrival-date">Latest arrival date</label>
+        {% else %}
+        <span class="form-align__label">Latest arrival date</span>
+        {% endif %}
+        <div class="form-align__control">
+          {% if show_arrival_input %}
+            <input type="date" id="arrival-date" name="arrival_date" value="{{ form.get('arrival_date') if form else (shipment.arrival_date.isoformat() if shipment.arrival_date else '') }}">
+          {% else %}{{ shipment.arrival_date|default('', true) }}{% endif %}
+        </div>
+      </div>
     </div>
     <div>Order date: {{ shipment.created_at.date() if shipment.created_at else '' }}</div>
   </div>
@@ -92,21 +108,30 @@
   <div class="kt-card">
     <h2 class="kt-card-title">Order components</h2>
     <h3>{% if sess.workshop_type %}{{ sess.workshop_type.code }} — {{ sess.workshop_type.name }}{% endif %} ({{ sess.delivery_type|default('', true) }})</h3>
-    <div>
-      <label>Order type:
-      {% if can_edit_materials_header('order_type', current_user, shipment) and not readonly %}
-        {% set ot_val = form.get('order_type') if form else shipment.order_type %}
-        <select name="order_type">
-          <option value="">— select —</option>
-          {% for ot in order_types %}
-            <option value="{{ ot }}" {% if ot_val==ot %}selected{% endif %}>{{ ot }}</option>
-          {% endfor %}
-        </select>
-      {% else %}{{ shipment.order_type|default('', true) }}{% endif %}
-      </label>
-      <span id="sim-outline" {% if not show_sim_outline %}style="display:none"{% endif %}>
-        <label>Simulation Outline
-          <select name="simulation_outline_id">
+    <div class="form-align">
+      {% set show_order_type_input = can_edit_materials_header('order_type', current_user, shipment) and not readonly %}
+      <div class="form-align__row">
+        {% if show_order_type_input %}
+        <label class="form-align__label" for="order-type">Order type</label>
+        {% else %}
+        <span class="form-align__label">Order type</span>
+        {% endif %}
+        <div class="form-align__control">
+          {% if show_order_type_input %}
+            {% set ot_val = form.get('order_type') if form else shipment.order_type %}
+            <select name="order_type" id="order-type">
+              <option value="">— select —</option>
+              {% for ot in order_types %}
+                <option value="{{ ot }}" {% if ot_val==ot %}selected{% endif %}>{{ ot }}</option>
+              {% endfor %}
+            </select>
+          {% else %}{{ shipment.order_type|default('', true) }}{% endif %}
+        </div>
+      </div>
+      <div id="sim-outline" class="form-align__row" {% if not show_sim_outline %}style="display:none"{% endif %}>
+        <label class="form-align__label" for="simulation-outline-id">Simulation Outline</label>
+        <div class="form-align__control">
+          <select name="simulation_outline_id" id="simulation-outline-id">
             <option value="">— select —</option>
             {% for o in simulation_outlines %}
               {% set so_val = form.get('simulation_outline_id') if form else sess.simulation_outline_id %}
@@ -115,30 +140,40 @@
               </option>
             {% endfor %}
           </select>
-        </label>
-      </span>
-      <label>Material format
-        {% if can_edit_materials_header('materials_format', current_user, shipment) and not readonly %}
-          {% set fmt_val = form.get('materials_format') if form else fmt %}
-          <select name="materials_format" id="materials-format">
-            <option value=""></option>
-            {% for key, label in material_formats %}
-              <option value="{{ key }}" {% if fmt_val==key %}selected{% endif %}>{{ label }}</option>
-            {% endfor %}
-          </select>
-        {% else %}{{ fmt|default('', true) }}{% endif %}
-      </label>
-      <span id="material-sets" {% if shipment.order_type=='Simulation' %}style="display:none"{% endif %}>
-        <label>Material Sets
-          <input type="number" name="material_sets" min="0" value="{{ form.get('material_sets') if form else (shipment.material_sets or 0) }}">
-        </label>
-      </span>
+        </div>
+      </div>
+      {% set show_materials_format_input = can_edit_materials_header('materials_format', current_user, shipment) and not readonly %}
+      <div class="form-align__row">
+        {% if show_materials_format_input %}
+        <label class="form-align__label" for="materials-format">Material format</label>
+        {% else %}
+        <span class="form-align__label">Material format</span>
+        {% endif %}
+        <div class="form-align__control">
+          {% if show_materials_format_input %}
+            {% set fmt_val = form.get('materials_format') if form else fmt %}
+            <select name="materials_format" id="materials-format">
+              <option value=""></option>
+              {% for key, label in material_formats %}
+                <option value="{{ key }}" {% if fmt_val==key %}selected{% endif %}>{{ label }}</option>
+              {% endfor %}
+            </select>
+          {% else %}{{ fmt|default('', true) }}{% endif %}
+        </div>
+      </div>
+      <div id="material-sets" class="form-align__row" {% if shipment.order_type=='Simulation' %}style="display:none"{% endif %}>
+        <label class="form-align__label" for="material-sets-input">Material Sets</label>
+        <div class="form-align__control">
+          <input type="number" id="material-sets-input" name="material_sets" min="0" value="{{ form.get('material_sets') if form else (shipment.material_sets or 0) }}">
+        </div>
+      </div>
+      <div id="credits-field" class="form-align__row" data-sim="{{ 1 if sim_base else 0 }}" {% if not show_credits %}style="display:none"{% endif %}>
+        <label class="form-align__label" for="credits"># of credits (2 teams per credit)</label>
+        <div class="form-align__control">
+          <input type="number" id="credits" name="credits" min="0" value="{{ form.get('credits') if form else (shipment.credits or 2) }}">
+        </div>
+      </div>
     </div>
-  <div id="credits-field" data-sim="{{ 1 if sim_base else 0 }}" {% if not show_credits %}style="display:none"{% endif %}>
-    <label># of credits (2 teams per credit)
-      <input type="number" name="credits" min="0" value="{{ form.get('credits') if form else (shipment.credits or 2) }}">
-    </label>
-  </div>
   <div>Special instructions:
     {% if can_edit_materials_header('special_instructions', current_user, shipment) and not readonly %}
       <textarea name="special_instructions">{{ (form.get('special_instructions') if form else (shipment.special_instructions or '')) | trim }}</textarea>


### PR DESCRIPTION
## Summary
- add a scoped form-align utility to right-align labels and keep help text under controls
- apply the alignment grid to session create/edit rows without changing existing control spacing
- align materials order header fields to the same grid while preserving inline actions and toggles

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68c970448ff0832e87254f0b5424ad77