### PR TITLE
Polish workshop view routing and participant management

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -190,6 +190,8 @@ Roles control permissions; Views control menu visibility.
   - My Profile
   - Logout
 
+Delivery (KT Facilitator) and Contractor accounts open the workshop runner view when selecting sessions from **My Sessions**. Other staff and CSA roles continue to the staff session detail page.
+
 ## 1.3 View Selector
 Only SysAdmin, Administrator, CRM, and KT Facilitator roles see the View selector. CSA, Participant, and Contractor do not.
 
@@ -231,6 +233,7 @@ Only SysAdmin, Administrator, CRM, and KT Facilitator roles see the View selecto
 
 | Route | Method | Roles | Session Status | Notes |
 |-------|--------|-------|----------------|-------|
+| `/workshops/<id>` | GET | Delivery, Contractor (assigned) | Any (assigned; materials-only sessions show empty state) | Workshop runner view with overview + participant management |
 | `/sessions/<id>/prework` | GET/POST | SysAdmin, Admin, CRM, Delivery, Contractor (assigned) | Any | Staff access only |
 | `/sessions/<id>/participants/add` | POST | CSA (assigned) | Until Ready for Delivery | Uses `csa_can_manage_participants` |
 | `/sessions/<id>/generate` | POST | SysAdmin, Admin, CRM, Delivery, Contractor | Delivered | Generates certificates |
@@ -318,8 +321,8 @@ Two separate tables by design; emails unique per table. If both tables hold the 
 - Add/remove participants **until Ready for Delivery**; read-only after.
 
 ## 4.3 Delivery (facilitator)
-- **My Sessions**: sessions where user is a facilitator; delivery data visible (address, timezone, notes). Title/Open links hand off to `/workshops/<session_id>` when the user is assigned as lead or co-facilitator; other staff retain the `/sessions/<id>` detail link.
-- **Workshop View** (`/workshops/<session_id>`): read-only session overview that mirrors the staff detail header in a compact two-column layout. Shows participants and certificate links without edit/remove actions, hides Materials/Settings navigation, and includes placeholder cards for Facilitator Resources and Prework Summary. Materials-only sessions render an empty state message instead of workshop details.
+- **My Sessions**: sessions where user is a facilitator; delivery data visible (address, timezone, notes). Delivery (KT Facilitator) and Contractor accounts always open `/workshops/<session_id>` for sessions where they are lead or co-facilitators, even when they also hold Admin/CRM roles. Other staff retain the `/sessions/<id>` detail link.
+- **Workshop View** (`/workshops/<session_id>`): runner-focused layout with the heading `"<id> <title>: <workshop_code> (<delivery_type>) - <status>"`, a slimmed overview card (location moved left; type/delivery/status removed), and a Participants card above Resources. Facilitators manage participants inline (add, edit, remove, completion date, CSV import) with certificate links mirroring staff detail. Resources remain facilitator-only placeholder content; Prework Summary stays a placeholder. Materials-only sessions render an empty state message instead of workshop details.
 
 ## 4.4 CRM
 - Full session lifecycle. Defaults on **My Sessions** to owner/CRM scope.
@@ -488,6 +491,8 @@ Each feature package contains `routes/`, `models/`, `services/` (business rules)
 - `flags.py` – simple feature-flag registry for experimental work.
 
 Route inventory lives at `sitemap.txt` (admin-only, linked from Settings) and lists each route, owning module, and required permission.
+
+- Workshop runner view template: `app/templates/sessions/workshop_view.html`.
 
 ---
 

--- a/app/routes/my_sessions.py
+++ b/app/routes/my_sessions.py
@@ -59,11 +59,13 @@ def list_my_sessions():
             if (s.lead_facilitator_id == user.id)
             or any(f.id == user.id for f in getattr(s, "facilitators", []))
         }
+        use_workshop_view = user.is_kt_delivery or user.is_kt_contractor
         return render_template(
             "my_sessions.html",
             sessions=sessions,
             show_all=show_all,
             assigned_session_ids=assigned_session_ids,
+            workshop_link_for_facilitator=use_workshop_view,
         )
     elif account_id:
         account = db.session.get(ParticipantAccount, account_id)

--- a/app/routes/workshops.py
+++ b/app/routes/workshops.py
@@ -68,6 +68,7 @@ def workshop_view(session_id: int, current_user):
 
     participants: list[dict[str, object]] = []
     badge_filename = None
+    import_errors = None
     if not session.materials_only:
         rows = (
             db.session.query(SessionParticipant, Participant, Certificate.pdf_path)
@@ -84,6 +85,7 @@ def workshop_view(session_id: int, current_user):
             {"participant": participant, "link": link, "pdf_path": pdf_path}
             for link, participant, pdf_path in rows
         ]
