### PR TITLE
Add per-day attendance controls to staff and workshop views

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -320,6 +320,10 @@ Two separate tables by design; emails unique per table. If both tables hold the 
   - `POST /sessions/<id>/attendance/mark_all_attended` – bulk sets all `day_index` 1..N to attended for the session and returns `{ok, updated_count}`.
 - Auth: Admin/CRM staff or Delivery/Contractor assigned to the session. Learners/CSA accounts receive `403`.
 - Material only sessions (`delivery_type = "Material only"`) reject both endpoints with `403`.
+- UI:
+  - `number_of_class_days` controls the Day 1..N columns. Increasing the count surfaces new unchecked days; decreasing hides extra columns without deleting stored attendance rows.
+  - Workshop View (`/workshops/<id>`) and Session Detail (`/sessions/<id>`) show per-participant Day 1..N checkboxes plus a “Mark all attended” bulk action. Controls render for staff and assigned facilitators only.
+  - Learners/CSA never see attendance controls. Certificate generation remains unchanged.
 
 ---
 

--- a/app/static/css/table.css
+++ b/app/static/css/table.css
@@ -37,6 +37,20 @@
   background: color-mix(in srgb, var(--kt-info) 8%, var(--kt-bg));
 }
 
+.attendance-table thead th {
+  white-space: nowrap;
+}
+
+.attendance-table .attendance-cell {
+  text-align: center;
+  vertical-align: middle;
+}
+
+.attendance-table .attendance-checkbox {
+  width: 1.25rem;
+  height: 1.25rem;
+}
+
 /* Narrow, right-aligned actions column */
 .kt-table .col-actions {
   width: 1%;

--- a/app/static/js/attendance_controls.js
+++ b/app/static/js/attendance_controls.js
@@ -1,0 +1,162 @@
+(function () {
+  function showFlash(message, category) {
+    const content = document.querySelector('.content');
+    if (!content) {
+      return;
+    }
+    let container = content.querySelector('.flashes');
+    if (!container) {
+      container = document.createElement('div');
+      container.className = 'flashes';
+      content.insertBefore(container, content.firstChild);
+    }
+    const flash = document.createElement('div');
+    const variant = category || 'info';
+    flash.className = 'flash flash-' + variant;
+    flash.setAttribute('role', 'alert');
+    flash.setAttribute('aria-live', 'polite');
+    flash.tabIndex = 0;
+    flash.appendChild(document.createTextNode(message));
+    const closeBtn = document.createElement('button');
+    closeBtn.type = 'button';
+    closeBtn.className = 'flash-close btn-icon';
+    closeBtn.setAttribute('aria-label', 'Close');
+    closeBtn.textContent = '×';
+    closeBtn.addEventListener('click', function () {
+      flash.remove();
+    });
+    flash.appendChild(closeBtn);
+    container.appendChild(flash);
+    flash.focus();
+  }
+
+  function sendJson(url, payload) {
+    return fetch(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Accept: 'application/json',
+        'X-Requested-With': 'XMLHttpRequest',
+      },
+      credentials: 'same-origin',
+      body: JSON.stringify(payload || {}),
+    }).then(function (response) {
+      return response
+        .json()
+        .catch(function () {
+          return {};
+        })
+        .then(function (data) {
+          if (!response.ok || (data && data.ok === false)) {
+            const message = (data && data.error) || response.statusText || 'Request failed.';
+            const error = new Error(message);
+            error.data = data;
+            throw error;
+          }
+          return data || {};
+        });
+    });
+  }
+
+  function handleToggle(event) {
+    const checkbox = event.target;
+    const container = checkbox.closest('[data-attendance-table]');
+    if (!container) {
+      return;
+    }
+    const toggleUrl = container.dataset.toggleUrl;
+    if (!toggleUrl) {
+      return;
+    }
+    const participantId = checkbox.getAttribute('data-participant-id');
+    const dayIndex = checkbox.getAttribute('data-day-index');
+    const participantName = checkbox.getAttribute('data-participant-name') || 'participant';
+    const newState = checkbox.checked;
+    const previousState = !newState;
+    checkbox.disabled = true;
+    sendJson(toggleUrl, {
+      participant_id: participantId,
+      day_index: dayIndex,
+      attended: newState,
+    })
+      .then(function (data) {
+        checkbox.checked = Boolean(data.attended);
+        checkbox.dataset.lastValue = checkbox.checked ? 'true' : 'false';
+        showFlash('Updated Day ' + dayIndex + ' attendance for ' + participantName + '.', 'success');
+      })
+      .catch(function (error) {
+        checkbox.checked = previousState;
+        showFlash(error.message || 'Unable to update attendance.', 'error');
+      })
+      .finally(function () {
+        checkbox.disabled = false;
+      });
+  }
+
+  function handleMarkAll(event) {
+    const button = event.target;
+    const container = button.closest('[data-attendance-table]');
+    if (!container) {
+      return;
+    }
+    const markAllUrl = container.dataset.markAllUrl;
+    if (!markAllUrl) {
+      return;
+    }
+    button.disabled = true;
+    sendJson(markAllUrl, {})
+      .then(function (data) {
+        container.querySelectorAll('[data-attendance-checkbox]').forEach(function (checkbox) {
+          checkbox.checked = true;
+          checkbox.dataset.lastValue = 'true';
+        });
+        const updated = data.updated_count != null ? Number(data.updated_count) : null;
+        if (updated && !Number.isNaN(updated)) {
+          showFlash('Marked attendance for ' + updated + ' entries.', 'success');
+        } else {
+          showFlash('Marked attendance for all participants.', 'success');
+        }
+      })
+      .catch(function (error) {
+        showFlash(error.message || 'Unable to mark attendance.', 'error');
+      })
+      .finally(function () {
+        button.disabled = false;
+      });
+  }
+
+  function initTable(container) {
+    const toggleUrl = container.dataset.toggleUrl;
+    const markAllUrl = container.dataset.markAllUrl;
+    if (!toggleUrl && !markAllUrl) {
+      return;
+    }
+    container.querySelectorAll('[data-attendance-checkbox]').forEach(function (checkbox) {
+      checkbox.addEventListener('change', handleToggle);
+      checkbox.dataset.lastValue = checkbox.checked ? 'true' : 'false';
+    });
+    const markAllButton = container.querySelector('[data-mark-all-attended]');
+    if (markAllButton) {
+      markAllButton.addEventListener('click', function (event) {
+        event.preventDefault();
+        handleMarkAll(event);
+      });
+    }
+  }
+
+  function initAttendance(context) {
+    context
+      .querySelectorAll('[data-attendance-table]')
+      .forEach(function (container) {
+        initTable(container);
+      });
+  }
+
+  document.addEventListener('DOMContentLoaded', function () {
+    initAttendance(document);
+  });
+
+  window.initAttendanceControls = function () {
+    initAttendance(document);
+  };
+})();

