### PR TITLE
Add participant attendance storage and APIs

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -313,6 +313,14 @@ Two separate tables by design; emails unique per table. If both tables hold the 
 ## 3.6 Clients (if present)
 - `clients`, `client_locations` and linkage tables as per migrations.
 
+## 3.7 Attendance storage & endpoints
+- Table: `participant_attendance` (`session_id`, `participant_id`, `day_index`, `attended` boolean default `false`, timestamps). Unique per `(session_id, participant_id, day_index)` with cascade deletes tied to sessions/participants.
+- API:
+  - `POST /sessions/<id>/attendance/toggle` – upserts a single record and returns `{ok, attended}`.
+  - `POST /sessions/<id>/attendance/mark_all_attended` – bulk sets all `day_index` 1..N to attended for the session and returns `{ok, updated_count}`.
+- Auth: Admin/CRM staff or Delivery/Contractor assigned to the session. Learners/CSA accounts receive `403`.
+- Material only sessions (`delivery_type = "Material only"`) reject both endpoints with `403`.
+
 ---
 
 # 4. Gating by Lifecycle

--- a/app/services/attendance.py
+++ b/app/services/attendance.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+from ..app import db
+from ..models import ParticipantAttendance, Session, SessionParticipant
+
+
+class AttendanceValidationError(ValueError):
+    """Raised when attendance parameters fail validation."""
+
+
+class AttendanceForbiddenError(PermissionError):
+    """Raised when attendance changes are not allowed for the session."""
+
+
+def _ensure_session_allows_attendance(session: Session) -> None:
+    if session.delivery_type == "Material only":
+        raise AttendanceForbiddenError(
+            "Material only sessions do not track attendance."
+        )
+
+
+def _validate_day_index(session: Session, day_index: int) -> None:
+    days = session.number_of_class_days or 0
+    if day_index < 1 or day_index > days:
+        raise AttendanceValidationError(
+            "day_index must be between 1 and number_of_class_days."
+        )
+
+
+def _ensure_participant(session: Session, participant_id: int) -> None:
+    exists = (
+        db.session.query(SessionParticipant.id)
+        .filter(
+            SessionParticipant.session_id == session.id,
+            SessionParticipant.participant_id == participant_id,
+        )
+        .scalar()
+    )
+    if not exists:
+        raise AttendanceValidationError("Participant is not part of this session.")
+
+
+def upsert_attendance(
+    session: Session, participant_id: int, day_index: int, attended: bool
+) -> ParticipantAttendance:
+    """Create or update a single attendance record for the given participant."""
+
+    _ensure_session_allows_attendance(session)
+    _validate_day_index(session, day_index)
+    _ensure_participant(session, participant_id)
+
+    attended_value = bool(attended)
+    record = (
+        ParticipantAttendance.query.filter_by(
+            session_id=session.id,
+            participant_id=participant_id,
+            day_index=day_index,
+        )
+        .one_or_none()
+    )
+    if record:
+        record.attended = attended_value
+    else:
+        record = ParticipantAttendance(
+            session_id=session.id,
+            participant_id=participant_id,
+            day_index=day_index,
+            attended=attended_value,
+        )
+        db.session.add(record)
+    return record
+
+
+def mark_all_attended(session: Session) -> int:
+    """Mark every participant/day combination in the session as attended."""
+
+    _ensure_session_allows_attendance(session)
+    days = session.number_of_class_days or 0
+    if days <= 0:
+        return 0
+
+    participant_ids = [
+        row.participant_id
+        for row in SessionParticipant.query.with_entities(
+            SessionParticipant.participant_id
+        ).filter_by(session_id=session.id)
+    ]
+    if not participant_ids:
+        return 0
+
+    existing_records = (
+        ParticipantAttendance.query.filter(
+            ParticipantAttendance.session_id == session.id,
+            ParticipantAttendance.participant_id.in_(participant_ids),
+        ).all()
+    )
+    existing_map = {
+        (record.participant_id, record.day_index): record
+        for record in existing_records
+    }
+
+    total_rows = len(participant_ids) * days
+    for participant_id in participant_ids:
+        for day_index in range(1, days + 1):
+            record = existing_map.get((participant_id, day_index))
+            if record:
+                record.attended = True
+            else:
+                record = ParticipantAttendance(
+                    session_id=session.id,
+                    participant_id=participant_id,
+                    day_index=day_index,
+                    attended=True,
+                )
+                db.session.add(record)
+                existing_map[(participant_id, day_index)] = record
+    return total_rows

