### PR TITLE
Add workshop prework send controls

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -342,8 +342,9 @@ Two separate tables by design; emails unique per table. If both tables hold the 
 - Configured per **Workshop Type** (rich text + questions).  
 - Session **Send Prework** (staff) provisions participant accounts (see defaults in §2.2) and emails access.
   - Allowed roles: Sys Admin, Admin, CRM, Delivery, Contractor.
-- “No prework for this workshop” disables assignment; **Send Accounts (no prework)** sends credentials only.  
+- “No prework for this workshop” disables assignment; **Send Accounts (no prework)** sends credentials only.
 - Participant prework hidden after session starts.
+- Workshop View Participants card shows a Prework column (Submitted with completion date or Not submitted). KT staff and assigned facilitators can send individual prework reminders or bulk-send to all not submitted learners directly from the Workshop View.
 
 ---
 

--- a/app/services/prework_invites.py
+++ b/app/services/prework_invites.py
@@ -1,0 +1,242 @@
+from __future__ import annotations
+
+import hashlib
+import secrets
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from typing import Iterable, Sequence
+
+from flask import current_app, render_template, url_for
+from sqlalchemy.orm import joinedload
+
+from .. import emailer
+from ..app import db
+from ..models import Participant, ParticipantAccount, PreworkAssignment, PreworkEmailLog, PreworkTemplate, Session, SessionParticipant
+from ..shared.accounts import ensure_participant_account
+from ..shared.constants import MAGIC_LINK_TTL_DAYS
+from ..shared.prework_status import ParticipantPreworkStatus, get_participant_prework_status
+from ..shared.time import now_utc
+
+
+class PreworkSendError(Exception):
+    """Raised when prework invites cannot be sent."""
+
+
+@dataclass
+class PreworkSendResult:
+    sent_count: int
+    skipped_count: int
+    failure_count: int
+
+    @property
+    def any_failure(self) -> bool:
+        return self.failure_count > 0
+
+
+def _snapshot_for_template(template: PreworkTemplate) -> dict:
+    questions = sorted(template.questions, key=lambda q: q.position)
+    return {
+        "questions": [
+            {
+                "index": index,
+                "text": q.text,
+                "required": q.required,
+                "kind": q.kind,
+                "min_items": q.min_items,
+                "max_items": q.max_items,
+            }
+            for index, q in enumerate(questions, start=1)
+        ],
+        "resources": [r.resource_id for r in template.resources],
+    }
+
+
+def _ensure_assignment(
+    session: Session,
+    account: ParticipantAccount,
+    template: PreworkTemplate,
+    existing: dict[int, PreworkAssignment],
+) -> PreworkAssignment:
+    assignment = existing.get(account.id)
+    if assignment:
+        return assignment
+
+    snapshot = _snapshot_for_template(template)
+    due_at: datetime | None = None
+    if session.start_date and session.daily_start_time:
+        due_at = datetime.combine(session.start_date, session.daily_start_time) - timedelta(days=3)
+
+    assignment = PreworkAssignment(
+        session_id=session.id,
+        participant_account_id=account.id,
+        template_id=template.id,
+        status="PENDING",
+        due_at=due_at,
+        snapshot_json=snapshot,
+    )
+    db.session.add(assignment)
+    existing[account.id] = assignment
+    return assignment
+
+
+def _send_prework_email(
+    session: Session,
+    assignment: PreworkAssignment,
+    account: ParticipantAccount,
+    temp_password: str | None,
+) -> bool:
+    token = secrets.token_urlsafe(16)
+    assignment.magic_token_hash = hashlib.sha256(
+        (token + current_app.secret_key).encode()
+    ).hexdigest()
+    assignment.magic_token_expires = now_utc() + timedelta(days=MAGIC_LINK_TTL_DAYS)
+    db.session.flush()
+
+    link = url_for(
+        "auth.prework_magic",
+        assignment_id=assignment.id,
+        token=token,
+        _external=True,
+        _scheme="https",
+    )
+    subject = f"Prework for Workshop: {session.title}"
+    body = render_template(
+        "email/prework.txt",
+        session=session,
+        assignment=assignment,
+        link=link,
+        account=account,
+        temp_password=temp_password,
+    )
+    html_body = render_template(
+        "email/prework.html",
+        session=session,
+        assignment=assignment,
+        link=link,
+        account=account,
+        temp_password=temp_password,
+    )
+    try:
+        res = emailer.send(account.email, subject, body, html=html_body)
+    except Exception as exc:  # pragma: no cover - defensive logging
+        res = {"ok": False, "detail": str(exc)}
+
+    if res.get("ok"):
+        assignment.status = "SENT"
+        assignment.sent_at = now_utc()
+        db.session.add(
+            PreworkEmailLog(
+                assignment_id=assignment.id,
+                to_email=account.email,
+                subject=subject,
+            )
+        )
+        current_app.logger.info(
+            f'[MAIL-OUT] prework session={session.id} pa={account.id} to={account.email} subject="{subject}"'
+        )
+        return True
+
+    current_app.logger.info(
+        f"[MAIL-FAIL] prework session={session.id} pa={account.id} to={account.email} error=\"{res.get('detail')}\""
+    )
+    return False
+
+
+def _eligible_participant_ids(
+    statuses: dict[int, ParticipantPreworkStatus],
+    explicit_ids: Sequence[int] | None,
+    allow_completed_resend: bool,
+) -> tuple[set[int], int]:
+    skipped = 0
+    if explicit_ids is not None:
+        target_ids = set(explicit_ids)
+    else:
+        target_ids = set(statuses.keys())
+
+    eligible: set[int] = set()
+    for participant_id in target_ids:
+        status = statuses.get(participant_id)
+        if status is None:
+            continue
+        if status.status == "WAIVED":
+            skipped += 1
+            continue
+        if status.is_submitted and not allow_completed_resend:
+            skipped += 1
+            continue
+        eligible.add(participant_id)
+    return eligible, skipped
+
+
+def send_prework_invites(
+    session: Session,
+    participant_ids: Sequence[int] | None = None,
+    *,
+    allow_completed_resend: bool = False,
+) -> PreworkSendResult:
+    """Send prework invites to session participants."""
+
+    if session.no_prework:
+        raise PreworkSendError("Prework disabled for this workshop")
+
+    if not session.workshop_type_id:
+        raise PreworkSendError("No workshop type configured")
+
+    template = PreworkTemplate.query.filter_by(
+        workshop_type_id=session.workshop_type_id, is_active=True
+    ).first()
+    if not template:
+        raise PreworkSendError("No active prework template")
+
+    statuses = get_participant_prework_status(session.id)
+    eligible_ids, skipped_count = _eligible_participant_ids(
+        statuses, participant_ids, allow_completed_resend
+    )
+
+    if not eligible_ids:
+        return PreworkSendResult(sent_count=0, skipped_count=skipped_count, failure_count=0)
+
+    participants_query = (
+        db.session.query(Participant)
+        .join(SessionParticipant, SessionParticipant.participant_id == Participant.id)
+        .filter(SessionParticipant.session_id == session.id)
+        .filter(SessionParticipant.participant_id.in_(eligible_ids))
+        .options(joinedload(Participant.account))
+    )
+    participants: Iterable[Participant] = participants_query.all()
+
+    assignments = {
+        a.participant_account_id: a
+        for a in PreworkAssignment.query.filter_by(session_id=session.id).all()
+    }
+
+    sent_count = 0
+    failure_count = 0
+    account_cache: dict[str, ParticipantAccount] = {}
+
+    for participant in participants:
+        try:
+            account, temp_password = ensure_participant_account(participant, account_cache)
+        except ValueError:
+            skipped_count += 1
+            continue
+
+        assignment = _ensure_assignment(session, account, template, assignments)
+        if assignment.status == "WAIVED":
+            skipped_count += 1
+            continue
+
+        if not allow_completed_resend and assignment.completed_at:
+            skipped_count += 1
+            continue
+
+        if _send_prework_email(session, assignment, account, temp_password):
+            sent_count += 1
+        else:
+            failure_count += 1
+
+    db.session.commit()
+    return PreworkSendResult(
+        sent_count=sent_count, skipped_count=skipped_count, failure_count=failure_count
+    )
+

