### PR TITLE
Enable configurable certificate fonts and layout

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -443,7 +443,9 @@ Two separate tables by design; emails unique per table. If both tables hold the 
 - Issued post-delivery. Templates are configured under **Settings → Certificate Templates**, where admins define series and map (language, A4/Letter) → PDF and optional badge **filename**. Workshop Types must select one active series and no longer store any badge value. Generation resolves the mapping for the session's type series and language/size; badges reference files under `app/assets/badges`. If any mapping or file is missing, rendering aborts with a clear error (no auto-fallback).
 - The template-mapping page offers bulk upload buttons for certificate template PDFs and badge WEBP files. Uploads overwrite by filename, refresh dropdown options, and never auto-change existing mappings. Badge uploads also copy files to the site root (`/srv/badges`) for static serving. Access is restricted to Sys Admin/Admin.
 - Paper size derives from session Region (North America → Letter; others → A4).
-- Name line: Y=145 mm; italic; auto-shrink 48→32; centered. On **Letter**, the recipient Name text box is narrowed by **2.5 cm** on the left and **2.5 cm** on the right (total horizontal reduction = 5.0 cm).
+- **Settings → Languages** tracks an Allowed fonts list. Certificate rendering restricts line fonts to the language’s allowed set; if the configured font is missing or disallowed the renderer falls back to the first allowed+available option (or Helvetica) and logs `[CERT-FONT]` once per substituted line.
+- Each certificate series stores per-size layout metadata covering Learner name, Workshop name, and Completion date (font + Y mm). Defaults preserve prior behavior — learner name at 145 mm (auto-shrink 48→32), workshop at 102 mm, date at 83 mm using the session end date — and Letter layouts continue narrowing the learner name text box by **2.5 cm** on both sides (total 5.0 cm).
+- An optional details panel can be enabled per size with Left/Right placement. Selected variables (contact hours, facilitators, dates, location title, class days) render as a multi-line block inside the bottom margin, skipping empty values without aborting generation.
 - Certificates are written to `<certs_root>/<YYYY>/<session_id>/` where `<certs_root>` = `SITE_ROOT/certificates` (default `/srv/certificates`). `YYYY` uses the session start-date year; if missing, use the current year.
 - Filenames: `<workshop_type.code>_<certificate_name_slug>_<YYYY-MM-DD>.pdf`.
 - `pdf_path` stores the relative path `YYYY/session_id/filename.pdf`. Generation overwrites existing files atomically.
@@ -456,7 +458,6 @@ Two separate tables by design; emails unique per table. If both tables hold the 
 - `--dry-run` lists candidate paths and a summary without deleting.
 - In production, set `ALLOW_CERT_PURGE=1` to enable deletions.
 - One-off CLI `backfill_cert_paths` (run: `python manage.py backfill_cert_paths`) updates legacy `YYYY/<workshop_code>/…` rows when a `YYYY/session_id/…` file exists. Safe to skip if not needed.
-- Workshop line at 102 mm; date line at 83 mm in `d Month YYYY` using session end date.
 - Learner nav shows **My Certificates** only if they own ≥1 certificate; staff see **My Profile → My Certificates** only when they have certificates as participants.
 
 ---

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -7,6 +7,7 @@ from sqlalchemy.orm import validates
 from ..app import db
 from ..shared.passwords import hash_password, check_password
 from ..shared.constants import ROLE_ATTRS
+from ..shared.certificates_layout import DEFAULT_LANGUAGE_FONT_CODES
 
 from .simulation import SimulationOutline  # noqa: E402,F401
 
@@ -155,6 +156,11 @@ class Language(db.Model):
     name = db.Column(db.String(120), unique=True, nullable=False)
     is_active = db.Column(db.Boolean, nullable=False, default=True)
     sort_order = db.Column(db.SmallInteger, nullable=False, default=100)
+    allowed_fonts = db.Column(
+        db.JSON,
+        nullable=False,
+        default=lambda: DEFAULT_LANGUAGE_FONT_CODES.copy(),
+    )
     created_at = db.Column(db.DateTime, server_default=db.func.now(), nullable=False)
 
 
