### PR TITLE
Allow editing materials header after delivery

### DIFF
--- a/app/routes/materials.py
+++ b/app/routes/materials.py
@@ -186,7 +186,8 @@ def materials_view(
     if not shipment.material_sets:
         shipment.material_sets = sess.capacity or 0
         db.session.commit()
-    readonly = view_only or bool(shipment.delivered_at)
+    session_locked = sess.status in {"Closed", "Cancelled"}
+    readonly = view_only or session_locked
     can_manage = can_manage_shipment(current_user)
     can_edit_arrival = can_edit_materials_header(
         "arrival_date", current_user, shipment


### PR DESCRIPTION
## Summary
- allow the materials header to stay editable after delivery unless the session status is Closed or Cancelled

## Testing
- PYTHONPATH=. pytest tests/test_materials.py -m ""


------
https://chatgpt.com/codex/tasks/task_e_68c9d7424dfc832e89d17bb805f21207