### PR TITLE
Keep column chooser toggle visible

### DIFF
--- a/app/static/css/table.css
+++ b/app/static/css/table.css
@@ -85,7 +85,11 @@
   justify-content: flex-end;
   gap: var(--space-2);
   margin-bottom: var(--space-2);
-  position: relative;
+  width: max-content;
+  margin-left: auto;
+  position: sticky;
+  right: 0;
+  z-index: 5;
 }
 
 .column-chooser-panel {


### PR DESCRIPTION
## Summary
- adjust table toolbar positioning so the column chooser toggle stays docked to the right edge of the viewport

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cb461dcb60832ea450d94ce3e86b9a