+        import_errors = flask_session.pop("import_errors", None)
         mapping, _ = get_template_mapping(session)
         if mapping:
             badge_filename = mapping.badge_filename
@@ -93,4 +95,5 @@ def workshop_view(session_id: int, current_user):
         session=session,
         participants=participants,
         badge_filename=badge_filename,
+        import_errors=import_errors,
     )

--- a/app/templates/my_sessions.html
+++ b/app/templates/my_sessions.html
@@ -4,7 +4,7 @@
 <h1>{% if current_user %}My Sessions{% else %}My Workshops{% endif %}</h1>
 {% if sessions %}
   {% if current_user %}
-    {% set can_use_workshop_view = (current_user.is_kt_delivery or current_user.is_kt_contractor) and not (current_user.is_app_admin or current_user.is_admin or current_user.is_kcrm) %}
+    {% set can_use_workshop_view = workshop_link_for_facilitator if workshop_link_for_facilitator is defined else False %}
     {% set facilitator_session_ids = assigned_session_ids if assigned_session_ids is defined else [] %}
     {% if current_user.id %}
       {% set storage_key = 'cbs.mysessions.columns.' ~ current_user.id %}

--- a/app/templates/participant_edit.html
+++ b/app/templates/participant_edit.html
@@ -2,11 +2,15 @@
 {% block title %}Edit Participant{% endblock %}
 {% block content %}
 <h1>Edit Participant</h1>
+{% set back_url = next_url if next_url else url_for('sessions.session_detail', session_id=session_id) %}
 <form method="post">
+  {% if next_url %}
+  <input type="hidden" name="next" value="{{ next_url }}">
+  {% endif %}
   <div><label>Email <input type="email" value="{{ participant.email }}" readonly></label></div>
   <div><label>Full name <input type="text" name="full_name" value="{{ participant.full_name }}"></label></div>
   <div><label>Title <input type="text" name="title" value="{{ participant.title }}"></label></div>
   <button type="submit">Save</button>
 </form>
-<p><a href="{{ url_for('sessions.session_detail', session_id=session_id) }}">Back</a></p>
+<p><a href="{{ back_url }}">Back</a></p>
 {% endblock %}

--- a/app/templates/sessions/workshop_view.html
+++ b/app/templates/sessions/workshop_view.html
@@ -1,7 +1,11 @@
 {% extends 'base.html' %}
-{% block title %}Workshop {{ session.title }}{% endblock %}
+{% set workshop_code = session.workshop_type.code if session.workshop_type else '—' %}
+{% set delivery_label = session.delivery_type or '—' %}
+{% set status_label = session.computed_status %}
+{% set workshop_heading = session.id ~ ' ' ~ session.title ~ ': ' ~ workshop_code ~ ' (' ~ delivery_label ~ ') - ' ~ status_label %}
+{% block title %}{{ workshop_heading }}{% endblock %}
 {% block content %}
-<h1>{{ session.title }}</h1>
+<h1>{{ workshop_heading }}</h1>
 <p><a href="{{ url_for('my_sessions.list_my_sessions') }}">Back to My Sessions</a></p>
 {% if session.cancelled %}<div class="banner">Session cancelled.</div>{% endif %}
 {% set facs = [] %}
@@ -16,6 +20,9 @@
   </div>
 </div>
 {% else %}
+{% set workshop_return = url_for('workshops.workshop_view', session_id=session.id) %}
+{% set can_manage_participants = not session.delivered and not session.participants_locked() %}
+{% set import_input_id = 'participant-import-' ~ session.id %}
 <section class="kt-card">
   <h2 class="kt-card-title">Workshop overview</h2>
   <div class="grid grid-2 gap-md">
@@ -30,13 +37,6 @@
           —
         {% endif %}
       </div>
-      <div><strong>Workshop Type:</strong> {% if session.workshop_type %}{{ session.workshop_type.code }} – {{ session.workshop_type.name }}{% else %}—{% endif %}</div>
-      <div><strong>Simulation:</strong> {{ session.simulation_outline.label if session.simulation_outline else '—' }}</div>
-      <div><strong>Dates:</strong> {{ session.start_date }} to {{ session.end_date }}; {{ session.daily_start_time|fmt_time_range_with_tz(session.daily_end_time, session.timezone) }}</div>
-      <div><strong>Workshop language:</strong> {{ session.workshop_language | lang_label }}</div>
-    </div>
-    <div class="grid gap-sm">
-      <div><strong>Delivery Type:</strong> {{ session.delivery_type or '—' }}</div>
       <div>
         <strong>Workshop Location:</strong>
         {% if session.workshop_location %}