--- a/app/shared/prework_status.py
+++ b/app/shared/prework_status.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Dict
+
+from sqlalchemy.orm import Query
+
+from ..app import db
+from ..models import Participant, ParticipantAccount, PreworkAssignment, SessionParticipant
+
+
+@dataclass
+class ParticipantPreworkStatus:
+    """Lightweight view of a participant's prework state for a session."""
+
+    participant_id: int
+    account_id: int | None
+    assignment_id: int | None
+    status: str | None
+    sent_at: datetime | None
+    completed_at: datetime | None
+
+    @property
+    def is_submitted(self) -> bool:
+        return bool(self.completed_at)
+
+
+def get_participant_prework_status(session_id: int) -> Dict[int, ParticipantPreworkStatus]:
+    """Return a mapping of participant id → prework status for the session."""
+
+    query: Query = (
+        db.session.query(
+            SessionParticipant.participant_id,
+            Participant.account_id,
+            PreworkAssignment.id,
+            PreworkAssignment.status,
+            PreworkAssignment.sent_at,
+            PreworkAssignment.completed_at,
+        )
+        .join(Participant, SessionParticipant.participant_id == Participant.id)
+        .outerjoin(
+            ParticipantAccount,
+            Participant.account_id == ParticipantAccount.id,
+        )
+        .outerjoin(
+            PreworkAssignment,
+            (PreworkAssignment.session_id == session_id)
+            & (PreworkAssignment.participant_account_id == ParticipantAccount.id),
+        )
+        .filter(SessionParticipant.session_id == session_id)
+    )
+
+    results: Dict[int, ParticipantPreworkStatus] = {}
+    for (
+        participant_id,
+        account_id,
+        assignment_id,
+        status,
+        sent_at,
+        completed_at,
+    ) in query.all():
+        results[participant_id] = ParticipantPreworkStatus(
+            participant_id=participant_id,
+            account_id=account_id,
+            assignment_id=assignment_id,
+            status=status,
+            sent_at=sent_at,
+            completed_at=completed_at,
+        )
+    return results
+

