### PR TITLE
Default materials dashboard to hide closed workshops

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -434,7 +434,8 @@ Two separate tables by design; emails unique per table. If both tables hold the 
 - **Columns**: default order **Order ID, Title, Status, Workshop start date, Client, Order type, Workshop, Latest arrival date, Workshop status** with Order ID leading and Title linking to the materials detail page. Additional optional columns surface Processed timestamps, Bulk Receiver, Outline, Credits/Teams (shown as `<credits> / <teams>` only when the session has a Simulation Outline; otherwise the column shows `—`; teams stay calculated as two per credit), Facilitator(s), Learner list, Region, and Shipping location title via the chooser noted above. Bulk Receiver entries wrap so long contact names or emails remain visible within the column width.
 - **Column chooser**: matches the Workshops dashboard behavior; see §7 for chooser details.
 - **Data prep**: dashboard queries join clients, workshop types, shipping locations, facilitators, and participant names in bulk and use SQL window functions to surface the latest processed Digital/Physical timestamps per order.
-- **Filters** (currently implemented): status, format. (Future: date range, components, type, facilitator.)  
+- **Filters** (currently implemented): status, format. (Future: date range, components, type, facilitator.)
+- **Workshop Status** defaults to **not Closed** (excludes `Session.status = 'Closed'`) until the user explicitly changes the filter. The Show/Hide Closed toggle mutates the `workshop_status` query param (`not_closed` ↔ `all`) and the toolbar shows a chip while the exclusion is active.
 - **Row actions** per permissions: Open, Edit, Mark Shipped, Mark Delivered.
 
 ---
@@ -506,7 +507,7 @@ Route inventory lives at `sitemap.txt` (admin-only, linked from Settings) and li
 - “KT Staff” is a derived condition; any stored boolean is deprecated and must not drive logic.  
 - CSA password default is **`KTRocks!CSA`**; other participants **`KTRocks!`**.  
 - Contractor menu/capabilities updated per §1.2/§1.5.
-- Materials dashboard documented to current behavior.
+- Materials dashboard documented to current behavior (default hides Closed workshops via the Workshop Status filter).
 - Session detail pages render a minimal order view for materials-only sessions and guard full details with `{% if not session.materials_only %}`; workshop-type and facilitator sections now use `{% if %}` guards to avoid null dereferences.
 - Added no-op Alembic revision `0053_cert_template_badge_image` to maintain migration continuity for certificate-template badge filenames.
 - Material Settings items include a **Quantity basis** (`Per learner`/`Per order`) stored on `materials_options` and used wherever the item is selected.

--- a/app/templates/materials_orders.html
+++ b/app/templates/materials_orders.html
@@ -32,19 +32,22 @@
   <button type="submit">Filter</button>
   <input type="hidden" name="sort" value="{{ sort }}">
   <input type="hidden" name="dir" value="{{ dir }}">
+  {% if workshop_status_param is not none %}
+  <input type="hidden" name="workshop_status" value="{{ workshop_status_param }}">
+  {% endif %}
 </form>
 <p>
-  {% if show_closed %}
-    <a href="{{ url_for('materials_orders.list_orders', client_id=client_id, order_type=order_type, status=status) }}">Hide closed sessions</a>
+  {% if workshop_status_filter == 'not_closed' %}
+    <a href="{{ url_for('materials_orders.list_orders', client_id=client_id, order_type=order_type, status=status, sort=sort, dir=dir, workshop_status='all') }}">Show closed sessions</a>
   {% else %}
-    <a href="{{ url_for('materials_orders.list_orders', client_id=client_id, order_type=order_type, status=status, closed=1) }}">Show closed sessions</a>
+    <a href="{{ url_for('materials_orders.list_orders', client_id=client_id, order_type=order_type, status=status, sort=sort, dir=dir, workshop_status='not_closed') }}">Hide closed sessions</a>
   {% endif %}
 </p>
 {% set base = '' %}
 {% if client_id %}{% set base = base + '&client_id=' + client_id|string %}{% endif %}
 {% if order_type %}{% set base = base + '&order_type=' + order_type|urlencode %}{% endif %}
 {% if status %}{% set base = base + '&status=' + status %}{% endif %}
-{% if show_closed %}{% set base = base + '&closed=1' %}{% endif %}
+{% if workshop_status_param is not none %}{% set base = base + '&workshop_status=' + workshop_status_param|urlencode %}{% endif %}
 {% if current_user and current_user.id %}
   {% set storage_key = 'cbs.materials.columns.' ~ current_user.id %}
   {% set width_key = 'cbs.materials.colwidths.' ~ current_user.id %}
