### PR TITLE
Compact global date inputs

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -104,7 +104,7 @@ Every functional change must update this file **in the same PR**.
 - Styles live in `/static/css/forms.css` and load globally.
 - Single-line controls include default 10px horizontal and 8px vertical margins to keep adjacent fields separated; inline actions like "Add" or "Edit" links sit 8px away.
 - `.filters` and `.filter-row` provide optional flex wrapping with these gaps via `column-gap`/`row-gap`.
-- `.kt-date--tight` trims WebKit padding/margins (0.5rem gutter, zero indicator margin, tighter edit padding) so the inline calendar icon hugs the right edge while keeping the default control height; applied to Completion Date fields in participant tables.
+- Date/datetime inputs use a compact global style (tight WebKit indicator spacing, ~14ch width with a 160px cap) so fields stay narrow by default; add `.kt-date--wide` when a wider field is necessary.
 
 ## 0.9 Navigation & Breadcrumbs
 - Header and main navigation use `/static/css/nav.css` with `--kt-bg` background, `--kt-text`/`--kt-info` links, and Raleway headings.

--- a/app/static/css/forms.css
+++ b/app/static/css/forms.css
@@ -77,26 +77,32 @@ select[multiple],
   border-radius: var(--radius-md, 12px);
 }
 
+input[type="time"] {
+  padding-right: calc(var(--field-px, 12px) * 2 + 1.5em);
+}
+
 input[type="date"],
-input[type="time"],
 input[type="datetime-local"] {
-  padding-right: calc(var(--field-px, 1px) * 2 + 1.5em);
+  width: 14ch;
+  max-width: 160px;
+  padding-right: calc(var(--field-px, 12px) + 0.5rem);
 }
 
-.kt-date--tight[type="date"],
-.kt-date--tight[type="datetime-local"] {
-  padding-right: calc(var(--field-px, 1px) + 0.5rem);
-}
-
-.kt-date--tight[type="date"]::-webkit-calendar-picker-indicator,
-.kt-date--tight[type="datetime-local"]::-webkit-calendar-picker-indicator {
+input[type="date"]::-webkit-calendar-picker-indicator,
+input[type="datetime-local"]::-webkit-calendar-picker-indicator {
   margin: 0;
   padding: 0.125rem;
 }
 
-.kt-date--tight[type="date"]::-webkit-datetime-edit,
-.kt-date--tight[type="datetime-local"]::-webkit-datetime-edit {
-  padding: var(--field-py, 1px) 0.25rem var(--field-py, 1px) var(--field-px, 2px);
+input[type="date"]::-webkit-datetime-edit,
+input[type="datetime-local"]::-webkit-datetime-edit {
+  padding: var(--field-py, 8px) 0.25rem var(--field-py, 8px) var(--field-px, 12px);
+}
+
+.kt-date--wide[type="date"],
+.kt-date--wide[type="datetime-local"] {
+  width: auto;
+  max-width: none;
 }
 
 textarea {

--- a/app/templates/session_detail.html
+++ b/app/templates/session_detail.html
@@ -245,7 +245,7 @@
             {% endif %}
             <td>
               <form action="{{ url_for('sessions.generate_single', session_id=session.id, participant_id=row.participant.id) }}" method="post">
-                <input type="date" class="kt-date--tight" name="completion_date" value="{{ row.link.completion_date }}">
+                <input type="date" name="completion_date" value="{{ row.link.completion_date }}">
                 <button type="submit" name="action" value="save">Save</button>
                 {% if session.delivered %}
                 <button type="submit" name="action" value="generate">Generate</button>

--- a/app/templates/sessions/workshop_view.html
+++ b/app/templates/sessions/workshop_view.html
@@ -186,7 +186,7 @@
             <td>
               <form action="{{ url_for('sessions.generate_single', session_id=session.id, participant_id=row.participant.id) }}" method="post">
                 <input type="hidden" name="next" value="{{ workshop_return }}">
-                <input type="date" class="kt-date--tight" name="completion_date" value="{{ row.link.completion_date }}">
+                <input type="date" name="completion_date" value="{{ row.link.completion_date }}">
                 <button type="submit" class="btn btn-secondary" name="action" value="save">Save</button>
                 {% if session.delivered %}
                 <button type="submit" class="btn btn-secondary" name="action" value="generate">Generate</button>


### PR DESCRIPTION
## Summary
- tighten base date and datetime input styling to reduce icon gap and limit default width, with a `.kt-date--wide` opt-out
- remove page-specific tight date field classes that are now redundant
- note the new global styling guidance in CONTEXT.md

## Testing
- not run (UI-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d1bb061f40832eb9c64677e30caa58