@@ -49,9 +49,13 @@
           —
         {% endif %}
       </div>
+      <div><strong>Simulation:</strong> {{ session.simulation_outline.label if session.simulation_outline else '—' }}</div>
+      <div><strong>Dates:</strong> {{ session.start_date }} to {{ session.end_date }}; {{ session.daily_start_time|fmt_time_range_with_tz(session.daily_end_time, session.timezone) }}</div>
+      <div><strong>Workshop language:</strong> {{ session.workshop_language | lang_label }}</div>
+    </div>
+    <div class="grid gap-sm">
       <div><strong>Shipping Location:</strong> {{ session.shipping_location.display_name() if session.shipping_location else '—' }}</div>
       <div><strong>Notes:</strong> {{ session.notes or session.description or '—' }}</div>
-      <div><strong>Status:</strong> {{ session.computed_status }}</div>
       <div><strong>Materials ordered:</strong> {{ 'Yes' if session.materials_ordered else 'No' }}{% if session.materials_ordered_at %} ({{ session.materials_ordered_at|fmt_dt }}){% endif %}</div>
       <div><strong>Ready for delivery:</strong> {{ 'Yes' if session.ready_for_delivery else 'No' }}{% if session.ready_at %} ({{ session.ready_at|fmt_dt }}){% endif %}</div>
       <div><strong>Workshop info sent:</strong> {{ 'Yes' if session.info_sent else 'No' }}{% if session.info_sent_at %} ({{ session.info_sent_at|fmt_dt }}){% endif %}</div>
@@ -59,6 +63,97 @@
       <div><strong>Finalized:</strong> {{ 'Yes' if session.finalized else 'No' }}{% if session.finalized_at %} ({{ session.finalized_at|fmt_dt }}){% endif %}</div>
     </div>
   </div>
+</section>
+
+<section class="kt-card">
+  <h2 class="kt-card-title">Participants</h2>
+  {% if can_manage_participants %}
+  <form action="{{ url_for('sessions.add_participant', session_id=session.id) }}" method="post">
+    <input type="hidden" name="next" value="{{ workshop_return }}">
+    <input type="text" name="full_name" placeholder="Full name">
+    <input type="email" name="email" placeholder="Email" required>
+    <input type="text" name="title" placeholder="Title">
+    <button type="submit">Add Participant</button>
+  </form>
+  <form action="{{ url_for('sessions.import_csv', session_id=session.id) }}" method="post" enctype="multipart/form-data">
+    <input type="hidden" name="next" value="{{ workshop_return }}">
+    <input type="file" id="{{ import_input_id }}" name="file" accept=".csv" required style="display:none" onchange="this.form.submit()">
+    <label for="{{ import_input_id }}" class="btn btn-secondary btn-sm">Import CSV</label>
+    <a href="{{ url_for('sessions.sample_csv', session_id=session.id) }}">Download sample CSV</a>
+  </form>
+  {% if import_errors %}
+  <div>
+    <p>Skipped lines:</p>
+    <ul>
+      {% for err in import_errors %}
+      <li>{{ err }}</li>
+      {% endfor %}
+    </ul>
+  </div>
+  {% endif %}
+  {% endif %}
+  <table class="kt-table">
+    <thead>
+      <tr>
+        <th scope="col">Full Name</th>
+        <th scope="col">Email</th>
+        <th scope="col">Title</th>
+        <th scope="col">Completion Date</th>
+        <th scope="col">Certificate</th>
+        <th scope="col">Actions</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for row in participants %}
+      <tr>
+        <td>{{ row.participant.full_name }}{% if row.participant.account and row.participant.account.certificate_name %} ({{ row.participant.account.certificate_name }}){% endif %}</td>
+        <td>{{ row.participant.email }}</td>
+        <td>{{ row.participant.title }}</td>
+        <td>
+          <form action="{{ url_for('sessions.generate_single', session_id=session.id, participant_id=row.participant.id) }}" method="post">
+            <input type="hidden" name="next" value="{{ workshop_return }}">
+            <input type="date" name="completion_date" value="{{ row.link.completion_date }}">
+            <button type="submit" name="action" value="save">Save</button>
+            {% if session.delivered %}
+            <button type="submit" name="action" value="generate">Generate</button>
+            {% endif %}
+          </form>
+        </td>
+        <td>
+          {% if row.pdf_path %}
+            {% if badge_filename %}
+              {% set badge_url = '/badges/' ~ badge_filename %}
+              <a href="{{ badge_url }}" download><img src="{{ badge_url }}" alt="badge" style="height:20px;width:auto;vertical-align:middle;"></a>
+              <a href="{{ badge_url }}" download>Badge</a>
+            {% endif %}
+            <a href="/certificates/{{ row.pdf_path }}">Certificate</a>
+          {% endif %}
+        </td>
+        <td>
+          {% if can_manage_participants %}
+          <a href="{{ url_for('sessions.edit_participant', session_id=session.id, participant_id=row.participant.id, next=workshop_return) }}">Edit</a>
+          <form action="{{ url_for('sessions.remove_participant', session_id=session.id, participant_id=row.participant.id) }}" method="post" style="display:inline">
+            <input type="hidden" name="next" value="{{ workshop_return }}">
+            <button type="submit">Remove</button>
+          </form>
+          {% endif %}
+        </td>
+      </tr>
+      {% else %}
+      <tr>
+        <td colspan="6">No participants added yet.</td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+  {% if session.delivered %}
+  <form action="{{ url_for('sessions.generate_bulk', session_id=session.id) }}" method="post">
+    <input type="hidden" name="next" value="{{ workshop_return }}">
+    <button type="submit">Generate Certificates</button>
+  </form>
+  {% else %}
+  <p>Certificates cannot be generated until session is marked Delivered.</p>
+  {% endif %}
 </section>
 
 <section class="kt-card">
