### PR TITLE
Trim left padding on date inputs

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -104,7 +104,7 @@ Every functional change must update this file **in the same PR**.
 - Styles live in `/static/css/forms.css` and load globally.
 - Single-line controls include default 10px horizontal and 8px vertical margins to keep adjacent fields separated; inline actions like "Add" or "Edit" links sit 8px away.
 - `.filters` and `.filter-row` provide optional flex wrapping with these gaps via `column-gap`/`row-gap`.
-- Date/datetime inputs use a compact global style (tight WebKit indicator spacing, ~14ch width with a 160px cap) so fields stay narrow by default; add `.kt-date--wide` when a wider field is necessary.
+- Date/datetime inputs use a compact global style (tight WebKit indicator spacing with the icon flush to the right edge, ~14ch width with a 160px cap) so fields stay narrow by default; add `.kt-date--wide` when a wider field is necessary. Their left padding is trimmed globally so text sits closer to the edge without affecting height or the calendar icon gutter.
 
 ## 0.9 Navigation & Breadcrumbs
 - Header and main navigation use `/static/css/nav.css` with `--kt-bg` background, `--kt-text`/`--kt-info` links, and Raleway headings.

--- a/app/static/css/forms.css
+++ b/app/static/css/forms.css
@@ -3,6 +3,7 @@
 :root {
   --field-h: 40px;
   --field-px: 12px;
+  --field-date-left: 2px;
   --field-py: 8px;
   --gap-x: 10px;
   --gap-y: 8px;
@@ -86,17 +87,19 @@ input[type="datetime-local"] {
   width: 14ch;
   max-width: 160px;
   padding-right: calc(var(--field-px, 12px) + 0.5rem);
+  padding-left: var(--field-date-left, 8px);
 }
 
 input[type="date"]::-webkit-calendar-picker-indicator,
 input[type="datetime-local"]::-webkit-calendar-picker-indicator {
   margin: 0;
+  margin-right: -0.125rem;
   padding: 0.125rem;
 }
 
 input[type="date"]::-webkit-datetime-edit,
 input[type="datetime-local"]::-webkit-datetime-edit {
-  padding: var(--field-py, 8px) 0.25rem var(--field-py, 8px) var(--field-px, 12px);
+  padding: var(--field-py, 8px) 0.25rem var(--field-py, 8px) var(--field-date-left, 8px);
 }
 
 .kt-date--wide[type="date"],


### PR DESCRIPTION
## Summary
- reduce the global left inset on all date and datetime-local inputs to 2px while keeping control sizing intact
- keep WebKit edit fields and the calendar icon gutter updated so the icon sits flush to the right edge
- document the slimmer default date padding and icon alignment in CONTEXT.md

## Testing
- not run (CSS-only change)

------
https://chatgpt.com/codex/tasks/task_e_68d1bda5eb44832e8e281d067381c683