--- a/app/templates/session_detail.html
+++ b/app/templates/session_detail.html
@@ -172,43 +172,99 @@
   </div>
   {% endif %}
   {% endif %}
-  <table class="kt-table">
-    <tr><th>Full Name</th><th>Email</th><th>Title</th><th>Completion Date</th><th>Certificate</th><th>Actions</th></tr>
-    {% for row in participants %}
-    <tr>
-      <td>{{ row.participant.full_name }}{% if row.participant.account and row.participant.account.certificate_name %} ({{ row.participant.account.certificate_name }}){% endif %}</td>
-      <td>{{ row.participant.email }}</td>
-      <td>{{ row.participant.title }}</td>
-      <td>
-        <form action="{{ url_for('sessions.generate_single', session_id=session.id, participant_id=row.participant.id) }}" method="post">
-          <input type="date" name="completion_date" value="{{ row.link.completion_date }}">
-          <button type="submit" name="action" value="save">Save</button>
-          {% if session.delivered %}
-          <button type="submit" name="action" value="generate">Generate</button>
+  {% set attendance_toggle_url = url_for('sessions.toggle_attendance', session_id=session.id) %}
+  {% set attendance_mark_all_url = url_for('sessions.mark_all_attendance', session_id=session.id) %}
+  <div class="attendance-manager"
+       {% if can_manage_attendance %}
+       data-attendance-table
+       data-toggle-url="{{ attendance_toggle_url }}"
+       data-mark-all-url="{{ attendance_mark_all_url }}"
+       {% endif %}>
+    {% if can_manage_attendance %}
+    <div class="table-toolbar">
+      <button type="button" class="btn btn-secondary" data-mark-all-attended>Mark all attended</button>
+    </div>
+    {% endif %}
+    <div class="kt-table-wrapper">
+      <table class="kt-table{% if attendance_days %} attendance-table{% endif %}">
+        <thead>
+          <tr>
+            <th scope="col"{% if attendance_days %} rowspan="2"{% endif %}>Full Name</th>
+            <th scope="col"{% if attendance_days %} rowspan="2"{% endif %}>Email</th>
+            <th scope="col"{% if attendance_days %} rowspan="2"{% endif %}>Title</th>
+            {% if attendance_days %}
+            <th scope="colgroup" colspan="{{ attendance_days|length }}">Attendance</th>
+            {% endif %}
+            <th scope="col"{% if attendance_days %} rowspan="2"{% endif %}>Completion Date</th>
+            <th scope="col"{% if attendance_days %} rowspan="2"{% endif %}>Certificate</th>
+            <th scope="col"{% if attendance_days %} rowspan="2"{% endif %}>Actions</th>
+          </tr>
+          {% if attendance_days %}
+          <tr>
+            {% for day in attendance_days %}
+            <th scope="col">Day {{ day }}</th>
+            {% endfor %}
+          </tr>
           {% endif %}