@@ -536,6 +542,7 @@ class CertificateTemplateSeries(db.Model):
     code = db.Column(db.String(16), unique=True, nullable=False)
     name = db.Column(db.String(255), nullable=False)
     is_active = db.Column(db.Boolean, nullable=False, default=True)
+    layout_config = db.Column(db.JSON, nullable=False, default=dict)
 
 
 class CertificateTemplate(db.Model):

--- a/app/shared/certificates.py
+++ b/app/shared/certificates.py
@@ -2,13 +2,14 @@ from __future__ import annotations
 
 import os
 import re
-from datetime import date
+from datetime import date, datetime
 from io import BytesIO
-from typing import Iterable
+from typing import Iterable, Sequence
 
 from flask import current_app
 from PyPDF2 import PdfReader, PdfWriter
 from reportlab.pdfgen import canvas
+from reportlab.pdfbase import pdfmetrics
 from reportlab.pdfbase.pdfmetrics import stringWidth
 
 from ..app import db
@@ -16,15 +17,26 @@ from ..models import (
     Certificate,
     CertificateTemplate,
     CertificateTemplateSeries,
+    Language,
     Participant,
     ParticipantAccount,
     Session,
     SessionParticipant,
 )
+from ..shared.certificates_layout import (
+    DEFAULT_LANGUAGE_FONT_CODES,
+    DETAIL_LABELS,
+    SAFE_FALLBACK_FONT,
+    sanitize_series_layout,
+)
+from ..shared.languages import LANG_CODE_NAMES
 from .storage import ensure_dir, write_atomic
 
 
 LETTER_NAME_INSET_MM = 25
+DEFAULT_BOTTOM_MARGIN_MM = 20
+DETAILS_FONT_SIZE_PT = 12
+DETAILS_LINE_SPACING_PT = 14
 
 
 def slug_certificate_name(name: str) -> str:
