### PR TITLE
Tighten kt-date opt-in spacing

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -104,7 +104,7 @@ Every functional change must update this file **in the same PR**.
 - Styles live in `/static/css/forms.css` and load globally.
 - Single-line controls include default 10px horizontal and 8px vertical margins to keep adjacent fields separated; inline actions like "Add" or "Edit" links sit 8px away.
 - `.filters` and `.filter-row` provide optional flex wrapping with these gaps via `column-gap`/`row-gap`.
-- `.kt-date--tight` trims extra padding around the inline calendar icon while keeping the default control height; applied to Completion Date fields in participant tables.
+- `.kt-date--tight` trims WebKit padding/margins (0.5rem gutter, zero indicator margin, tighter edit padding) so the inline calendar icon hugs the right edge while keeping the default control height; applied to Completion Date fields in participant tables.
 
 ## 0.9 Navigation & Breadcrumbs
 - Header and main navigation use `/static/css/nav.css` with `--kt-bg` background, `--kt-text`/`--kt-info` links, and Raleway headings.

--- a/app/static/css/forms.css
+++ b/app/static/css/forms.css
@@ -83,23 +83,20 @@ input[type="datetime-local"] {
   padding-right: calc(var(--field-px, 5px) * 2 + 1.5em);
 }
 
-.kt-date--tight {
-  padding-right: 12px;
-}
-
-input.kt-date--tight {
-  padding-right: 12px;
+.kt-date--tight[type="date"],
+.kt-date--tight[type="datetime-local"] {
+  padding-right: calc(var(--field-px, 12px) + 0.5rem);
 }
 
 .kt-date--tight[type="date"]::-webkit-calendar-picker-indicator,
 .kt-date--tight[type="datetime-local"]::-webkit-calendar-picker-indicator {
-  margin: 0 2px 0 0;
-  padding: 0;
+  margin: 0;
+  padding: 0.125rem;
 }
 
 .kt-date--tight[type="date"]::-webkit-datetime-edit,
 .kt-date--tight[type="datetime-local"]::-webkit-datetime-edit {
-  padding: 0 8px;
+  padding: var(--field-py, 8px) 0.25rem var(--field-py, 8px) var(--field-px, 12px);
 }
 
 textarea {


### PR DESCRIPTION
## Summary
- shave the kt-date--tight right padding, indicator margin, and WebKit edit gutter so the calendar icon hugs the field edge without changing control height
- document the refined 0.5rem gutter and zero-margin indicator details in CONTEXT.md

## Testing
- not run (CSS-only change)

------
https://chatgpt.com/codex/tasks/task_e_68d1aefe456c832e99e8a5a329f24944