### PR TITLE
Align participant import UI and finalize button styling

### DIFF
--- a/app/templates/session_detail.html
+++ b/app/templates/session_detail.html
@@ -70,6 +70,8 @@
 </nav>
 {% endif %}
 {% if not session.materials_only %}
+{% set import_input_id = 'participant-import-' ~ session.id %}
+{% set participants_return = url_for('sessions.session_detail', session_id=session.id) %}
 <div>
   <h2>Client Session Administrator</h2>
   {% if session.csa_account %}
@@ -88,14 +90,16 @@
 {% if csa_view %}
   {% if csa_can_manage and not session.delivered and not session.participants_locked() %}
   <form action="{{ url_for('sessions.add_participant', session_id=session.id) }}" method="post">
+    <input type="hidden" name="next" value="{{ participants_return }}">
     <input type="text" name="full_name" placeholder="Full name">
     <input type="email" name="email" placeholder="Email" required>
     <input type="text" name="title" placeholder="Title">
     <button type="submit">Add Participant</button>
   </form>
   <form action="{{ url_for('sessions.import_csv', session_id=session.id) }}" method="post" enctype="multipart/form-data">
-    <input type="file" name="file" accept=".csv">
-    <button type="submit">Import CSV</button>
+    <input type="hidden" name="next" value="{{ participants_return }}">
+    <input type="file" id="{{ import_input_id }}" name="file" accept=".csv" required style="display:none" onchange="this.form.submit()">
+    <label for="{{ import_input_id }}" class="btn">Import CSV</label>
     <a href="{{ url_for('sessions.sample_csv', session_id=session.id) }}">Download sample CSV</a>
   </form>
   {% if import_errors %}
@@ -142,14 +146,16 @@
 {% else %}
   {% if not session.delivered and not session.participants_locked() %}
   <form action="{{ url_for('sessions.add_participant', session_id=session.id) }}" method="post">
+    <input type="hidden" name="next" value="{{ participants_return }}">
     <input type="text" name="full_name" placeholder="Full name">
     <input type="email" name="email" placeholder="Email" required>
     <input type="text" name="title" placeholder="Title">
     <button type="submit">Add Participant</button>
   </form>
   <form action="{{ url_for('sessions.import_csv', session_id=session.id) }}" method="post" enctype="multipart/form-data">
-    <input type="file" name="file" accept=".csv">
-    <button type="submit">Import CSV</button>
+    <input type="hidden" name="next" value="{{ participants_return }}">
+    <input type="file" id="{{ import_input_id }}" name="file" accept=".csv" required style="display:none" onchange="this.form.submit()">
+    <label for="{{ import_input_id }}" class="btn">Import CSV</label>
     <a href="{{ url_for('sessions.sample_csv', session_id=session.id) }}">Download sample CSV</a>
   </form>
   {% if import_errors %}

--- a/app/templates/sessions/materials.html
+++ b/app/templates/sessions/materials.html
@@ -304,7 +304,7 @@
     {% else %}{{ shipment.tracking|default('', true) }}{% endif %}
   </div>
   <button type="submit" name="action" value="update_header" class="btn btn-primary" {% if readonly %}disabled{% endif %}>Save</button>
-  <button type="submit" name="action" value="finalize" class="btn btn-secondary" {% if readonly %}disabled{% endif %}>Ready for Delivery/Finalized</button>
+  <button type="submit" name="action" value="finalize" class="btn btn-primary" {% if readonly %}disabled{% endif %}>Ready for Delivery/Finalized</button>
 </form>
 {% if can_manage %}
 <form id="defaults-form" method="post" action="{{ url_for('materials.apply_defaults', session_id=sess.id) }}">

--- a/app/templates/sessions/workshop_view.html
+++ b/app/templates/sessions/workshop_view.html
@@ -78,7 +78,7 @@
   <form action="{{ url_for('sessions.import_csv', session_id=session.id) }}" method="post" enctype="multipart/form-data">
     <input type="hidden" name="next" value="{{ workshop_return }}">
     <input type="file" id="{{ import_input_id }}" name="file" accept=".csv" required style="display:none" onchange="this.form.submit()">
-    <label for="{{ import_input_id }}" class="btn btn-secondary btn-sm">Import CSV</label>
+    <label for="{{ import_input_id }}" class="btn">Import CSV</label>
     <a href="{{ url_for('sessions.sample_csv', session_id=session.id) }}">Download sample CSV</a>
   </form>
   {% if import_errors %}


### PR DESCRIPTION
## Summary
- restyle workshop and session Import CSV triggers to use the primary button treatment
- update session detail participant forms to mirror workshop upload behavior with a single Import CSV button
- switch the materials Ready for Delivery/Finalized action to the primary button styling

## Testing
- not run (templates only)


------
https://chatgpt.com/codex/tasks/task_e_68cc77bf0028832e979ea1a92022b9ba