### PR TITLE
Add resource audience controls and filter by language

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -287,7 +287,7 @@ Two separate tables by design; emails unique per table. If both tables hold the 
 - `prework_answers` (assignment_id, question snapshot, text, item_index)
 
 ## 3.3 Resources
-- `resources` (name, type enum LINK/DOCUMENT/APP, value/url/path, active)
+- `resources` (name, type enum LINK/DOCUMENT/APP, value/url/path, `description_html`, `language` code, `audience` enum Participant/Facilitator/Both, active)
 - `workshop_type_resources` (m:n; unique pair)
 
 ## 3.4 Certificates
@@ -329,7 +329,7 @@ Two separate tables by design; emails unique per table. If both tables hold the 
 
 ## 4.3 Delivery (facilitator)
 - **My Sessions**: sessions where user is a facilitator; delivery data visible (address, timezone, notes). Delivery (KT Facilitator) and Contractor accounts always open `/workshops/<session_id>` for sessions where they are lead or co-facilitators, even when they also hold Admin/CRM roles. Other staff retain the `/sessions/<id>` detail link.
-- **Workshop View** (`/workshops/<session_id>`): runner-focused layout with the heading `"<id> <title>: <workshop_code> (<delivery_type>) - <status>"`, a slimmed overview card (location moved left; type/delivery/status removed), and a Participants card above Resources. Facilitators manage participants inline (add, edit, remove, completion date, CSV import) with certificate links mirroring staff detail. Resources remain facilitator-only placeholder content; Prework Summary stays a placeholder. Materials-only sessions render an empty state message instead of workshop details.
+- **Workshop View** (`/workshops/<session_id>`): runner-focused layout with the heading `"<id> <title>: <workshop_code> (<delivery_type>) - <status>"`, a slimmed overview card (location moved left; type/delivery/status removed), and a Participants card above Resources. Facilitators manage participants inline (add, edit, remove, completion date, CSV import) with certificate links mirroring staff detail. The Resources card lists active resources assigned to the session's workshop type where `audience ∈ {Facilitator, Both}` and `resource.language == session.workshop_language`, using the same tile layout as the learner view (expanded by default) and showing the standard empty-state copy when none match. Prework Summary stays a placeholder. Materials-only sessions render an empty state message instead of workshop details.
 
 ## 4.4 CRM
 - Full session lifecycle. Defaults on **My Sessions** to owner/CRM scope.
@@ -348,10 +348,11 @@ Two separate tables by design; emails unique per table. If both tables hold the 
 
 # 6. Resources
 
-- Managed at **Settings → Resources**; mapped to Workshop Types.
-- Learner/CSA **My Resources** shows only workshop types associated with sessions for that participant **whose start date has passed**.
+- Managed at **Settings → Resources**; mapped to Workshop Types with per-resource language and audience selectors. The list view adds Audience/Language filters and surfaces both columns alongside Name/Type/Target/Workshop Types/Active.
+- Learner/CSA **My Resources** shows only workshop types associated with sessions for that participant **whose start date has passed** and filters resources to `audience ∈ {Participant, Both}` with `resource.language` matching any started session for that workshop type.
 - Staff see the “My Resources” navigation link only if they're assigned to at least one session; they may still visit `/my-resources` directly without participant records, and the page returns HTTP 200 with an empty state when no resources apply.
 - Resources include an optional rich-text **Description** stored as sanitized HTML and entered in Settings via a Trix editor; on **My Resources** the resource title toggles a collapsible panel whose expanded state shows the link/file tile followed by the sanitized description.
+- Facilitator Workshop View uses the same tile styling, auto-expanding each item, and restricts visibility to facilitator/Both audiences for the session language; the learner view remains unchanged visually.
 - Workshop types are de-duplicated by ID in application code to avoid SQL `DISTINCT` on JSON columns such as `supported_languages`.
 - `/my-resources` gracefully renders an empty state when no resources are available (never 500s).
 

--- a/app/templates/sessions/workshop_view.html
+++ b/app/templates/sessions/workshop_view.html
@@ -158,9 +158,67 @@
 
 <section class="kt-card">
   <h2 class="kt-card-title">Resources (facilitators)</h2>