@@ -122,6 +134,39 @@ def render_certificate(
     mm = lambda v: v * 72.0 / 25.4
     center_x = w / 2.0
 
+    series_layout = sanitize_series_layout(mapping.series.layout_config)
+    size_layout = series_layout.get(effective_size, series_layout["A4"])
+    allowed_fonts = _language_allowed_fonts(session.workshop_language)
+    available_fonts = _available_font_codes()
+
+    name_font = _resolve_font(
+        size_layout["name"]["font"],
+        allowed_fonts,
+        available_fonts,
+        session,
+        effective_size,
+        "name",
+    )
+    workshop_font = _resolve_font(
+        size_layout["workshop"]["font"],
+        allowed_fonts,
+        available_fonts,
+        session,
+        effective_size,
+        "workshop",
+    )
+    date_font = _resolve_font(
+        size_layout["date"]["font"],
+        allowed_fonts,
+        available_fonts,
+        session,
+        effective_size,
+        "date",
+    )
+    name_y = mm(size_layout["name"]["y_mm"])
+    workshop_y = mm(size_layout["workshop"]["y_mm"])
+    date_y = mm(size_layout["date"]["y_mm"])
+
     def fit_text(
         text: str, font_name: str, max_pt: int, min_pt: int, max_width: float
     ) -> int:
@@ -136,19 +181,45 @@ def render_certificate(
     name_width = base_name_width
     if effective_size == "LETTER":
         name_width -= mm(2 * LETTER_NAME_INSET_MM)
-    name_pt = fit_text(display_name, "Times-Italic", 48, 32, name_width)
-    c.setFont("Times-Italic", name_pt)
+    name_pt = fit_text(display_name, name_font, 48, 32, name_width)
+    c.setFont(name_font, name_pt)
     c.setFillGray(0.25)
-    c.drawCentredString(center_x, mm(145), display_name)
+    c.drawCentredString(center_x, name_y, display_name)
 
-    workshop_pt = fit_text(workshop, "Helvetica", 40, 28, w - mm(40))
-    c.setFont("Helvetica", workshop_pt)
+    workshop_pt = fit_text(workshop, workshop_font, 40, 28, w - mm(40))
+    c.setFont(workshop_font, workshop_pt)
     c.setFillGray(0.3)
-    c.drawCentredString(center_x, mm(102), workshop)
+    c.drawCentredString(center_x, workshop_y, workshop)
 
-    c.setFont("Helvetica", 20)
+    c.setFont(date_font, 20)
     c.setFillGray(0.3)
-    c.drawCentredString(center_x, mm(83), completion.strftime("%d %B %Y").lstrip("0"))
+    c.drawCentredString(
+        center_x,
+        date_y,
+        completion.strftime("%d %B %Y").lstrip("0"),
+    )
+
+    details_cfg = size_layout.get("details", {})
+    if details_cfg.get("enabled"):
+        detail_lines = _build_details_lines(session, details_cfg.get("variables", []))
+        if detail_lines:
+            detail_font = _resolve_font(
+                date_font,
+                allowed_fonts,
+                available_fonts,
+                session,
+                effective_size,
+                "details",
+            )
+            margin_x = mm(DEFAULT_BOTTOM_MARGIN_MM)
+            c.setFont(detail_font, DETAILS_FONT_SIZE_PT)
+            c.setFillGray(0.3)
+            for index, line in enumerate(detail_lines):
+                y_pos = mm(DEFAULT_BOTTOM_MARGIN_MM) + index * DETAILS_LINE_SPACING_PT
+                if details_cfg.get("side", "LEFT") == "RIGHT":
+                    c.drawRightString(w - margin_x, y_pos, line)
+                else:
+                    c.drawString(margin_x, y_pos, line)
 
     c.save()
     buffer.seek(0)
@@ -240,3 +311,161 @@ def remove_session_certificates(session_id: int, end_date: date) -> int:
                 except FileNotFoundError:
                     pass
     return removed
+
+
+def _available_font_codes() -> set[str]:
+    fonts = set(pdfmetrics.getRegisteredFontNames())
+    try:
+        fonts.update(pdfmetrics.standardFonts)
+    except AttributeError:
+        fonts.update({"Helvetica", "Times-Roman", "Courier"})
+    return fonts
+
+
+def _language_allowed_fonts(lang_code: str | None) -> list[str]:
+    if not lang_code:
+        return DEFAULT_LANGUAGE_FONT_CODES.copy()
+    lang_name = LANG_CODE_NAMES.get(lang_code, lang_code)
+    lang = (
+        db.session.query(Language)
+        .filter(db.func.lower(Language.name) == lang_name.lower())
+        .one_or_none()
+    )
+    fonts: Sequence[str] | None = getattr(lang, "allowed_fonts", None)
+    filtered = [f for f in (fonts or []) if isinstance(f, str)]
+    if filtered:
+        return filtered
+    return DEFAULT_LANGUAGE_FONT_CODES.copy()
+
+
+def _resolve_font(
+    preferred: str,
+    allowed_fonts: Sequence[str],
+    available_fonts: set[str],
+    session: Session,
+    size: str,
+    line: str,
+) -> str:
+    sanitized_allowed = [f for f in allowed_fonts if f in available_fonts]
+    if preferred in sanitized_allowed:
+        return preferred
+    reason: str | None = None
+    if preferred and preferred not in allowed_fonts:
+        reason = "not allowed"
+    elif preferred and preferred not in available_fonts:
+        reason = "not available"
+    if sanitized_allowed:
+        candidate = sanitized_allowed[0]
+    else:
+        fallback_candidates = [f for f in (SAFE_FALLBACK_FONT,) if f in available_fonts]
+        if not fallback_candidates:
+            fallback_candidates = sorted(available_fonts) or [SAFE_FALLBACK_FONT]
+        candidate = fallback_candidates[0]
+        if not reason:
+            reason = "no allowed fonts"
+    current_app.logger.warning(
+        "[CERT-FONT] session=%s lang=%s size=%s line=%s %s→%s (%s)",
+        session.id,
+        session.workshop_language,
+        size,
+        line,
+        preferred or "<default>",
+        candidate,
+        reason or "fallback",
+    )
+    return candidate
+
+
+def _build_details_lines(session: Session, variables: Sequence[str]) -> list[str]:
+    lines: list[str] = []
+    for key in variables:
+        label = DETAIL_LABELS.get(key)
+        if not label:
+            continue
+        value = _detail_value(session, key)
+        if value:
+            lines.append(f"{label}: {value}")
+    return lines
+
+
+def _detail_value(session: Session, key: str) -> str | None:
+    if key == "contact_hours":
+        return _format_contact_hours(session)
+    if key == "facilitators":
+        return _format_facilitators(session)
+    if key == "dates":
+        return _format_session_dates(session)
+    if key == "location_title":
+        if session.workshop_location and session.workshop_location.label:
+            return session.workshop_location.label
+        if session.location:
+            return session.location
+        return None
+    if key == "class_days":
+        days = session.number_of_class_days or 0
+        return str(days) if days else None
+    return None
+
+
+def _format_contact_hours(session: Session) -> str | None:
+    start = session.daily_start_time
+    end = session.daily_end_time
+    if not start or not end:
+        return None
+    start_dt = datetime.combine(date.today(), start)
+    end_dt = datetime.combine(date.today(), end)
+    if end_dt <= start_dt:
+        return None
+    hours = (end_dt - start_dt).total_seconds() / 3600
+    days = session.number_of_class_days or 1
+    total = hours * days
+    if total <= 0:
+        return None
+    if abs(total - round(total)) < 0.01:
+        return str(int(round(total)))
+    return f"{total:.1f}".rstrip("0").rstrip(".")
+
+
+def _format_facilitators(session: Session) -> str | None:
+    names: list[str] = []
+    if session.lead_facilitator:
+        lead_name = (
+            session.lead_facilitator.full_name
+            or session.lead_facilitator.email
+            or ""
+        )
+        if lead_name:
+            names.append(lead_name)
+    seen_ids = {getattr(session.lead_facilitator, "id", None)}
+    for facilitator in session.facilitators:
+        if facilitator.id in seen_ids:
+            continue
+        seen_ids.add(facilitator.id)
+        display = facilitator.full_name or facilitator.email or ""
+        if display:
+            names.append(display)
+    return ", ".join(names) if names else None
+
+
+def _format_session_dates(session: Session) -> str | None:
+    start = session.start_date
+    end = session.end_date or start
+    if not start and not end:
+        return None
+    if not start:
+        start = end
+    if not end:
+        end = start
+    start_day = start.strftime("%d").lstrip("0") or start.strftime("%d")
+    end_day = end.strftime("%d").lstrip("0") or end.strftime("%d")
+    start_month = start.strftime("%B")
+    end_month = end.strftime("%B")
+    start_year = start.strftime("%Y")
+    end_year = end.strftime("%Y")
+    if start == end:
+        return f"{start_day} {start_month} {start_year}"
+    if start_year == end_year:
+        if start.month == end.month:
+            return f"{start_day}–{end_day} {start_month} {start_year}"
+        return f"{start_day} {start_month} – {end_day} {end_month} {start_year}"
+    return f"{start_day} {start_month} {start_year} – {end_day} {end_month} {end_year}"

--- a/app/shared/certificates_layout.py
+++ b/app/shared/certificates_layout.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Iterable
+
+PDF_FONT_CHOICES: list[tuple[str, str]] = [
+    ("Helvetica", "Helvetica"),
+    ("Helvetica-Bold", "Helvetica Bold"),
+    ("Helvetica-Oblique", "Helvetica Oblique"),
+    ("Helvetica-BoldOblique", "Helvetica Bold Oblique"),
+    ("Times-Roman", "Times Roman"),
+    ("Times-Bold", "Times Bold"),
+    ("Times-Italic", "Times Italic"),
+    ("Times-BoldItalic", "Times Bold Italic"),
+    ("Courier", "Courier"),
+    ("Courier-Bold", "Courier Bold"),
+    ("Courier-Oblique", "Courier Oblique"),
+    ("Courier-BoldOblique", "Courier Bold Oblique"),
+]
+
+PDF_FONT_CODES: set[str] = {code for code, _ in PDF_FONT_CHOICES}
+
+DEFAULT_LANGUAGE_FONT_CODES: list[str] = [
+    "Times-Italic",
+    "Times-Roman",
+    "Times-Bold",
+    "Helvetica",
+    "Helvetica-Bold",
+    "Helvetica-Oblique",
+]
+
+SAFE_FALLBACK_FONT = "Helvetica"
+
+DETAIL_VARIABLES: list[str] = [
+    "contact_hours",
+    "facilitators",
+    "dates",
+    "location_title",
+    "class_days",
+]
+
+DETAIL_LABELS: dict[str, str] = {
+    "contact_hours": "Contact hours",
+    "facilitators": "Facilitators",
+    "dates": "Dates",
+    "location_title": "Location",
+    "class_days": "Class days",
+}
+
+DETAIL_SIDES = ("LEFT", "RIGHT")
+
+PAGE_HEIGHT_MM = {
+    "A4": 297.0,
+    "LETTER": 279.4,
+}
+
+_DEFAULT_DETAILS = {"enabled": False, "side": "LEFT", "variables": []}
+
+_DEFAULT_LAYOUT_BY_SIZE = {
+    "A4": {
+        "name": {"font": "Times-Italic", "y_mm": 145.0},
+        "workshop": {"font": "Helvetica", "y_mm": 102.0},
+        "date": {"font": "Helvetica", "y_mm": 83.0},
+        "details": deepcopy(_DEFAULT_DETAILS),
+    },
+    "LETTER": {
+        "name": {"font": "Times-Italic", "y_mm": 145.0},
+        "workshop": {"font": "Helvetica", "y_mm": 102.0},
+        "date": {"font": "Helvetica", "y_mm": 83.0},
+        "details": deepcopy(_DEFAULT_DETAILS),
+    },
+}
+
+
+def get_font_options() -> list[tuple[str, str]]:
+    return PDF_FONT_CHOICES
+
+
+def filter_font_codes(values: Iterable[str]) -> list[str]:
+    seen: set[str] = set()
+    filtered: list[str] = []
+    for value in values:
+        if value in PDF_FONT_CODES and value not in seen:
+            filtered.append(value)
+            seen.add(value)
+    return filtered
+
+
+def get_default_size_layout(size: str) -> dict:
+    base = _DEFAULT_LAYOUT_BY_SIZE.get(size.upper(), _DEFAULT_LAYOUT_BY_SIZE["A4"])
+    return deepcopy(base)
+
+
+def ensure_details_config(details: dict | None) -> dict:
+    config = deepcopy(_DEFAULT_DETAILS)
+    if isinstance(details, dict):
+        if details.get("enabled"):
+            config["enabled"] = True
+        side = str(details.get("side", "LEFT")).upper()
+        if side in DETAIL_SIDES:
+            config["side"] = side
+        variables = details.get("variables") or []
+        config["variables"] = filter_detail_variables(variables)
+    return config
+
+
+def filter_detail_variables(values: Iterable[str]) -> list[str]:
+    filtered: list[str] = []
+    for value in values:
+        if value in DETAIL_VARIABLES and value not in filtered:
+            filtered.append(value)
+    return filtered
+
+
+def sanitize_size_layout(size: str, layout: dict | None) -> dict:
+    base = get_default_size_layout(size)
+    if not isinstance(layout, dict):
+        return base
+    for key in ("name", "workshop", "date"):
+        line = layout.get(key)
+        if isinstance(line, dict):
+            font = line.get("font")
+            if isinstance(font, str) and font in PDF_FONT_CODES:
+                base[key]["font"] = font
+            y_val = line.get("y_mm")
+            try:
+                y_float = float(y_val)
+            except (TypeError, ValueError):
+                y_float = None
+            if y_float is not None:
+                base[key]["y_mm"] = y_float
+    base["details"] = ensure_details_config(layout.get("details"))
+    return base
+
+
+def sanitize_series_layout(layout: dict | None) -> dict:
+    if not isinstance(layout, dict):
+        layout = {}
+    return {
+        size: sanitize_size_layout(size, layout.get(size))
+        for size in ("A4", "LETTER")
+    }

--- a/app/templates/settings_cert_templates/templates.html
+++ b/app/templates/settings_cert_templates/templates.html
@@ -43,6 +43,55 @@
     </tr>
     {% endfor %}
   </table>
+  <h2>Layout</h2>
+  {% for size in ['A4','LETTER'] %}
+    {% set size_layout = layout[size] %}
+    {% set details = size_layout['details'] %}
+    <fieldset style="margin-bottom:1.5em;">
+      <legend>{{ size }} layout</legend>
+      <div style="display:grid; grid-template-columns:repeat(auto-fit,minmax(220px,1fr)); gap:12px;">
+        {% for key, label in {'name':'Learner name','workshop':'Workshop name','date':'Completion date'}.items() %}
+          <div>
+            <label for="layout-{{ size }}-{{ key }}-font">{{ label }} font</label><br>
+            <select id="layout-{{ size }}-{{ key }}-font" name="layout_{{ size }}_{{ key }}_font">
+              {% for font_code, font_label in font_options %}
+                <option value="{{ font_code }}" {% if size_layout[key]['font'] == font_code %}selected{% endif %}>{{ font_label }}</option>
+              {% endfor %}
+            </select>
+          </div>
+          <div>
+            <label for="layout-{{ size }}-{{ key }}-y">{{ label }} Y (mm)</label><br>
+            <input id="layout-{{ size }}-{{ key }}-y" type="number" step="0.1" name="layout_{{ size }}_{{ key }}_y" value="{{ '%.1f'|format(size_layout[key]['y_mm']) }}">
+          </div>
+        {% endfor %}
+      </div>
+      <div style="margin-top:1em;">
+        <label>
+          <input type="checkbox" name="layout_{{ size }}_details_enabled" value="1" {% if details.enabled %}checked{% endif %}>
+          Enable details panel
+        </label>
+      </div>
+      <div style="margin-top:0.5em; display:flex; gap:12px; flex-wrap:wrap;">
+        <div>
+          <label for="layout-{{ size }}-details-side">Panel side</label><br>
+          <select id="layout-{{ size }}-details-side" name="layout_{{ size }}_details_side">
+            {% for side in detail_sides %}
+              <option value="{{ side }}" {% if details.side == side %}selected{% endif %}>{{ side.title() }}</option>
+            {% endfor %}
+          </select>
+        </div>
+        <div>
+          <label for="layout-{{ size }}-details-variables">Panel variables</label><br>
+          <select id="layout-{{ size }}-details-variables" name="layout_{{ size }}_details_variables" multiple size="{{ detail_variables|length }}" style="min-width:200px;">
+            {% for var in detail_variables %}
+              <option value="{{ var }}" {% if var in details.variables %}selected{% endif %}>{{ var.replace('_',' ')|title }}</option>
+            {% endfor %}
+          </select>
+          <p class="form-help">Selected order is the display order.</p>
+        </div>
+      </div>
+    </fieldset>
+  {% endfor %}
   <p><button type="submit">Save</button></p>
 </form>
 {% endblock %}

--- a/app/templates/settings_languages/form.html
+++ b/app/templates/settings_languages/form.html
@@ -9,6 +9,15 @@
   <div>Sort order:
     <input type="number" name="sort_order" value="{{ lang.sort_order if lang else 100 }}">
   </div>
+  <div>Allowed fonts:
+    <select name="allowed_fonts" multiple size="8" style="min-width: 220px;">
+      {% set selections = selected_fonts or [] %}
+      {% for code, label in font_options %}
+        <option value="{{ code }}" {% if code in selections %}selected{% endif %}>{{ label }}</option>
+      {% endfor %}
+    </select>
+    <p class="form-help">Hold Ctrl (Windows) or Command (Mac) to select multiple fonts.</p>
+  </div>
   {% if lang %}
   <div>Status:
     <input type="checkbox" name="is_active" value="1" {% if lang.is_active %}checked{% endif %}>

--- a/app/templates/settings_languages/list.html
+++ b/app/templates/settings_languages/list.html
@@ -6,10 +6,19 @@
 <p><a href="{{ url_for('settings_languages.new_lang') }}">New language</a></p>
 {% if langs %}
 <table class="kt-table">
-  <tr><th>Name</th><th class="cell-nowrap">Sort Order</th><th class="cell-nowrap">Status</th><th class="col-actions"></th></tr>
+  <tr><th>Name</th><th>Allowed fonts</th><th class="cell-nowrap">Sort Order</th><th class="cell-nowrap">Status</th><th class="col-actions"></th></tr>
   {% for lang in langs %}
   <tr>
     <td>{{ lang.name }}</td>
+    <td>
+      {% set codes = lang.allowed_fonts or [] %}
+      {% set ns = namespace(labels=[]) %}
+      {% for code in codes %}
+        {% set label = font_labels.get(code, code) %}
+        {% set ns.labels = ns.labels + [label] %}
+      {% endfor %}
+      {{ ns.labels|join(', ') if ns.labels else '—' }}
+    </td>
     <td class="cell-nowrap">{{ lang.sort_order }}</td>
     <td class="cell-nowrap">{{ 'Active' if lang.is_active else 'Inactive' }}</td>
     <td class="col-actions">

--- a/migrations/versions/0069_certificate_layout_fonts.py
+++ b/migrations/versions/0069_certificate_layout_fonts.py
@@ -1,0 +1,65 @@
+"""add language allowed fonts and series layout config
+
+Revision ID: 0069_certificate_layout_fonts
+Revises: 0068_participant_attendance
+Create Date: 2025-09-21 00:00:00.000000
+"""
+
+import json
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "0069_certificate_layout_fonts"
+down_revision = "0068_participant_attendance"
+branch_labels = None
+depends_on = None
+
+_DEFAULT_ALLOWED_FONTS = [
+    "Times-Italic",
+    "Times-Roman",
+    "Times-Bold",
+    "Helvetica",
+    "Helvetica-Bold",
+    "Helvetica-Oblique",
+]
+
+
+def upgrade() -> None:
+    op.add_column(
+        "languages",
+        sa.Column(
+            "allowed_fonts",
+            sa.JSON(),
+            nullable=False,
+            server_default="[]",
+        ),
+    )
+    op.add_column(
+        "certificate_template_series",
+        sa.Column(
+            "layout_config",
+            sa.JSON(),
+            nullable=False,
+            server_default="{}",
+        ),
+    )
+
+    bind = op.get_bind()
+    bind.execute(
+        sa.text("UPDATE languages SET allowed_fonts = :fonts"),
+        {"fonts": json.dumps(_DEFAULT_ALLOWED_FONTS)},
+    )
+
+    op.alter_column("languages", "allowed_fonts", server_default=None)
+    op.alter_column(
+        "certificate_template_series",
+        "layout_config",
+        server_default=None,
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("certificate_template_series", "layout_config")
+    op.drop_column("languages", "allowed_fonts")


### PR DESCRIPTION
## Summary
- add migration and helpers to store allowed fonts per language and per-size layout metadata on certificate series
- extend language and certificate template settings UIs to manage font restrictions, line positions, and optional details panels
- update certificate rendering to honor layout overrides, fall back to safe fonts when necessary, and document the changes in CONTEXT.md

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d189af2b9c832e98238a24bc30bb13