### PR TITLE
Remove banner and add staff-only view hint

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -217,7 +217,7 @@ Delivery (KT Facilitator) and Contractor accounts open the workshop runner view 
 - **My Sessions**: Admin, CRM, and Delivery roles see an **Edit** action per row; Contractors, CSA, and Learner accounts do not.
 
 ## 1.3 View Selector
-Only SysAdmin, Administrator, CRM, and KT Facilitator roles see the View selector. CSA, Participant, and Contractor do not.
+Only SysAdmin, Administrator, CRM, and KT Facilitator roles see the View selector. CSA, Participant, and Contractor do not. For KT Staff, a muted "Switch views here." hint appears directly beneath the selector inside the left navigation; there is no banner elsewhere.
 
 ## 1.4 “KT Staff” definition (derived, not stored)
 - KT Staff = any **User** account that is **not** Contractor and **not** a participant/CSA.  

--- a/app/app.py
+++ b/app/app.py
@@ -48,7 +48,7 @@ from .shared.views import (
 )
 from .shared.nav import build_menu
 from .shared.storage_resources import resource_fs_dir, resource_fs_path, resources_root
-from .shared.acl import is_admin, is_kcrm, is_delivery, is_contractor
+from .shared.acl import is_admin, is_kcrm, is_delivery, is_contractor, is_kt_staff
 from .shared.languages import code_to_label
 from .shared.html import sanitize_prework_html
 
@@ -235,6 +235,7 @@ def create_app():
             "active_view": active_view,
             "nav_menu": nav_menu,
             "view_options": view_opts,
+            "is_staff_user": is_kt_staff(user),
         }
 
     @app.get("/health")

--- a/app/shared/acl.py
+++ b/app/shared/acl.py
@@ -38,8 +38,35 @@ def is_contractor(user: Any) -> bool:
 
 
 def is_kt_staff(user: Any) -> bool:
-    """Return True for any User account that is not a Contractor."""
-    return bool(isinstance(user, User) and not is_contractor(user))
+    """Return True when the account should be treated as KT Staff."""
+
+    if not user:
+        return False
+
+    if isinstance(user, ParticipantAccount):
+        return False
+
+    if not isinstance(user, User):
+        return False
+
+    positive_flags = (
+        "is_app_admin",
+        "is_admin",
+        "is_kt_admin",
+        "is_kcrm",
+        "is_kt_delivery",
+        "is_kt_staff",
+    )
+    if any(getattr(user, flag, False) for flag in positive_flags):
+        return True
+
+    if getattr(user, "is_kt_contractor", False):
+        return False
+
+    if hasattr(user, "has_role") and user.has_role(CONTRACTOR):
+        return False
+
+    return True
 
 
 def can_demote_to_contractor(actor: User, target: User) -> bool:

--- a/app/static/css/print.css
+++ b/app/static/css/print.css
@@ -6,8 +6,7 @@
   .flash,
   .flashes,
   .btn,
-  .pagination,
-  .view-banner {
+  .pagination {
     display: none !important;
   }
 

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -30,12 +30,6 @@
       flex:1;
       padding:var(--space-4);
     }
-    .view-banner {
-      background:#ffe9a1;
-      padding:var(--space-2) var(--space-4);
-      margin-bottom:var(--space-4);
-      border:1px solid #f0c36d;
-    }
   </style>
   {% block extra_head %}{% endblock %}
 </head>
@@ -44,9 +38,6 @@
     {% include 'nav.html' %}
   </aside>
   <main class="content">
-    {% if current_user and active_view != 'ADMIN' %}
-    <div class="view-banner">You're in <strong>{{ active_view.replace('_',' ').title() }}</strong> view. Permissions are unchanged. <a href="{{ url_for('settings_view', view='ADMIN') }}">Switch to Admin</a></div>
-    {% endif %}
     {% with msgs=get_flashed_messages(with_categories=true) %}
       {% if msgs %}
       <div class="flashes">