--- a/migrations/versions/0068_participant_attendance.py
+++ b/migrations/versions/0068_participant_attendance.py
@@ -1,0 +1,59 @@
+"""participant attendance table
+
+Revision ID: 0068_participant_attendance
+Revises: 0067_session_number_of_class_days
+Create Date: 2025-09-20 00:00:00.000000
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "0068_participant_attendance"
+down_revision = "0067_session_number_of_class_days"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "participant_attendance",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("session_id", sa.Integer(), nullable=False),
+        sa.Column("participant_id", sa.Integer(), nullable=False),
+        sa.Column("day_index", sa.Integer(), nullable=False),
+        sa.Column(
+            "attended",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("false"),
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.ForeignKeyConstraint(
+            ["session_id"], ["sessions.id"], ondelete="CASCADE"
+        ),
+        sa.ForeignKeyConstraint(
+            ["participant_id"], ["participants.id"], ondelete="CASCADE"
+        ),
+        sa.UniqueConstraint(
+            "session_id",
+            "participant_id",
+            "day_index",
+            name="uq_participant_attendance_unique",
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("participant_attendance")

--- a/sitemap.txt
+++ b/sitemap.txt
@@ -15,6 +15,8 @@
 /sessions/<id>/materials/apply-defaults – Apply Workshop-Type defaults to Material Items
 /sessions/<id>/edit     – Staff session edit form (manual # of class days 1–10 lives here)
 /sessions/<id>/participants – Add/edit/CSV import participants
+/sessions/<id>/attendance/toggle – POST: toggle per-day attendance (staff or assigned facilitator)
+/sessions/<id>/attendance/mark_all_attended – POST: bulk mark all participants/days attended (staff or assigned facilitator)
 /my-sessions             – Facilitators/CRM/CSA: sessions relevant to them (Delivery/Contractor click-through opens Workshop view; CRM-only scoped to client CRM owner)
 /my-certificates         – Learner portal: download own PDFs
 /profile                 – Learner profile (full name, certificate name)

--- a/tests/test_attendance.py
+++ b/tests/test_attendance.py
@@ -1,0 +1,264 @@
+import os
+from datetime import date
+
+import pytest
+
+from app.app import create_app, db
+from app.models import (
+    Client,
+    Participant,
+    ParticipantAccount,
+    ParticipantAttendance,
+    Session,
+    SessionParticipant,
+    User,
+    WorkshopType,
+)
+
+
+pytestmark = pytest.mark.smoke
+
+
+@pytest.fixture
+def app():
+    os.environ["DATABASE_URL"] = "sqlite:///:memory:"
+    os.makedirs("/srv", exist_ok=True)
+    application = create_app()
+    with application.app_context():
+        db.create_all()
+    yield application
+    with application.app_context():
+        db.session.remove()
+
+
+def login_user(client, *, user_id=None, participant_account_id=None):
+    with client.session_transaction() as sess:
+        sess.clear()
+        if user_id is not None:
+            sess["user_id"] = user_id
+        if participant_account_id is not None:
+            sess["participant_account_id"] = participant_account_id
+
+
+def seed_session(app, *, materials_only: bool = False):
+    with app.app_context():
+        admin = User(email="admin@example.com", is_admin=True)
+        admin.set_password("x")
+        facilitator = User(email="fac@example.com", is_kt_delivery=True)
+        facilitator.set_password("x")
+        other_facilitator = User(email="other@example.com", is_kt_delivery=True)
+        other_facilitator.set_password("x")
+        workshop_type = WorkshopType(code="WT", name="Workshop", cert_series="SER")
+        client = Client(name="Client")
+        db.session.add_all([admin, facilitator, other_facilitator, workshop_type, client])
+        db.session.flush()
+
+        session = Session(
+            title="Session",
+            client_id=client.id,
+            workshop_type_id=workshop_type.id,
+            start_date=date.today(),
+            end_date=date.today(),
+            region="NA",
+            workshop_language="en",
+            capacity=25,
+            delivery_type="Material only" if materials_only else "In Person",
+            materials_only=materials_only,
+            number_of_class_days=3,
+        )
+        if not materials_only:
+            session.lead_facilitator_id = facilitator.id
+            session.facilitators = [facilitator]
+        db.session.add(session)
+        db.session.flush()
+
+        participants = []
+        for idx in range(2):
+            participant = Participant(email=f"p{idx}@example.com")
+            db.session.add(participant)
+            db.session.flush()
+            db.session.add(
+                SessionParticipant(
+                    session_id=session.id, participant_id=participant.id
+                )
+            )
+            participants.append(participant.id)
+        db.session.commit()
+        return {
+            "admin_id": admin.id,
+            "facilitator_id": facilitator.id,
+            "other_facilitator_id": other_facilitator.id,
+            "session_id": session.id,
+            "participant_ids": participants,
+        }
+
+
+def test_toggle_attendance_creates_and_updates(app):
+    seed = seed_session(app)
+    client = app.test_client()
+    login_user(client, user_id=seed["admin_id"])
+
+    session_id = seed["session_id"]
+    participant_id = seed["participant_ids"][0]
+
+    resp = client.post(
+        f"/sessions/{session_id}/attendance/toggle",
+        json={
+            "participant_id": participant_id,
+            "day_index": 1,
+            "attended": True,
+        },
+    )
+    assert resp.status_code == 200
+    assert resp.get_json()["attended"] is True
+
+    resp = client.post(
+        f"/sessions/{session_id}/attendance/toggle",
+        json={
+            "participant_id": participant_id,
+            "day_index": 1,
+            "attended": False,
+        },
+    )
+    assert resp.status_code == 200
+    assert resp.get_json()["attended"] is False
+
+    with app.app_context():
+        record = ParticipantAttendance.query.filter_by(
+            session_id=session_id, participant_id=participant_id, day_index=1
+        ).one()
+        assert record.attended is False
+
+
+def test_mark_all_attended_sets_all_days(app):
+    seed = seed_session(app)
+    client = app.test_client()
+    login_user(client, user_id=seed["admin_id"])
+
+    session_id = seed["session_id"]
+    first_participant = seed["participant_ids"][0]
+    with app.app_context():
+        db.session.add(
+            ParticipantAttendance(
+                session_id=session_id,
+                participant_id=first_participant,
+                day_index=1,
+                attended=False,
+            )
+        )
+        db.session.commit()
+
+    resp = client.post(f"/sessions/{session_id}/attendance/mark_all_attended")
+    assert resp.status_code == 200
+    assert resp.get_json()["updated_count"] == 6
+
+    with app.app_context():
+        records = ParticipantAttendance.query.filter_by(session_id=session_id).all()
+        assert len(records) == 6
+        assert all(record.attended is True for record in records)
+
+
+def test_toggle_rejects_invalid_day_index(app):
+    seed = seed_session(app)
+    client = app.test_client()
+    login_user(client, user_id=seed["admin_id"])
+
+    session_id = seed["session_id"]
+    participant_id = seed["participant_ids"][0]
+
+    resp = client.post(
+        f"/sessions/{session_id}/attendance/toggle",
+        json={
+            "participant_id": participant_id,
+            "day_index": 4,
+            "attended": True,
+        },
+    )
+    assert resp.status_code == 400
+
+
+def test_toggle_rejects_participant_not_in_session(app):
+    seed = seed_session(app)
+    client = app.test_client()
+    login_user(client, user_id=seed["admin_id"])
+
+    session_id = seed["session_id"]
+    with app.app_context():
+        outsider = Participant(email="outsider@example.com")
+        db.session.add(outsider)
+        db.session.commit()
+        outsider_id = outsider.id
+
+    resp = client.post(
+        f"/sessions/{session_id}/attendance/toggle",
+        json={
+            "participant_id": outsider_id,
+            "day_index": 1,
+            "attended": True,
+        },
+    )
+    assert resp.status_code == 400
+
+
+def test_material_only_session_blocked(app):
+    seed = seed_session(app, materials_only=True)
+    client = app.test_client()
+    login_user(client, user_id=seed["admin_id"])
+
+    session_id = seed["session_id"]
+    participant_id = seed["participant_ids"][0]
+
+    resp = client.post(
+        f"/sessions/{session_id}/attendance/toggle",
+        json={
+            "participant_id": participant_id,
+            "day_index": 1,
+            "attended": True,
+        },
+    )
+    assert resp.status_code == 403
+
+    resp = client.post(f"/sessions/{session_id}/attendance/mark_all_attended")
+    assert resp.status_code == 403
+
+
+def test_csa_blocked_from_attendance(app):
+    seed = seed_session(app)
+    client = app.test_client()
+
+    with app.app_context():
+        account = ParticipantAccount(email="csa@example.com", full_name="CSA")
+        db.session.add(account)
+        db.session.commit()
+        account_id = account.id
+
+    login_user(client, participant_account_id=account_id)
+    session_id = seed["session_id"]
+    participant_id = seed["participant_ids"][0]
+    resp = client.post(
+        f"/sessions/{session_id}/attendance/toggle",
+        json={
+            "participant_id": participant_id,
+            "day_index": 1,
+            "attended": True,
+        },
+    )
+    assert resp.status_code == 403
+
+
+def test_unassigned_facilitator_blocked(app):
+    seed = seed_session(app)
+    client = app.test_client()
+    login_user(client, user_id=seed["other_facilitator_id"])
+
+    session_id = seed["session_id"]
+    participant_id = seed["participant_ids"][0]
+    resp = client.post(
+        f"/sessions/{session_id}/attendance/toggle",
+        json={
+            "participant_id": participant_id,
+            "day_index": 1,
+            "attended": True,
+        },
+    )
+    assert resp.status_code == 403


### PR DESCRIPTION
## Summary
- add a participant_attendance table plus ORM relationships and helpers to track per-day attendance
- expose POST endpoints to toggle a participant/day and bulk mark all days attended with staff or assigned facilitator access only
- cover the new flows with smoke tests and document the table and endpoints in CONTEXT.md and sitemap.txt

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d14f490960832eb3cb33c303520bd5