### PR TITLE
Style lifecycle statuses based on delivery

### DIFF
--- a/app/static/css/utilities.css
+++ b/app/static/css/utilities.css
@@ -19,3 +19,15 @@
 .gap-lg {
   gap: var(--space-6);
 }
+
+.lifecycle-status {
+  font-weight: 600;
+}
+
+.lifecycle-status--positive {
+  color: var(--kt-accent-green);
+}
+
+.lifecycle-status--negative {
+  color: var(--kt-accent-red);
+}

--- a/app/templates/macros/lifecycle.html
+++ b/app/templates/macros/lifecycle.html
@@ -1,0 +1,21 @@
+{% macro yes_no(value, highlight=False) -%}
+  {%- if highlight -%}
+    {%- if value -%}
+      <span class="lifecycle-status lifecycle-status--positive">Yes</span>
+    {%- else -%}
+      <span class="lifecycle-status lifecycle-status--negative">No</span>
+    {%- endif -%}
+  {%- else -%}
+    {%- if value -%}Yes{%- else -%}No{%- endif -%}
+  {%- endif -%}
+{%- endmacro %}
+
+{% macro delivered(value, highlight=False, finalized=False) -%}
+  {%- if finalized -%}
+    {%- if value -%}Yes{%- else -%}No{%- endif -%}
+  {%- elif highlight and value -%}
+    <span class="lifecycle-status lifecycle-status--positive">Yes</span>
+  {%- else -%}
+    {%- if value -%}Yes{%- else -%}No{%- endif -%}
+  {%- endif -%}
+{%- endmacro %}

--- a/app/templates/session_detail.html
+++ b/app/templates/session_detail.html
@@ -1,6 +1,9 @@
 {% extends 'base.html' %}
+{% import 'macros/lifecycle.html' as lifecycle %}
 {% block title %}Session {{ session.title }}{% endblock %}
 {% block content %}
+{% set highlight_lifecycle_fields = (not session.delivered) and (not session.finalized) %}
+{% set highlight_delivered = session.delivered and not session.finalized %}
 <h1>{{ session.title }}</h1>
 <p><a href="{{ url_for('sessions.list_sessions', **back_params) }}">Back to Sessions</a></p>
 {% if session.cancelled %}<div class="banner">Session cancelled.</div>{% endif %}
@@ -24,10 +27,10 @@
   Shipping Location: {{ session.shipping_location.display_name() if session.shipping_location else '' }}<br>
   Notes:  {{ session.notes or session.description or '' }}<br>
   Status: {{ session.computed_status }}<br>
-  Materials ordered : {{ ' Yes' if session.materials_ordered else 'No' }}{% if session.materials_ordered_at %} ({{ session.materials_ordered_at|fmt_dt }}){% endif %}<br>
-  Ready for delivery: {{ 'Yes' if session.ready_for_delivery else 'No' }}{% if session.ready_at %} ({{ session.ready_at|fmt_dt }}){% endif %}<br>
-  Workshop info sent: {{ 'Yes' if session.info_sent else 'No' }}{% if session.info_sent_at %} ({{ session.info_sent_at|fmt_dt }}){% endif %}<br>
-  Delivered         : {{ 'Yes' if session.delivered else 'No' }}{% if session.delivered_at %} ({{ session.delivered_at|fmt_dt }}){% endif %}<br>
+  Materials ordered : {{ lifecycle.yes_no(session.materials_ordered, highlight_lifecycle_fields)|safe }}{% if session.materials_ordered_at %} ({{ session.materials_ordered_at|fmt_dt }}){% endif %}<br>
+  Ready for delivery: {{ lifecycle.yes_no(session.ready_for_delivery, highlight_lifecycle_fields)|safe }}{% if session.ready_at %} ({{ session.ready_at|fmt_dt }}){% endif %}<br>
+  Workshop info sent: {{ lifecycle.yes_no(session.info_sent, highlight_lifecycle_fields)|safe }}{% if session.info_sent_at %} ({{ session.info_sent_at|fmt_dt }}){% endif %}<br>
+  Delivered         : {{ lifecycle.delivered(session.delivered, highlight_delivered, session.finalized)|safe }}{% if session.delivered_at %} ({{ session.delivered_at|fmt_dt }}){% endif %}<br>
 </div>
 {% else %}
 <div>
@@ -43,10 +46,10 @@
   Shipping Location: {{ session.shipping_location.display_name() if session.shipping_location else '' }}<br>
   Notes:  {{ session.notes or session.description or '' }}<br><br>
   Status: {{ session.computed_status }}<br>