@@ -55,6 +58,9 @@
 <div class="dashboard-table" data-column-chooser data-storage-key="{{ storage_key }}" data-width-storage-key="{{ width_key }}" data-chooser-label="Choose columns">
   <div class="table-toolbar">
     <button type="button" class="btn btn-secondary btn-sm" data-column-chooser-toggle aria-haspopup="dialog" aria-expanded="false">Columns</button>
+    {% if workshop_status_chip_label %}
+      <span class="chip chip--selected">{{ workshop_status_chip_label }}</span>
+    {% endif %}
   </div>
   <div class="kt-table-wrapper">
     <table class="kt-table">

--- a/tests/test_materials_orders.py
+++ b/tests/test_materials_orders.py
@@ -64,6 +64,57 @@ def _setup_data():
     return admin.id, sess.id
 
 
+def _setup_dashboard_sessions():
+    admin = User(email="admin@example.com", is_app_admin=True, is_admin=True)
+    admin.set_password("x")
+    wt = WorkshopType(code="WT", name="WT", cert_series="fn")
+    mt = MaterialType(name="Kit")
+    mat = Material(material_type_id=mt.id, name="Sample Kit")
+    client = Client(name="C1")
+    ship = ClientShippingLocation(
+        client=client,
+        contact_name="CN",
+        address_line1="A1",
+        city="City",
+        postal_code="123",
+        country="US",
+    )
+    open_session = Session(
+        title="Alpha Materials",
+        workshop_type=wt,
+        start_date=date.today(),
+        end_date=date.today(),
+        client=client,
+        shipping_location=ship,
+    )
+    closed_session = Session(
+        title="Closed Materials",
+        workshop_type=wt,
+        start_date=date.today(),
+        end_date=date.today(),
+        client=client,
+        shipping_location=ship,
+        status="Closed",
+    )
+    db.session.add_all(
+        [admin, wt, mt, mat, client, ship, open_session, closed_session]
+    )
+    db.session.commit()
+    open_shipping = SessionShipping(
+        session_id=open_session.id,
+        order_date=date.today(),
+        order_type="KT-Run Standard materials",
+    )
+    closed_shipping = SessionShipping(
+        session_id=closed_session.id,
+        order_date=date.today(),
+        order_type="KT-Run Standard materials",
+    )
+    db.session.add_all([open_shipping, closed_shipping])
+    db.session.commit()
+    return admin.id, open_session.title, closed_session.title
+
+
 def _login(client, admin_id):
     with client.session_transaction() as sess_tx:
         sess_tx["user_id"] = admin_id
@@ -109,3 +160,44 @@ def test_order_date_field_and_save(app):
     with app.app_context():
         shipment = SessionShipping.query.filter_by(session_id=session_id).first()
         assert shipment.order_date == date(2025, 1, 2)
+
+
+def test_materials_dashboard_hides_closed_by_default(app):
+    with app.app_context():
+        admin_id, open_title, closed_title = _setup_dashboard_sessions()
+    client = app.test_client()
+    _login(client, admin_id)
+    resp = client.get("/materials")
+    assert resp.status_code == 200
+    assert open_title.encode() in resp.data
+    assert closed_title.encode() not in resp.data
+    assert b"Status: not Closed" in resp.data
+    assert b"Show closed sessions" in resp.data
+
+
+def test_materials_dashboard_show_closed_filter(app):
+    with app.app_context():
+        admin_id, open_title, closed_title = _setup_dashboard_sessions()
+    client = app.test_client()
+    _login(client, admin_id)
+    resp = client.get("/materials", query_string={"workshop_status": "all", "sort": "title"})
+    assert resp.status_code == 200
+    assert open_title.encode() in resp.data
+    assert closed_title.encode() in resp.data
+    assert b"Status: not Closed" not in resp.data
+    assert b"Hide closed sessions" in resp.data
+    assert b"workshop_status=not_closed" in resp.data
+
+
+def test_materials_dashboard_hide_closed_filter(app):
+    with app.app_context():
+        admin_id, open_title, closed_title = _setup_dashboard_sessions()
+    client = app.test_client()
+    _login(client, admin_id)
+    resp = client.get("/materials", query_string={"workshop_status": "not_closed"})
+    assert resp.status_code == 200
+    assert open_title.encode() in resp.data
+    assert closed_title.encode() not in resp.data
+    assert b"Status: not Closed" in resp.data
+    assert b"Show closed sessions" in resp.data
+    assert b"workshop_status=all" in resp.data


### PR DESCRIPTION
## Summary
- default the materials dashboard query to exclude sessions with status Closed unless the user requests otherwise
- wire the show/hide closed sessions links through the new workshop_status filter and surface the active state as a toolbar chip
- add regression tests around the default, show, and hide behaviors and document the change in CONTEXT.md

## Testing
- PYTHONPATH=. pytest tests/test_materials_orders.py

------
https://chatgpt.com/codex/tasks/task_e_68cb40f01cf8832ea04c17979a8537ad