-  <div class="empty-state">
-    <p>Facilitator resources will be available in a future update.</p>
-  </div>
+  {% if facilitator_resources %}
+    <div class="resource-list">
+      {% for r in facilitator_resources %}
+        {% set public_url = r.public_url %}
+        {% set filename = r.document_filename or (r.resource_value.rsplit('/', 1)[-1] if r.resource_value else '') %}
+        {% set ext = filename.rsplit('.', 1)[-1]|lower if '.' in filename else '' %}
+        {% set is_image = ext in ['png', 'jpg', 'jpeg', 'gif', 'bmp', 'svg', 'webp'] %}
+        {% set is_pdf = ext == 'pdf' %}
+        <details class="resource-item" open>
+          <summary class="resource-summary">{{ r.name }}</summary>
+          <div class="resource-panel">
+            <div class="resource-tile">
+              {% if r.type == 'DOCUMENT' and public_url %}
+                <a href="{{ public_url }}" download class="resource-file-link">
+                  {% if is_image %}
+                    <img src="{{ public_url }}" alt="" class="resource-thumb">
+                  {% else %}
+                    <span class="resource-icon" aria-hidden="true">
+                      {% if is_pdf %}
+                        📄
+                      {% else %}
+                        ⬇️
+                      {% endif %}
+                    </span>
+                  {% endif %}
+                  <span class="resource-file-text">
+                    <span class="resource-file-name">{{ filename or r.name }}</span>
+                    <span class="resource-file-meta">
+                      {% if is_image %}
+                        Download image
+                      {% elif is_pdf %}
+                        Download PDF
+                      {% else %}
+                        Download file
+                      {% endif %}
+                    </span>
+                  </span>
+                </a>
+              {% else %}
+                <span class="resource-icon" aria-hidden="true">🔗</span>
+                {% if r.resource_value %}
+                  <a href="{{ r.resource_value }}" target="_blank" rel="noopener" class="btn btn-secondary">Open resource</a>
+                {% else %}
+                  <span class="resource-file-name">No file uploaded.</span>
+                {% endif %}
+              {% endif %}
+            </div>
+            {% if r.description_html %}
+              <div class="resource-description rich-text">
+                {{ r.description_html | safe }}
+              </div>
+            {% endif %}
+          </div>
+        </details>
+      {% endfor %}
+    </div>
+  {% else %}
+    <div class="empty-state">
+      <p>No resources available.</p>
+    </div>
+  {% endif %}
 </section>
 
 <section class="kt-card">

--- a/app/templates/settings_resources/form.html
+++ b/app/templates/settings_resources/form.html
@@ -16,6 +16,22 @@
       <option value="APP" {% if cur=='APP' %}selected{% endif %}>App</option>
     </select>
   </label><br>
+  <label>Audience
+    {% set current_audience = resource.audience if resource else 'Participant' %}
+    <select name="audience">
+      {% for choice in audience_choices %}
+        <option value="{{ choice }}" {% if current_audience == choice %}selected{% endif %}>{{ choice }}</option>
+      {% endfor %}
+    </select>
+  </label><br>
+  <label>Language
+    {% set current_lang = resource.language if resource else default_language %}
+    <select name="language">
+      {% for code, label in language_options %}
+        <option value="{{ code }}" {% if current_lang == code %}selected{% endif %}>{{ label }}</option>
+      {% endfor %}
+    </select>
+  </label><br>
   <label>Link <input type="url" name="link" value="{{ resource.resource_value if resource and resource.type in ['LINK','APP'] else '' }}"></label><br>
   <label>File <input type="file" name="file"></label><br>
   {% if resource and resource.public_url %}

--- a/app/templates/settings_resources/list.html
+++ b/app/templates/settings_resources/list.html
@@ -4,14 +4,38 @@
 <div class="kt-card">
 <h1 class="kt-card-title">Resources</h1>
 <p><a href="{{ url_for('settings_resources.new_resource') }}">New Resource</a></p>
+<form method="get" class="filters">
+  <div class="filter-row">
+    <label>Audience
+      <select name="audience">
+        <option value="">All audiences</option>
+        {% for choice in audience_choices %}
+          <option value="{{ choice }}" {% if selected_audience == choice %}selected{% endif %}>{{ choice }}</option>
+        {% endfor %}
+      </select>
+    </label>
+    <label>Language
+      <select name="language">
+        <option value="">All languages</option>
+        {% for code, label in language_options %}
+          <option value="{{ code }}" {% if selected_language == code %}selected{% endif %}>{{ label }}</option>
+        {% endfor %}
+      </select>
+    </label>
+    <button type="submit" class="btn btn-secondary btn-sm">Filter</button>
+    <a href="{{ url_for('settings_resources.list_resources') }}" class="btn btn-link">Clear</a>
+  </div>
+</form>
 <table class="kt-table">
   <tr>
