### PR TITLE
Filter session locations by delivery mode

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -605,3 +605,4 @@ Route inventory lives at `sitemap.txt` (admin-only, linked from Settings) and li
 - Workshop Type default-material rows drop the "Remove" checkbox in favor of a
   per-row delete action (`POST /workshop-types/defaults/<id>/delete`).
 - PO Number field removed from materials orders and underlying storage.
+- Session create/edit forms filter workshop locations based on delivery type: Onsite shows onsite-only, Virtual shows virtual-only, incompatible selections are cleared, and an inline notice surfaces when no locations match.

--- a/app/routes/clients.py
+++ b/app/routes/clients.py
@@ -322,7 +322,7 @@ def inline_workshop_location(client_id, current_user, csa_account):
     loc.is_active = request.form.get("is_active") in {"1", "on", "true"}
     db.session.add(loc)
     db.session.commit()
-    return {"id": loc.id, "label": loc.label}
+    return {"id": loc.id, "label": loc.label, "is_virtual": loc.is_virtual}
 
 
 @bp.get("/<int:client_id>/inline-workshop-locations")
@@ -333,7 +333,11 @@ def list_inline_workshop_locations(client_id, current_user, csa_account):
         .order_by(ClientWorkshopLocation.label)
         .all()
     )
-    return {"locations": [{"id": l.id, "label": l.label} for l in locs]}
+    return {
+        "locations": [
+            {"id": l.id, "label": l.label, "is_virtual": l.is_virtual} for l in locs
+        ]
+    }
 
 
 @bp.post("/<int:client_id>/inline-shipping-location")

--- a/app/templates/sessions/form.html
+++ b/app/templates/sessions/form.html
@@ -97,9 +97,10 @@
           <select name="workshop_location_id" id="workshop-location-select">
             <option value=""></option>
             {% for loc in workshop_locations %}
-            <option value="{{ loc.id }}" {% if session.workshop_location_id==loc.id %}selected{% endif %}>{{ loc.label }}</option>
+            <option value="{{ loc.id }}" data-virtual="{{ 'true' if loc.is_virtual else 'false' }}" {% if session.workshop_location_id==loc.id %}selected{% endif %}>{{ loc.label }}</option>
             {% endfor %}
           </select>
+          <div id="location-filter-note" class="form-align__note" style="display:none;">No locations match the selected mode</div>
           <a href="#" id="add-workshop-location">Add</a>
         </div>
       </div>
@@ -288,12 +289,65 @@
   var typeSelect = document.querySelector('select[name="workshop_type_id"]');
   var simDiv = document.getElementById('sim-outline');
   var materialsBtn = document.getElementById('materials-only-btn');
+  var deliveryTypeField = document.getElementById('delivery-type');
+  var locationSelect = document.getElementById('workshop-location-select');
+  var locationNote = document.getElementById('location-filter-note');
   if(materialsBtn){
     materialsBtn.addEventListener('click', function(){
       document.querySelectorAll('.session-form__section:not(:first-of-type) [required]').forEach(function(el){
         el.removeAttribute('required');
       });
     });
+  }
+  function applyLocationFilter(){
+    if(!locationSelect){ return; }
+    var mode = deliveryTypeField ? deliveryTypeField.value : '';
+    var showVirtual = mode === 'Virtual';
+    var restrict = mode === 'Virtual' || mode === 'Onsite';
+    var totalOptions = 0;
+    var visibleOptions = 0;
+    var selectionCleared = false;
+    Array.from(locationSelect.options).forEach(function(opt){
+      if(!opt.value){
+        opt.hidden = false;
+        opt.disabled = false;
+        return;
+      }
+      var isVirtual = opt.dataset.virtual === 'true';
+      var shouldHide = false;
+      if(restrict){
+        shouldHide = showVirtual ? !isVirtual : isVirtual;
+      }
+      opt.hidden = shouldHide;
+      opt.disabled = shouldHide;
+      if(shouldHide && opt.selected){
+        opt.selected = false;
+        selectionCleared = true;
+      }
+      totalOptions += 1;
+      if(!shouldHide){
+        visibleOptions += 1;
+      }
+    });
+    var currentOption = locationSelect.options[locationSelect.selectedIndex];
+    if(selectionCleared || (currentOption && (currentOption.disabled || currentOption.hidden))){
+      locationSelect.value = '';
+      locationSelect.dispatchEvent(new Event('change', { bubbles: true }));
+    } else if(!currentOption && locationSelect.value){
+      locationSelect.value = '';
+      locationSelect.dispatchEvent(new Event('change', { bubbles: true }));
+    }
+    if(locationNote){
+      if(restrict && totalOptions > 0 && visibleOptions === 0){
+        locationNote.style.display = 'block';
+      }else{
+        locationNote.style.display = 'none';
+      }
+    }
+  }
+  applyLocationFilter();
+  if(deliveryTypeField){
+    deliveryTypeField.addEventListener('change', applyLocationFilter);
   }
   function filterTypes(){
     if(!langSelect || !typeSelect){ return; }
@@ -454,10 +508,12 @@
         .then(data=>{
           data.locations.forEach(function(loc){
             var o=document.createElement('option');
-            o.value=loc.id; o.textContent=loc.label; locSel.appendChild(o);
+            o.value=loc.id; o.textContent=loc.label; o.dataset.virtual = loc.is_virtual ? 'true' : 'false'; locSel.appendChild(o);
           });
+          applyLocationFilter();
         });
     }
+    applyLocationFilter();
   });
   document.getElementById('include-all-fac').addEventListener('change', function(){
     var url = new URL(window.location.href);
@@ -536,7 +592,8 @@
         if(status==200 && data.id){
           var sel=document.getElementById('workshop-location-select');
           var o=document.createElement('option');
-          o.value=data.id; o.textContent=data.label; sel.appendChild(o); sel.value=data.id;
+          o.value=data.id; o.textContent=data.label; o.dataset.virtual = data.is_virtual ? 'true' : 'false'; sel.appendChild(o); sel.value=data.id;
+          applyLocationFilter();
           locDialog.close();
         }else if(data.errors){
           showErrors(locForm, data.errors);


### PR DESCRIPTION
## Summary
- add virtual/onsite metadata to workshop location options on the session form
- dynamically filter the location list when delivery type toggles and clear invalid selections
- extend inline location APIs to return the virtual flag and document the behavior in CONTEXT.md

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d3e0639908832ebb74f8d2b73eef5f