@@ -73,47 +168,6 @@
   <div class="empty-state">
     <p>Prework summaries will be available in a future update.</p>
   </div>
-</section>
-
-<section class="kt-card">
-  <h2 class="kt-card-title">Participants</h2>
-  <table class="kt-table">
-    <thead>
-      <tr>
-        <th scope="col">Full Name</th>
-        <th scope="col">Email</th>
-        <th scope="col">Title</th>
-        <th scope="col">Completion Date</th>
-        <th scope="col">Certificate</th>
-      </tr>
-    </thead>
-    <tbody>
-      {% for row in participants %}
-      <tr>
-        <td>{{ row.participant.full_name }}{% if row.participant.account and row.participant.account.certificate_name %} ({{ row.participant.account.certificate_name }}){% endif %}</td>
-        <td>{{ row.participant.email }}</td>
-        <td>{{ row.participant.title }}</td>
-        <td>{{ row.link.completion_date or '—' }}</td>
-        <td>
-          {% if row.pdf_path %}
-            {% if badge_filename %}
-              {% set badge_url = '/badges/' ~ badge_filename %}
-              <a href="{{ badge_url }}" download><img src="{{ badge_url }}" alt="badge" style="height:20px;width:auto;vertical-align:middle;"></a>
-              <a href="{{ badge_url }}" download>Badge</a>
-            {% endif %}
-            <a href="/certificates/{{ row.pdf_path }}">Certificate</a>
-          {% else %}
-            —
-          {% endif %}
-        </td>
-      </tr>
-      {% else %}
-      <tr>
-        <td colspan="5">No participants added yet.</td>
-      </tr>
-      {% endfor %}
-    </tbody>
-  </table>
 </section>
 {% endif %}
 {% endblock %}

--- a/sitemap.txt
+++ b/sitemap.txt
@@ -8,11 +8,11 @@
 /sessions                – Staff/CSA: list with filters
 /sessions/new            – Create session (staff only)
 /sessions/<id>           – Session detail (overview + tabs)
-/workshops/<id>         – Workshop View (read-only) for assigned facilitators
+/workshops/<id>         – Workshop runner view (Delivery/Contractor; also used when a user has KT Facilitator among roles)
 /sessions/<id>/materials – Materials order for the session (inherits Shipping Location)
 /sessions/<id>/materials/apply-defaults – Apply Workshop-Type defaults to Material Items
 /sessions/<id>/participants – Add/edit/CSV import participants
-/my-sessions             – Facilitators/CRM/CSA: sessions relevant to them
+/my-sessions             – Facilitators/CRM/CSA: sessions relevant to them (Delivery/Contractor click-through opens Workshop view)
 /my-certificates         – Learner portal: download own PDFs
 /profile                 – Learner profile (full name, certificate name)
 /my-resources            – Learner portal: grouped resources by Workshop Type


### PR DESCRIPTION
## Summary
- send Delivery and Contractor users from My Sessions to the workshop runner view regardless of other staff roles
- revamp the workshop view header/overview layout and surface full participant management above resources while preserving facilitator-only resources
- add redirect plumbing for participant actions so forms return to the workshop view, and update the product docs and sitemap to match

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68cc23da3474832e93e22424fa1032ed