-    <th>Name</th><th>Type</th><th>Target</th><th>Workshop Types</th><th>Active</th><th>Actions</th>
+    <th>Name</th><th>Type</th><th>Audience</th><th>Language</th><th>Target</th><th>Workshop Types</th><th>Active</th><th>Actions</th>
   </tr>
   {% for r in resources %}
   <tr>
     <td>{{ r.name }}</td>
     <td>{{ r.type }}</td>
+    <td>{{ r.audience }}</td>
+    <td>{{ r.language | lang_label }}</td>
     <td>
       {% if r.type == 'DOCUMENT' %}
         {{ r.resource_value }}

--- a/migrations/versions/0066_resource_audience_language.py
+++ b/migrations/versions/0066_resource_audience_language.py
@@ -1,0 +1,41 @@
+"""add audience and language to resources"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "0066_resource_audience_language"
+down_revision = "0065_shipping_location_title"
+branch_labels = None
+depends_on = None
+
+
+audience_enum = sa.Enum(
+    "Participant", "Facilitator", "Both", name="resource_audience"
+)
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    audience_enum.create(bind, checkfirst=True)
+    op.add_column(
+        "resources",
+        sa.Column("language", sa.String(length=8), nullable=False, server_default="en"),
+    )
+    op.add_column(
+        "resources",
+        sa.Column(
+            "audience",
+            audience_enum,
+            nullable=False,
+            server_default="Participant",
+        ),
+    )
+    op.execute("UPDATE resources SET language = 'en' WHERE language IS NULL OR language = ''")
+    op.execute("UPDATE resources SET audience = 'Participant' WHERE audience IS NULL")
+
+
+def downgrade() -> None:
+    op.drop_column("resources", "audience")
+    op.drop_column("resources", "language")
+    audience_enum.drop(op.get_bind(), checkfirst=True)

--- a/sitemap.txt
+++ b/sitemap.txt
@@ -9,14 +9,14 @@
 /materials               – Materials dashboard; shows only materials-enabled sessions (includes Material only orders)
 /sessions/new            – Create session (staff only)
 /sessions/<id>           – Session detail (overview + tabs)
-/workshops/<id>         – Workshop runner view (Delivery/Contractor; also used when a user has KT Facilitator among roles; Material only sessions redirect to /sessions/<id>)
+/workshops/<id>         – Workshop runner view (Delivery/Contractor; also used when a user has KT Facilitator among roles; Materials card hidden for materials-only sessions which redirect to /sessions/<id>; Resources card lists session-language facilitator/Both resources)
 /sessions/<id>/materials – Materials order for the session (inherits Shipping Location)
 /sessions/<id>/materials/apply-defaults – Apply Workshop-Type defaults to Material Items
 /sessions/<id>/participants – Add/edit/CSV import participants
 /my-sessions             – Facilitators/CRM/CSA: sessions relevant to them (Delivery/Contractor click-through opens Workshop view; CRM-only scoped to client CRM owner)
 /my-certificates         – Learner portal: download own PDFs
 /profile                 – Learner profile (full name, certificate name)
-/my-resources            – Learner portal: grouped resources by Workshop Type
+/my-resources            – Learner portal: grouped resources by Workshop Type (Participant/Both resources matching session languages)
 
 # Settings (Admin/SysAdmin)
 /settings                – Landing (cards/links)
@@ -35,7 +35,7 @@
   /settings/materials    – Materials Options (by order_type; languages, formats)
   /settings/languages    – Languages list (active, sort)
   /mail-settings         – SMTP configuration, processors mapping, test send
-  /settings/resources    – Manage resources (name, type, link/file, workshop types)
+  /settings/resources    – Manage resources (name, type, language, audience, link/file, workshop types; filters by audience/language)
 
 # Badges & cert files
 /badges/<filename>       – Static badge image from /srv/badges or app/assets/badges


### PR DESCRIPTION
## Summary
- add language and audience columns to resources with a migration and model validation
- expose audience/language selectors and filters in the resources admin UI and surface facilitator resources in workshop view
- tighten learner/workshop queries and tests to honor audience + language visibility; update docs and sitemap

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68cc7b11c920832eb6f50aeacd381bd1