### PR TITLE
Add edit action to My Sessions and confirm Delivered updates

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -198,6 +198,7 @@ Roles control permissions; Views control menu visibility.
   - Logout
 
 Delivery (KT Facilitator) and Contractor accounts open the workshop runner view when selecting sessions from **My Sessions**. Other staff and CSA roles continue to the staff session detail page.
+- **My Sessions**: Admin, CRM, and Delivery roles see an **Edit** action per row; Contractors, CSA, and Learner accounts do not.
 
 ## 1.3 View Selector
 Only SysAdmin, Administrator, CRM, and KT Facilitator roles see the View selector. CSA, Participant, and Contractor do not.
@@ -398,7 +399,8 @@ Two separate tables by design; emails unique per table. If both tables hold the 
  - The Workshop Type edit page and **New Workshop Type** view include a **Default Materials** table mapping Delivery Type × Region × Language to catalog items with a default format and active flag.
  - Default Materials rows use a dropdown Materials selector; selecting a Material Item limits the row's Language and Default Format lists to that item's allowed values. The selector has no "Show all" toggle. Quantity basis comes from Materials Settings and is not editable on Workshop Types.
 - **Materials-only orders** share the session form. `/sessions/new` shows an **Order Information** section (Title, Client with CRM, Region, Language) with a **No workshop, material order only** button that creates a hidden session (`materials_only = true`, `delivery_type = "Material only"`) and redirects to that session's Materials Order page. Certificates and badges are unaffected and remain gated.
-- **Material only invariant**: when `delivery_type = "Material only"`, setting **Ready for delivery** or **Finalized** forces `status = "Closed"`, and `delivered` remains `False`. Workshop view (`/workshops/<id>`) redirects to the staff session detail.
+- **Material only invariant**: when `delivery_type = "Material only"`, setting **Ready for delivery** or **Finalized** forces `status = "Closed"`, and `delivered` remains `False`. Workshop view (`/workshops/<id>`) redirects to the staff session detail. The **Delivered** action is hidden for material-only sessions.
+- Staff **Delivered** action displays “Are you sure? This can’t be undone” and, on confirm, marks both **Ready for delivery** and **Delivered** in a single step.
 - Clicking **No workshop, material order only** removes `required` constraints from later form fields so only Order Information entries are enforced before submission.
 - When `materials_only = true`, training-session features (participants, prework, certificates) are hidden/denied.
  - Default Materials-only **Order Type** = “Client-run Bulk order”.

--- a/app/routes/my_sessions.py
+++ b/app/routes/my_sessions.py
@@ -65,12 +65,18 @@ def list_my_sessions():
             or any(f.id == user.id for f in getattr(s, "facilitators", []))
         }
         use_workshop_view = is_delivery_role or is_contractor_role
+        show_edit_button = bool(
+            is_admin(user)
+            or is_kcrm(user)
+            or (is_delivery_role and not is_contractor_role)
+        )
         return render_template(
             "my_sessions.html",
             sessions=sessions,
             show_all=show_all,
             assigned_session_ids=assigned_session_ids,
             workshop_link_for_facilitator=use_workshop_view,
+            show_edit_button=show_edit_button,
         )
     elif account_id:
         account = db.session.get(ParticipantAccount, account_id)
@@ -104,6 +110,7 @@ def list_my_sessions():
             assignments=assignments,
             certs=certs,
             today=date.today(),
+            show_edit_button=False,
         )
     else:
         return redirect(url_for("auth.login"))

--- a/app/templates/my_sessions.html
+++ b/app/templates/my_sessions.html
@@ -6,6 +6,7 @@
   {% if current_user %}
     {% set can_use_workshop_view = workshop_link_for_facilitator if workshop_link_for_facilitator is defined else False %}
     {% set facilitator_session_ids = assigned_session_ids if assigned_session_ids is defined else [] %}
+    {% set can_edit_sessions = show_edit_button if show_edit_button is defined else False %}
     {% if current_user.id %}
       {% set storage_key = 'cbs.mysessions.columns.' ~ current_user.id %}
       {% set width_key = 'cbs.mysessions.colwidths.' ~ current_user.id %}
@@ -72,6 +73,9 @@
                   <a href="{{ url_for('workshops.workshop_view', session_id=s.id) }}">Open</a>
                 {% else %}
                   <a href="{{ url_for('sessions.session_detail', session_id=s.id) }}">Open</a>
+                {% endif %}
+                {% if can_edit_sessions %}
+                  <a href="{{ url_for('sessions.edit_session', session_id=s.id) }}">Edit</a>
                 {% endif %}
               </td>
             </tr>

--- a/app/templates/session_detail.html
+++ b/app/templates/session_detail.html
@@ -10,7 +10,7 @@
 <div class="session-status-actions" style="margin: var(--space-2) 0; display: flex; flex-wrap: wrap; align-items: center; gap: var(--space-2);">
   <span><strong>Status:</strong> {{ session.computed_status }}</span>
   {% if can_edit_session and not material_only_session and not session.delivered and not session.cancelled %}
-  <form action="{{ url_for('sessions.mark_delivered', session_id=session.id) }}" method="post" style="display:inline">
+  <form action="{{ url_for('sessions.mark_delivered', session_id=session.id) }}" method="post" style="display:inline" onsubmit="return confirm('Are you sure? This can’t be undone');">
     <button type="submit" class="btn btn-success">Delivered</button>
   </form>
   {% endif %}


### PR DESCRIPTION
## Summary
- show an Edit action in My Sessions for Admin, CRM, and Delivery roles while hiding it from contractors and learners
- require a confirmation prompt when marking a session delivered and ensure the action also flags the session ready for delivery
- document the updated behaviors in CONTEXT.md

## Testing
- PYTHONPATH=. pytest tests/test_materials_only.py
- PYTHONPATH=. pytest tests/test_sessions_status.py

------
https://chatgpt.com/codex/tasks/task_e_68d194549560832eacda1f3734db40c2