### PR TITLE
Tighten calendar icon spacing on participant date inputs

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -104,6 +104,7 @@ Every functional change must update this file **in the same PR**.
 - Styles live in `/static/css/forms.css` and load globally.
 - Single-line controls include default 10px horizontal and 8px vertical margins to keep adjacent fields separated; inline actions like "Add" or "Edit" links sit 8px away.
 - `.filters` and `.filter-row` provide optional flex wrapping with these gaps via `column-gap`/`row-gap`.
+- `.kt-date--tight` trims extra padding around the inline calendar icon while keeping the default control height; applied to Completion Date fields in participant tables.
 
 ## 0.9 Navigation & Breadcrumbs
 - Header and main navigation use `/static/css/nav.css` with `--kt-bg` background, `--kt-text`/`--kt-info` links, and Raleway headings.

--- a/app/static/css/forms.css
+++ b/app/static/css/forms.css
@@ -83,6 +83,25 @@ input[type="datetime-local"] {
   padding-right: calc(var(--field-px, 12px) * 2 + 1.5em);
 }
 
+.kt-date--tight {
+  padding-right: 22px;
+}
+
+input.kt-date--tight {
+  padding-right: 22px;
+}
+
+.kt-date--tight[type="date"]::-webkit-calendar-picker-indicator,
+.kt-date--tight[type="datetime-local"]::-webkit-calendar-picker-indicator {
+  margin: 0 2px 0 0;
+  padding: 0;
+}
+
+.kt-date--tight[type="date"]::-webkit-datetime-edit,
+.kt-date--tight[type="datetime-local"]::-webkit-datetime-edit {
+  padding: 0 8px;
+}
+
 textarea {
   min-height: calc(var(--field-h, 40px) * 2);
   line-height: 1.4;

--- a/app/templates/session_detail.html
+++ b/app/templates/session_detail.html
@@ -245,7 +245,7 @@
             {% endif %}
             <td>
               <form action="{{ url_for('sessions.generate_single', session_id=session.id, participant_id=row.participant.id) }}" method="post">
-                <input type="date" name="completion_date" value="{{ row.link.completion_date }}">
+                <input type="date" class="kt-date--tight" name="completion_date" value="{{ row.link.completion_date }}">
                 <button type="submit" name="action" value="save">Save</button>
                 {% if session.delivered %}
                 <button type="submit" name="action" value="generate">Generate</button>

--- a/app/templates/sessions/workshop_view.html
+++ b/app/templates/sessions/workshop_view.html
@@ -186,7 +186,7 @@
             <td>
               <form action="{{ url_for('sessions.generate_single', session_id=session.id, participant_id=row.participant.id) }}" method="post">
                 <input type="hidden" name="next" value="{{ workshop_return }}">
-                <input type="date" name="completion_date" value="{{ row.link.completion_date }}">
+                <input type="date" class="kt-date--tight" name="completion_date" value="{{ row.link.completion_date }}">
                 <button type="submit" class="btn btn-secondary" name="action" value="save">Save</button>
                 {% if session.delivered %}
                 <button type="submit" class="btn btn-secondary" name="action" value="generate">Generate</button>


### PR DESCRIPTION
## Summary
- add a `.kt-date--tight` utility to narrow the inline calendar icon spacing without changing input height
- apply the tighter spacing class to the participant Completion Date inputs in workshop and session views
- document the new utility class in CONTEXT.md

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d19ca47ac4832e81115bfad78eaeb6