-        </form>
-      </td>
-      <td>
-        {% if row.pdf_path %}
-          {% if badge_filename %}
-            {% set badge_url = '/badges/' ~ badge_filename %}
-            <a href="{{ badge_url }}" download><img src="{{ badge_url }}" alt="badge" style="height:20px;width:auto;vertical-align:middle;"></a>
-            <a href="{{ badge_url }}" download>Badge</a>
-          {% endif %}
-          <a href="/certificates/{{ row.pdf_path }}">Certificate</a>
-        {% endif %}
-      </td>
-      <td>
-        {% if not session.delivered and not session.participants_locked() %}
-        <a href="{{ url_for('sessions.edit_participant', session_id=session.id, participant_id=row.participant.id) }}">Edit</a>
-        <form action="{{ url_for('sessions.remove_participant', session_id=session.id, participant_id=row.participant.id) }}" method="post" style="display:inline">
-          <button type="submit">Remove</button>
-        </form>
-        {% endif %}
-      </td>
-    </tr>
-    {% endfor %}
-  </table>
+        </thead>
+        <tbody>
+          {% for row in participants %}
+          <tr>
+            <td>{{ row.participant.full_name }}{% if row.participant.account and row.participant.account.certificate_name %} ({{ row.participant.account.certificate_name }}){% endif %}</td>
+            <td>{{ row.participant.email }}</td>
+            <td>{{ row.participant.title }}</td>
+            {% if attendance_days %}
+              {% set attendance = row.attendance if row.attendance is defined else {} %}
+              {% for day in attendance_days %}
+              <td class="attendance-cell">
+                {% if can_manage_attendance %}
+                <input type="checkbox"
+                       class="attendance-checkbox"
+                       data-attendance-checkbox
+                       data-participant-id="{{ row.participant.id }}"
+                       data-participant-name="{{ row.participant.full_name or row.participant.email }}"
+                       data-day-index="{{ day }}"
+                       aria-label="Day {{ day }} attendance for {{ row.participant.full_name or row.participant.email }}"
+                       {% if attendance.get(day) %}checked{% endif %}>
+                {% else %}
+                  {{ 'Yes' if attendance.get(day) else '—' }}
+                {% endif %}
+              </td>
+              {% endfor %}
+            {% endif %}
+            <td>
+              <form action="{{ url_for('sessions.generate_single', session_id=session.id, participant_id=row.participant.id) }}" method="post">
+                <input type="date" name="completion_date" value="{{ row.link.completion_date }}">
+                <button type="submit" name="action" value="save">Save</button>
+                {% if session.delivered %}
+                <button type="submit" name="action" value="generate">Generate</button>
+                {% endif %}
+              </form>
+            </td>
+            <td>
+              {% if row.pdf_path %}
+                {% if badge_filename %}
+                  {% set badge_url = '/badges/' ~ badge_filename %}
+                  <a href="{{ badge_url }}" download><img src="{{ badge_url }}" alt="badge" style="height:20px;width:auto;vertical-align:middle;"></a>
+                  <a href="{{ badge_url }}" download>Badge</a>
+                {% endif %}
+                <a href="/certificates/{{ row.pdf_path }}">Certificate</a>
+              {% endif %}
+            </td>
+            <td>
+              {% if not session.delivered and not session.participants_locked() %}
+              <a href="{{ url_for('sessions.edit_participant', session_id=session.id, participant_id=row.participant.id) }}">Edit</a>
+              <form action="{{ url_for('sessions.remove_participant', session_id=session.id, participant_id=row.participant.id) }}" method="post" style="display:inline">
+                <button type="submit">Remove</button>
+              </form>
+              {% endif %}
+            </td>
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  </div>
   {% if session.delivered %}
   <form action="{{ url_for('sessions.generate_bulk', session_id=session.id) }}" method="post">
     <button type="submit">Generate Certificates</button>
