### PR TITLE
Filter bulk and material orders from dashboard

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -25,6 +25,7 @@ from .models import (
     User,
     ParticipantAccount,
     Session,
+    SessionShipping,
     Client,
     Language,
     Participant,
@@ -240,6 +241,20 @@ def create_app():
                 return redirect(url_for("materials_orders.list_orders"))
             query = db.session.query(Session)
             query = query.filter(Session.status.notin_(["Closed", "Cancelled"]))
+            bulk_order = "client-run bulk order"
+            material_order = "material order"
+            normalized_order_type = func.lower(func.trim(SessionShipping.order_type))
+            bulk_exists = (
+                db.session.query(SessionShipping.id)
+                .filter(SessionShipping.session_id == Session.id)
+                .filter(normalized_order_type == bulk_order)
+                .correlate(Session)
+            )
+            query = query.filter(~bulk_exists.exists())
+            normalized_delivery_type = func.lower(func.trim(Session.delivery_type))
+            query = query.filter(
+                func.coalesce(normalized_delivery_type, "") != material_order
+            )
             if active_view == "DELIVERY":
                 query = query.filter(
                     or_(


### PR DESCRIPTION
## Summary
- update the home dashboard query to exclude sessions tied to bulk materials orders or material-only delivery types
- import SessionShipping so the dashboard filter can examine shipment order types

## Testing
- PYTHONPATH=. pytest tests/test_materials_only.py tests/test_materials_orders.py

------
https://chatgpt.com/codex/tasks/task_e_68cc46772750832e8d58e71eb5da6849