-  Materials ordered:  {{ 'Yes' if session.materials_ordered else 'No' }}{% if session.materials_ordered_at %} ({{ session.materials_ordered_at|fmt_dt }}){% endif %}<br>
-  Ready for delivery: {{ 'Yes' if session.ready_for_delivery else 'No' }}{% if session.ready_at %} ({{ session.ready_at|fmt_dt }}){% endif %}<br>
-  Workshop info sent: {{ 'Yes' if session.info_sent else 'No' }}{% if session.info_sent_at %} ({{ session.info_sent_at|fmt_dt }}){% endif %}<br>
-  Delivered:          {{ 'Yes' if session.delivered else 'No' }}{% if session.delivered_at %} ({{ session.delivered_at|fmt_dt }}){% endif %}<br>
+  Materials ordered:  {{ lifecycle.yes_no(session.materials_ordered, highlight_lifecycle_fields)|safe }}{% if session.materials_ordered_at %} ({{ session.materials_ordered_at|fmt_dt }}){% endif %}<br>
+  Ready for delivery: {{ lifecycle.yes_no(session.ready_for_delivery, highlight_lifecycle_fields)|safe }}{% if session.ready_at %} ({{ session.ready_at|fmt_dt }}){% endif %}<br>
+  Workshop info sent: {{ lifecycle.yes_no(session.info_sent, highlight_lifecycle_fields)|safe }}{% if session.info_sent_at %} ({{ session.info_sent_at|fmt_dt }}){% endif %}<br>
+  Delivered:          {{ lifecycle.delivered(session.delivered, highlight_delivered, session.finalized)|safe }}{% if session.delivered_at %} ({{ session.delivered_at|fmt_dt }}){% endif %}<br>
   Finalized:          {{ 'Yes' if session.finalized else 'No' }}{% if session.finalized_at %} ({{ session.finalized_at|fmt_dt }}){% endif %}
 </div>
 {% endif %}

--- a/app/templates/sessions/workshop_view.html
+++ b/app/templates/sessions/workshop_view.html
@@ -1,10 +1,13 @@
 {% extends 'base.html' %}
+{% import 'macros/lifecycle.html' as lifecycle %}
 {% set workshop_code = session.workshop_type.code if session.workshop_type else '—' %}
 {% set delivery_label = session.delivery_type or '—' %}
 {% set status_label = session.computed_status %}
 {% set workshop_heading = session.id ~ ' ' ~ session.title ~ ': ' ~ workshop_code ~ ' (' ~ delivery_label ~ ') - ' ~ status_label %}
 {% block title %}{{ workshop_heading }}{% endblock %}
 {% block content %}
+{% set highlight_lifecycle_fields = (not session.delivered) and (not session.finalized) %}
+{% set highlight_delivered = session.delivered and not session.finalized %}
 <h1>{{ workshop_heading }}</h1>
 <p><a href="{{ url_for('my_sessions.list_my_sessions') }}">Back to My Sessions</a></p>
 {% if session.cancelled %}<div class="banner">Session cancelled.</div>{% endif %}
@@ -56,10 +59,10 @@
     <div class="grid gap-sm">
       <div><strong>Shipping Location:</strong> {{ session.shipping_location.display_name() if session.shipping_location else '—' }}</div>
       <div><strong>Notes:</strong> {{ session.notes or session.description or '—' }}</div>
-      <div><strong>Materials ordered:</strong> {{ 'Yes' if session.materials_ordered else 'No' }}{% if session.materials_ordered_at %} ({{ session.materials_ordered_at|fmt_dt }}){% endif %}</div>
-      <div><strong>Ready for delivery:</strong> {{ 'Yes' if session.ready_for_delivery else 'No' }}{% if session.ready_at %} ({{ session.ready_at|fmt_dt }}){% endif %}</div>
-      <div><strong>Workshop info sent:</strong> {{ 'Yes' if session.info_sent else 'No' }}{% if session.info_sent_at %} ({{ session.info_sent_at|fmt_dt }}){% endif %}</div>
-      <div><strong>Delivered:</strong> {{ 'Yes' if session.delivered else 'No' }}{% if session.delivered_at %} ({{ session.delivered_at|fmt_dt }}){% endif %}</div>
+      <div><strong>Materials ordered:</strong> {{ lifecycle.yes_no(session.materials_ordered, highlight_lifecycle_fields)|safe }}{% if session.materials_ordered_at %} ({{ session.materials_ordered_at|fmt_dt }}){% endif %}</div>
+      <div><strong>Ready for delivery:</strong> {{ lifecycle.yes_no(session.ready_for_delivery, highlight_lifecycle_fields)|safe }}{% if session.ready_at %} ({{ session.ready_at|fmt_dt }}){% endif %}</div>
+      <div><strong>Workshop info sent:</strong> {{ lifecycle.yes_no(session.info_sent, highlight_lifecycle_fields)|safe }}{% if session.info_sent_at %} ({{ session.info_sent_at|fmt_dt }}){% endif %}</div>
+      <div><strong>Delivered:</strong> {{ lifecycle.delivered(session.delivered, highlight_delivered, session.finalized)|safe }}{% if session.delivered_at %} ({{ session.delivered_at|fmt_dt }}){% endif %}</div>
       <div><strong>Finalized:</strong> {{ 'Yes' if session.finalized else 'No' }}{% if session.finalized_at %} ({{ session.finalized_at|fmt_dt }}){% endif %}</div>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- add reusable macros for lifecycle yes/no values
- update session detail and workshop views to style lifecycle fields per delivery/finalization state
- add utility classes for lifecycle colors

## Testing
- pytest tests/test_sessions_status.py

------
https://chatgpt.com/codex/tasks/task_e_68d15f33e74c832eabe30a3003695d5e