@@ -219,4 +275,9 @@
     {% endif %}
   </div>
 {% endif %}
+{% endblock %}
+
+{% block extra_js %}
+  {{ super() }}
+  <script src="{{ url_for('static', filename='js/attendance_controls.js') }}"></script>
 {% endblock %}

--- a/app/templates/sessions/workshop_view.html
+++ b/app/templates/sessions/workshop_view.html
@@ -101,30 +101,73 @@
   </div>
   {% endif %}
   {% endif %}
-  <table class="kt-table">
-    <thead>
-      <tr>
-        <th scope="col">Full Name</th>
-        <th scope="col">Email</th>
-        <th scope="col">Title</th>
-        <th scope="col">Prework</th>
-        <th scope="col">Completion Date</th>
-        <th scope="col">Certificate</th>
-        <th scope="col">Actions</th>
-      </tr>
-    </thead>
-    <tbody>
-      {% for row in participants %}
-      <tr>
-        <td>{{ row.participant.full_name }}{% if row.participant.account and row.participant.account.certificate_name %} ({{ row.participant.account.certificate_name }}){% endif %}</td>
-        <td>{{ row.participant.email }}</td>
-        <td>{{ row.participant.title }}</td>
-        <td>
-          {% set status = row.prework_status %}
-          {% set is_waived = status and status.status == 'WAIVED' %}
-          {% if status and status.is_submitted %}
-            Submitted{% if status.completed_at %} ({{ status.completed_at.date() | fmt_dt }}){% endif %}
-          {% else %}
+  {% set attendance_toggle_url = url_for('sessions.toggle_attendance', session_id=session.id) %}
+  {% set attendance_mark_all_url = url_for('sessions.mark_all_attendance', session_id=session.id) %}
+  <div class="attendance-manager"
+       {% if can_manage_attendance %}
+       data-attendance-table
+       data-toggle-url="{{ attendance_toggle_url }}"
+       data-mark-all-url="{{ attendance_mark_all_url }}"
+       {% endif %}>
+    {% if can_manage_attendance %}
+    <div class="table-toolbar">
+      <button type="button" class="btn btn-secondary" data-mark-all-attended>Mark all attended</button>
+    </div>
+    {% endif %}
+    <div class="kt-table-wrapper">
+      <table class="kt-table{% if attendance_days %} attendance-table{% endif %}">
+        <thead>
+          <tr>
+            <th scope="col"{% if attendance_days %} rowspan="2"{% endif %}>Full Name</th>
+            <th scope="col"{% if attendance_days %} rowspan="2"{% endif %}>Email</th>
+            <th scope="col"{% if attendance_days %} rowspan="2"{% endif %}>Title</th>
+            {% if attendance_days %}
+            <th scope="colgroup" colspan="{{ attendance_days|length }}">Attendance</th>
+            {% endif %}
+            <th scope="col"{% if attendance_days %} rowspan="2"{% endif %}>Prework</th>
+            <th scope="col"{% if attendance_days %} rowspan="2"{% endif %}>Completion Date</th>
+            <th scope="col"{% if attendance_days %} rowspan="2"{% endif %}>Certificate</th>
+            <th scope="col"{% if attendance_days %} rowspan="2"{% endif %}>Actions</th>
+          </tr>
+          {% if attendance_days %}
+          <tr>
+            {% for day in attendance_days %}
+            <th scope="col">Day {{ day }}</th>
+            {% endfor %}
+          </tr>
+          {% endif %}
+        </thead>
+        <tbody>
+          {% for row in participants %}
+          <tr>
+            <td>{{ row.participant.full_name }}{% if row.participant.account and row.participant.account.certificate_name %} ({{ row.participant.account.certificate_name }}){% endif %}</td>
+            <td>{{ row.participant.email }}</td>
+            <td>{{ row.participant.title }}</td>
+            {% if attendance_days %}
+              {% set attendance = row.attendance if row.attendance is defined else {} %}
+              {% for day in attendance_days %}
+              <td class="attendance-cell">
+                {% if can_manage_attendance %}
+                <input type="checkbox"
+                       class="attendance-checkbox"
+                       data-attendance-checkbox
+                       data-participant-id="{{ row.participant.id }}"
+                       data-participant-name="{{ row.participant.full_name or row.participant.email }}"
+                       data-day-index="{{ day }}"
+                       aria-label="Day {{ day }} attendance for {{ row.participant.full_name or row.participant.email }}"
+                       {% if attendance.get(day) %}checked{% endif %}>
+                {% else %}
+                  {{ 'Yes' if attendance.get(day) else '—' }}
+                {% endif %}
+              </td>
+              {% endfor %}
+            {% endif %}
+            <td>
+              {% set status = row.prework_status %}
+              {% set is_waived = status and status.status == 'WAIVED' %}
+              {% if status and status.is_submitted %}
+                Submitted{% if status.completed_at %} ({{ status.completed_at.date() | fmt_dt }}){% endif %}
+              {% else %}
             {% if is_waived %}
               Not submitted (waived)
             {% else %}
