### PR TITLE
Persist workshop type active flag and filter inactive options

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -54,7 +54,7 @@ Every functional change must update this file **in the same PR**.
 - Tests: prefer integration tests that hit route + template path for core flows.
 - Formatting: Black-compatible; imports grouped as stdlib, third-party, local with blank lines between groups.
 - Templates render language names via `lang_label`; codes are never shown directly.
-- Workshop Types expose an `active` boolean (checkbox in forms); the legacy free-text `status` field is deprecated and ignored by new code.
+- Workshop Types expose an `active` boolean (checkbox in forms); the legacy free-text `status` field is deprecated and ignored by new code. Session create lists only active types, while session edit keeps an already-selected inactive type available so existing workshops remain stable.
 - Smoke suite is limited to eight tests covering auth/roles, dashboards segregation, materials lifecycle, delivered/finalize guardrails, prework invites & disable modes, attendance certificate gating, resources visibility, and profile contact persistence.
 
 ## 0.5 Test Strategy

--- a/app/routes/sessions.py
+++ b/app/routes/sessions.py
@@ -495,7 +495,11 @@ def list_sessions(current_user):
 def new_session(current_user):
     if is_contractor(current_user):
         abort(403)
-    workshop_types = WorkshopType.query.order_by(WorkshopType.code).all()
+    workshop_types = (
+        WorkshopType.query.filter(WorkshopType.active == True)
+        .order_by(WorkshopType.code)
+        .all()
+    )
     include_all = request.args.get("include_all_facilitators") == "1"
     fac_query = User.query.filter(
         or_(User.is_kt_delivery == True, User.is_kt_contractor == True)
@@ -967,7 +971,16 @@ def edit_session(session_id: int, current_user):
         abort(404)
     if is_contractor(current_user):
         abort(403)
-    workshop_types = WorkshopType.query.order_by(WorkshopType.code).all()
+    workshop_types = (
+        WorkshopType.query.filter(
+            or_(
+                WorkshopType.active == True,
+                WorkshopType.id == sess.workshop_type_id,
+            )
+        )
+        .order_by(WorkshopType.code)
+        .all()
+    )
     include_all = request.args.get("include_all_facilitators") == "1"
     fac_query = User.query.filter(
         or_(User.is_kt_delivery == True, User.is_kt_contractor == True)

--- a/app/routes/workshop_types.py
+++ b/app/routes/workshop_types.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from flask import (
     Blueprint,
     abort,
+    current_app,
     flash,
     redirect,
     render_template,
@@ -241,7 +242,7 @@ def create_type(current_user):
     wt = WorkshopType(
         code=code,
         name=name,
-        active=True if active_raw is None else bool(active_raw),
+        active=bool(active_raw),
         description=request.form.get("description") or None,
         simulation_based=bool(request.form.get("simulation_based")),
         supported_languages=langs or ["en"],
@@ -305,6 +306,9 @@ def create_type(current_user):
             action="workshop_type_create",
             details=f"id={wt.id} code={wt.code}",
         )
+    )
+    current_app.logger.info(
+        "[workshop-type] set active=%s id=%s", str(bool(wt.active)).lower(), wt.id
     )
     db.session.commit()
     flash("Workshop Type created", "success")
@@ -394,7 +398,7 @@ def update_type(type_id: int, current_user):
         abort(400)
     wt.name = request.form.get("name") or wt.name
     active_raw = request.form.get("active")
-    wt.active = True if active_raw is None else bool(active_raw)
+    wt.active = bool(active_raw)
     wt.description = request.form.get("description") or None
     wt.simulation_based = bool(request.form.get("simulation_based"))
     langs = request.form.getlist("supported_languages")
@@ -515,6 +519,9 @@ def update_type(type_id: int, current_user):
             action="workshop_type_update",
             details=f"id={wt.id}",
         )
+    )
+    current_app.logger.info(
+        "[workshop-type] set active=%s id=%s", str(bool(wt.active)).lower(), wt.id
     )
     db.session.commit()
     flash("Workshop Type updated", "success")

--- a/migrations/versions/0074_workshop_type_active.py
+++ b/migrations/versions/0074_workshop_type_active.py
@@ -8,6 +8,7 @@ Create Date: 2024-10-05 00:00:00.000000
 
 from alembic import op
 import sqlalchemy as sa