--- a/app/templates/nav.html
+++ b/app/templates/nav.html
@@ -17,7 +17,7 @@
   {% for item in nav_menu %}
     {{ render_item(item) }}
   {% endfor %}
-  {% if view_options|length > 1 %}
+  {% if is_staff_user and view_options|length > 1 %}
   <form method="post" action="{{ url_for('settings_view') }}" class="kt-sidebar-footer">
     <label>View:</label>
     <select name="view" onchange="this.form.submit()">
@@ -26,6 +26,7 @@
       <option value="{{ opt }}" {% if opt == active_view %}selected{% endif %}>{{ label }}</option>
       {% endfor %}
     </select>
+    <div class="text-muted small mt-1">Switch views here.</div>
   </form>
   {% endif %}
 </nav>

--- a/tests/smoke/test_auth_roles.py
+++ b/tests/smoke/test_auth_roles.py
@@ -74,6 +74,10 @@ def test_auth_roles_home_selection(app, client):
     # Admin stays on staff home and can switch to materials dashboard
     resp = _login(client, "admin@example.com", "pw")
     assert resp.request.path == "/home"
+    admin_html = resp.get_data(as_text=True)
+    assert "Switch views here." in admin_html
+    assert "<label>View:</label>" in admin_html
+    assert "Switch to Admin" not in admin_html
     response = client.get(
         "/settings/view", query_string={"view": "MATERIAL_MANAGER"}, follow_redirects=False
     )
@@ -86,23 +90,43 @@ def test_auth_roles_home_selection(app, client):
     # CRM lands on My Sessions
     resp = _login(client, "crm@example.com", "pw")
     assert resp.request.path == "/my-sessions"
+    crm_html = resp.get_data(as_text=True)
+    assert "Switch views here." in crm_html
+    assert "<label>View:</label>" in crm_html
+    assert "Switch to Admin" not in crm_html
     client.get("/logout")
 
     # Facilitator lands on My Sessions
     resp = _login(client, "facilitator@example.com", "pw")
     assert resp.request.path == "/my-sessions"
+    facilitator_html = resp.get_data(as_text=True)
+    assert "Switch views here." in facilitator_html
+    assert "<label>View:</label>" in facilitator_html
+    assert "Switch to Admin" not in facilitator_html
     client.get("/logout")
 
     # Contractor is routed to My Sessions
     resp = _login(client, "contractor@example.com", "pw")
     assert resp.request.path == "/my-sessions"
+    contractor_html = resp.get_data(as_text=True)
+    assert "Switch views here." not in contractor_html
+    assert "<label>View:</label>" not in contractor_html
+    assert "Switch to Admin" not in contractor_html
     client.get("/logout")
 
     # Learner account goes to participant workshops
     resp = _login(client, "learner@example.com", "pw")
     assert resp.request.path == "/my-workshops"
+    learner_html = resp.get_data(as_text=True)
+    assert "Switch views here." not in learner_html
+    assert "<label>View:</label>" not in learner_html
+    assert "Switch to Admin" not in learner_html
     client.get("/logout")
 
     # CSA account is routed to CSA dashboard
     resp = _login(client, "csa@example.com", "pw")
     assert resp.request.path == "/csa/my-sessions"
+    csa_html = resp.get_data(as_text=True)
+    assert "Switch views here." not in csa_html
+    assert "<label>View:</label>" not in csa_html
+    assert "Switch to Admin" not in csa_html


### PR DESCRIPTION
## Summary
- remove the global view banner and related styling
- gate the view selector and new staff-only hint via the updated is_kt_staff helper
- cover the navigation visibility changes with smoke assertions and document the behavior

## Testing
- PYTHONPATH=. pytest tests/smoke/test_auth_roles.py

------
https://chatgpt.com/codex/tasks/task_e_68d3e0d02a68832e8faef73035487cfe