@@ -139,43 +182,45 @@
             {% endif %}
           {% endif %}
         </td>
-        <td>
-          <form action="{{ url_for('sessions.generate_single', session_id=session.id, participant_id=row.participant.id) }}" method="post">
-            <input type="hidden" name="next" value="{{ workshop_return }}">
-            <input type="date" name="completion_date" value="{{ row.link.completion_date }}">
-            <button type="submit" class="btn btn-secondary" name="action" value="save">Save</button>
-            {% if session.delivered %}
-            <button type="submit" class="btn btn-secondary" name="action" value="generate">Generate</button>
-            {% endif %}
-          </form>
-        </td>
-        <td>
-          {% if row.pdf_path %}
-            {% if badge_filename %}
-              {% set badge_url = '/badges/' ~ badge_filename %}
-              <a href="{{ badge_url }}" download><img src="{{ badge_url }}" alt="badge" style="height:20px;width:auto;vertical-align:middle;"></a>
-              <a href="{{ badge_url }}" download>Badge</a>
-            {% endif %}
-            <a href="/certificates/{{ row.pdf_path }}">Certificate</a>
-          {% endif %}
-        </td>
-        <td>
-          {% if can_manage_participants %}
-          <a href="{{ url_for('sessions.edit_participant', session_id=session.id, participant_id=row.participant.id, next=workshop_return) }}">Edit</a>
-          <form action="{{ url_for('sessions.remove_participant', session_id=session.id, participant_id=row.participant.id) }}" method="post" style="display:inline">
-            <input type="hidden" name="next" value="{{ workshop_return }}">
-            <button type="submit" class="btn btn-danger  btn-sm">Remove</button>
-          </form>
-          {% endif %}
-        </td>
-      </tr>
-      {% else %}
-      <tr>
-        <td colspan="7">No participants added yet.</td>
-      </tr>
-      {% endfor %}
-    </tbody>
-  </table>
+            <td>
+              <form action="{{ url_for('sessions.generate_single', session_id=session.id, participant_id=row.participant.id) }}" method="post">
+                <input type="hidden" name="next" value="{{ workshop_return }}">
+                <input type="date" name="completion_date" value="{{ row.link.completion_date }}">
+                <button type="submit" class="btn btn-secondary" name="action" value="save">Save</button>
+                {% if session.delivered %}
+                <button type="submit" class="btn btn-secondary" name="action" value="generate">Generate</button>
+                {% endif %}
+              </form>
+            </td>
+            <td>
+              {% if row.pdf_path %}
+                {% if badge_filename %}
+                  {% set badge_url = '/badges/' ~ badge_filename %}
+                  <a href="{{ badge_url }}" download><img src="{{ badge_url }}" alt="badge" style="height:20px;width:auto;vertical-align:middle;"></a>
+                  <a href="{{ badge_url }}" download>Badge</a>
+                {% endif %}
+                <a href="/certificates/{{ row.pdf_path }}">Certificate</a>
+              {% endif %}
+            </td>
+            <td>
+              {% if can_manage_participants %}
+              <a href="{{ url_for('sessions.edit_participant', session_id=session.id, participant_id=row.participant.id, next=workshop_return) }}">Edit</a>
+              <form action="{{ url_for('sessions.remove_participant', session_id=session.id, participant_id=row.participant.id) }}" method="post" style="display:inline">
+                <input type="hidden" name="next" value="{{ workshop_return }}">
+                <button type="submit" class="btn btn-danger  btn-sm">Remove</button>
+              </form>
+              {% endif %}
+            </td>
+          </tr>
+          {% else %}
+          <tr>
+            <td colspan="{{ 7 + (attendance_days|length if attendance_days else 0) }}">No participants added yet.</td>
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  </div>
   {% if session.delivered %}
   <form action="{{ url_for('sessions.generate_bulk', session_id=session.id) }}" method="post">
     <input type="hidden" name="next" value="{{ workshop_return }}">
@@ -253,4 +298,9 @@
 
 {% include "sessions/_prework_summary.html" %}
 {% endif %}
+{% endblock %}
+
+{% block extra_js %}
+  {{ super() }}
+  <script src="{{ url_for('static', filename='js/attendance_controls.js') }}"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- preload session attendance data and expose day lists to the workshop and session views for efficient rendering
- extend the participant tables with Day 1..N attendance columns, a bulk "Mark all attended" action, and role-aware controls
- add front-end handling for attendance toggles, update table styling, and document the new UI behavior in CONTEXT.md

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d1611a5dcc832e94d7668666f1e11c