--- a/app/static/css/buttons.css
+++ b/app/static/css/buttons.css
@@ -146,6 +146,18 @@ input[type="reset"]:disabled,
   text-decoration: none;
 }
 
+.btn.btn-secondary,
+.btn.btn-secondary:link,
+.btn.btn-secondary:visited {
+  color: var(--kt-text);
+}
+
+.btn.btn-secondary:hover,
+.btn.btn-secondary:active,
+.btn.btn-secondary:focus {
+  color: var(--kt-text);
+}
+
 .btn-sm {
   padding: var(--space-1) var(--space-2);
   font-size: 0.875rem;

--- a/app/templates/sessions/workshop_view.html
+++ b/app/templates/sessions/workshop_view.html
@@ -67,6 +67,12 @@
 
 <section class="kt-card">
   <h2 class="kt-card-title">Participants</h2>
+  {% if can_send_prework %}
+  <form action="{{ url_for('sessions.send_prework', session_id=session.id) }}" method="post" style="margin-bottom: var(--space-3);">
+    <input type="hidden" name="next" value="{{ workshop_return }}">
+    <button type="submit" class="btn btn-secondary">Send prework to all not submitted</button>
+  </form>
+  {% endif %}
   {% if can_manage_participants %}
   <form action="{{ url_for('sessions.add_participant', session_id=session.id) }}" method="post">
     <input type="hidden" name="next" value="{{ workshop_return }}">
@@ -98,6 +104,7 @@
         <th scope="col">Full Name</th>
         <th scope="col">Email</th>
         <th scope="col">Title</th>
+        <th scope="col">Prework</th>
         <th scope="col">Completion Date</th>
         <th scope="col">Certificate</th>
         <th scope="col">Actions</th>
@@ -109,6 +116,26 @@
         <td>{{ row.participant.full_name }}{% if row.participant.account and row.participant.account.certificate_name %} ({{ row.participant.account.certificate_name }}){% endif %}</td>
         <td>{{ row.participant.email }}</td>
         <td>{{ row.participant.title }}</td>
+        <td>
+          {% set status = row.prework_status %}
+          {% set is_waived = status and status.status == 'WAIVED' %}
+          {% if status and status.is_submitted %}
+            Submitted{% if status.completed_at %} ({{ status.completed_at.date() | fmt_dt }}){% endif %}
+          {% else %}
+            {% if is_waived %}
+              Not submitted (waived)
+            {% else %}
+              Not submitted
+            {% endif %}
+            {% if can_send_prework and not is_waived %}
+            <form action="{{ url_for('sessions.send_prework', session_id=session.id) }}" method="post" style="display:inline-block;margin-left:var(--space-2);">
+              <input type="hidden" name="next" value="{{ workshop_return }}">
+              <input type="hidden" name="participant_ids[]" value="{{ row.participant.id }}">
+              <button type="submit" class="btn btn-secondary btn-sm">Send prework</button>
+            </form>
+            {% endif %}
+          {% endif %}
+        </td>
         <td>
           <form action="{{ url_for('sessions.generate_single', session_id=session.id, participant_id=row.participant.id) }}" method="post">
             <input type="hidden" name="next" value="{{ workshop_return }}">
@@ -141,7 +168,7 @@
       </tr>
       {% else %}
       <tr>
-        <td colspan="6">No participants added yet.</td>
+        <td colspan="7">No participants added yet.</td>
       </tr>
       {% endfor %}
     </tbody>

--- a/tests/test_workshop_prework.py
+++ b/tests/test_workshop_prework.py
@@ -1,0 +1,144 @@
+from datetime import date, time
+
+import pytest
+
+from app import emailer
+from app.app import create_app, db
+from app.models import (
+    Participant,
+    ParticipantAccount,
+    PreworkAssignment,
+    PreworkQuestion,
+    PreworkTemplate,
+    Session,
+    SessionParticipant,
+    User,
+    WorkshopType,
+)
+
+
+@pytest.fixture
+def app_context():
+    app = create_app()
+    ctx = app.app_context()
+    ctx.push()
+    db.create_all()
+    yield app
+    db.session.remove()
+    db.drop_all()
+    ctx.pop()
+
+
+def _seed_session(with_completion: bool = True):
+    facilitator = User(email="fac@example.com", is_kt_delivery=True)
+    facilitator.set_password("pw")
+    wt = WorkshopType(code="PWV", name="Prework View", cert_series="fn")
+    template = PreworkTemplate(workshop_type=wt, info_html="info")
+    question = PreworkQuestion(template=template, position=1, text="Q1", kind="TEXT")
+    sess = Session(
+        title="Workshop",
+        workshop_type=wt,
+        start_date=date.today(),
+        end_date=date.today(),
+        daily_start_time=time(9, 0),
+        workshop_language="en",
+        lead_facilitator=facilitator,
+    )
+    sess.facilitators = [facilitator]
+    participant = Participant(full_name="Submitted", email="submitted@example.com")
+    pending_participant = Participant(full_name="Pending", email="pending@example.com")
+    db.session.add_all(
+        [
+            facilitator,
+            wt,
+            template,
+            question,
+            sess,
+            participant,
+            pending_participant,
+        ]
+    )
+    db.session.flush()
+    db.session.add_all(
+        [
+            SessionParticipant(session=sess, participant=participant),
+            SessionParticipant(session=sess, participant=pending_participant),
+        ]
+    )
+    db.session.commit()
+
+    if with_completion:
+        account = ParticipantAccount(
+            email=participant.email,
+            full_name=participant.full_name,
+            certificate_name=participant.full_name,
+        )
+        participant.account = account
+        db.session.add(account)
+        db.session.flush()
+        assignment = PreworkAssignment(
+            session=sess,
+            participant_account=account,
+            template=template,
+            status="COMPLETED",
+            completed_at=date.today(),
+            snapshot_json={"questions": [], "resources": []},
+        )
+        db.session.add(assignment)
+        db.session.commit()
+
+    return sess, facilitator, participant, pending_participant
+
+
+def test_workshop_view_shows_prework_status(app_context):
+    app = app_context
+    sess, facilitator, _, pending_participant = _seed_session()
+    client = app.test_client()
+    with client.session_transaction() as sess_data:
+        sess_data["user_id"] = facilitator.id
+    resp = client.get(f"/workshops/{sess.id}")
+    html = resp.get_data(as_text=True)
+    assert "Submitted" in html
+    assert "Not submitted" in html
+    assert "Send prework" in html
+    assert pending_participant.full_name in html
+
+
+def test_send_prework_endpoint_filters_by_participant(app_context, monkeypatch):
+    app = app_context
+    sess, facilitator, _, pending_participant = _seed_session(with_completion=False)
+    sent_to = []
+
+    def fake_send(to, subject, body, html):
+        sent_to.append(to)
+        return {"ok": True}
+
+    monkeypatch.setattr(emailer, "send", fake_send)
+
+    client = app.test_client()
+    with client.session_transaction() as sess_data:
+        sess_data["user_id"] = facilitator.id
+    resp = client.post(
+        f"/sessions/{sess.id}/prework/send",
+        data={"participant_ids[]": str(pending_participant.id)},
+    )
+    assert resp.status_code == 302
+    assert sent_to == [pending_participant.email]
+    assignment = PreworkAssignment.query.filter_by(session_id=sess.id).first()
+    assert assignment is not None
+    assert assignment.sent_at is not None
+
+
+def test_send_prework_blocks_unauthorized(app_context):
+    app = app_context
+    sess, facilitator, _, _ = _seed_session(with_completion=False)
+    other_user = User(email="other@example.com")
+    db.session.add(other_user)
+    db.session.commit()
+
+    client = app.test_client()
+    with client.session_transaction() as sess_data:
+        sess_data["user_id"] = other_user.id
+    resp = client.post(f"/sessions/{sess.id}/prework/send")
+    assert resp.status_code == 403
+


### PR DESCRIPTION
## Summary
- add shared helper and service to query prework status and send invites without duplicating logic
- expose POST /sessions/<id>/prework/send for staff and assigned facilitators with success/JSON feedback and reuse it from the staff prework page
- surface prework status/actions on the Workshop View participants table, and document the new flow
- cover workshop prework UI and endpoint permissions with tests
- ensure secondary buttons display readable text instead of white-on-white styling

## Testing
- pytest -m "smoke"

------
https://chatgpt.com/codex/tasks/task_e_68d04c2bef24832e81a28c3c6305da68