+from sqlalchemy.sql import table, column
 
 
 # revision identifiers, used by Alembic.
@@ -17,19 +18,59 @@ branch_labels = None
 depends_on = None
 
 
+def _column_names(table_name: str) -> set[str]:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    return {col["name"] for col in inspector.get_columns(table_name)}
+
+
 def upgrade():
-    """Add boolean 'active' column to workshop_types."""
-    op.add_column(
+    """Ensure the workshop_types.active column exists and is populated."""
+
+    columns = _column_names("workshop_types")
+    if "active" not in columns:
+        op.add_column(
+            "workshop_types",
+            sa.Column("active", sa.Boolean(), nullable=True),
+        )
+        columns.add("active")
+
+    wt_active = table("workshop_types", column("active", sa.Boolean()))
+
+    if "status" in columns:
+        wt_status = table(
+            "workshop_types",
+            column("status", sa.String()),
+            column("active", sa.Boolean()),
+        )
+        op.execute(
+            wt_status.update()
+            .where(wt_status.c.active.is_(None))
+            .values(
+                active=sa.case(
+                    ((sa.func.lower(wt_status.c.status) == "active", sa.true()),),
+                    else_=sa.false(),
+                )
+            )
+        )
+
+    op.execute(
+        wt_active.update()
+        .where(wt_active.c.active.is_(None))
+        .values(active=sa.true())
+    )
+
+    op.alter_column(
         "workshop_types",
-        sa.Column(
-            "active",
-            sa.Boolean(),
-            server_default=sa.true(),
-            nullable=False,
-        ),
+        "active",
+        existing_type=sa.Boolean(),
+        nullable=False,
+        server_default=sa.true(),
     )
 
 
 def downgrade():
-    """Remove the 'active' column from workshop_types."""
-    op.drop_column("workshop_types", "active")
+    """Remove the 'active' column from workshop_types if it exists."""
+
+    if "active" in _column_names("workshop_types"):
+        op.drop_column("workshop_types", "active")

--- a/pytest.ini
+++ b/pytest.ini
@@ -5,4 +5,5 @@ markers =
     full: comprehensive test suite excluding slow and quarantined
     slow: long-running tests executed nightly
     quarantine: flaky tests excluded from regular runs
+    no_smoke: exclude from the smoke subset while keeping in the full suite
 testpaths = tests

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,6 +9,8 @@ def pytest_collection_modifyitems(config, items):
         if "slow" in item.keywords or "quarantine" in item.keywords:
             continue
         item.add_marker("full")
+        if "no_smoke" in item.keywords:
+            continue
         item.add_marker("smoke")
 
 

--- a/tests/test_workshop_type_active.py
+++ b/tests/test_workshop_type_active.py
@@ -1,0 +1,176 @@
+import pytest
+from datetime import date, time
+
+from app.app import db
+from app.models import (
+    CertificateTemplateSeries,
+    Client,
+    Session,
+    User,
+    WorkshopType,
+)
+
+
+ADMIN_EMAIL = "admin@example.com"
+ADMIN_PASSWORD = "pw"
+SERIES_CODE = "fn"
+
+
+def _setup_admin(app):
+    with app.app_context():
+        admin = User(
+            email=ADMIN_EMAIL,
+            is_app_admin=True,
+            is_admin=True,
+            region="NA",
+        )
+        admin.set_password(ADMIN_PASSWORD)
+        series = CertificateTemplateSeries(
+            code=SERIES_CODE,
+            name="Foundational",
+            is_active=True,
+        )
+        db.session.add_all([admin, series])
+        db.session.commit()
+
+
+def _login(client):
+    return client.post(
+        "/login",
+        data={"email": ADMIN_EMAIL, "password": ADMIN_PASSWORD},
+        follow_redirects=True,
+    )
+
+
+@pytest.mark.no_smoke
+def test_workshop_type_inactive_checkbox_persists(app, client):
+    _setup_admin(app)
+    _login(client)
+
+    with client.session_transaction() as session:
+        session["_csrf_token"] = "token"
+
+    response = client.post(
+        "/workshop-types/new",
+        data={
+            "csrf_token": "token",
+            "code": "INACT",
+            "name": "Inactive Type",
+            "cert_series": SERIES_CODE,
+            "supported_languages": ["en"],
+        },
+        follow_redirects=True,
+    )
+    assert response.status_code == 200
+    page = response.get_data(as_text=True)
+    assert "Inactive" in page
+
+    with app.app_context():
+        wt = WorkshopType.query.filter_by(code="INACT").one()
+        assert wt.active is False
+        wt_id = wt.id
+
+    edit_page = client.get(f"/workshop-types/{wt_id}/edit")
+    assert edit_page.status_code == 200
+    edit_html = edit_page.get_data(as_text=True)
+    checkbox_line = next(
+        line
+        for line in edit_html.splitlines()
+        if 'name="active"' in line and 'value="1"' in line
+    )
+    assert "checked" not in checkbox_line
+
+
+@pytest.mark.no_smoke
+def test_new_session_excludes_inactive_workshop_types(app, client):
+    _setup_admin(app)
+    with app.app_context():
+        active_type = WorkshopType(
+            code="ACTIVE",
+            name="Active Type",
+            cert_series=SERIES_CODE,
+            active=True,
+        )
+        inactive_type = WorkshopType(
+            code="INACTIVE",
+            name="Inactive Type",
+            cert_series=SERIES_CODE,
+            active=False,
+        )
+        db.session.add_all([active_type, inactive_type])
+        db.session.commit()
+        active_id = active_type.id
+        inactive_id = inactive_type.id
+
+    _login(client)
+    response = client.get("/sessions/new")
+    assert response.status_code == 200
+    html = response.get_data(as_text=True)
+    assert f'value="{active_id}"' in html
+    assert f'value="{inactive_id}"' not in html
+
+
+@pytest.mark.no_smoke
+def test_edit_session_preserves_inactive_type(app, client):
+    _setup_admin(app)
+    with app.app_context():
+        inactive_type = WorkshopType(
+            code="LEGACY",
+            name="Legacy Type",
+            cert_series=SERIES_CODE,
+            active=False,
+        )
+        client_record = Client(name="ClientCo")
+        today = date.today()
+        session = Session(
+            title="Legacy Session",
+            start_date=today,
+            end_date=today,
+            daily_start_time=time.fromisoformat("08:00"),
+            daily_end_time=time.fromisoformat("17:00"),
+            timezone="UTC",
+            delivery_type="Virtual",
+            region="NA",
+            workshop_language="en",
+            capacity=10,
+            number_of_class_days=1,
+            workshop_type=inactive_type,
+            client=client_record,
+        )
+        db.session.add_all([inactive_type, client_record, session])
+        db.session.commit()
+        session_id = session.id
+        workshop_type_id = inactive_type.id
+        client_id = client_record.id
+
+    _login(client)
+    form_page = client.get(f"/sessions/{session_id}/edit")
+    assert form_page.status_code == 200
+    form_html = form_page.get_data(as_text=True)
+    assert f'value="{workshop_type_id}"' in form_html
+
+    today_str = date.today().isoformat()
+    response = client.post(
+        f"/sessions/{session_id}/edit",
+        data={
+            "title": "Legacy Session",
+            "start_date": today_str,
+            "end_date": today_str,
+            "daily_start_time": "08:00",
+            "daily_end_time": "17:00",
+            "timezone": "UTC",
+            "delivery_type": "Virtual",
+            "region": "NA",
+            "workshop_language": "en",
+            "capacity": "10",
+            "number_of_class_days": "1",
+            "workshop_type_id": str(workshop_type_id),
+            "client_id": str(client_id),
+        },
+        follow_redirects=False,
+    )
+    assert response.status_code == 302
+
+    with app.app_context():
+        refreshed = db.session.get(Session, session_id)
+        assert refreshed.workshop_type_id == workshop_type_id


### PR DESCRIPTION
## Summary
- ensure workshop type active checkbox persists and emits audit log entries when saved
- filter inactive workshop types from the new session form while still showing an already-selected inactive type on edit
- backfill and enforce the workshop_types.active column and add coverage for the new behaviours

## Testing
- PYTHONPATH=. pytest
- PYTHONPATH=. pytest -m "no_smoke"

------
https://chatgpt.com/codex/tasks/task_e_68d3e64b196c832eaba031adaf2293fa