### PR TITLE
Add idempotent workshop type active migration

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -26,6 +26,8 @@ Every functional change must update this file **in the same PR**.
   - Create: `python manage.py db migrate -m "message"`
   - Apply: `python manage.py db upgrade`
 
+- We favor idempotent SQL (`IF NOT EXISTS`, `COALESCE` backfills) to allow safe re-runs.
+
 - 2025-10-05: Corrected migration `0074_workshop_type_active` to chain after `0073_user_profile_contact_fields` and keep its upgrade/downgrade reversible.
 - 2025-09-29: Fixed Alembic metadata header for migration `0071_prework_invites` so it imports cleanly.
 - 2025-09-23: Added shim migration `0072_prework_disable_fields` to chain `9e9d34b28f26` to the renumbered `0073_user_profile_contact_fields` migration.

--- a/migrations/versions/0075_workshop_type_active_idempotent.py
+++ b/migrations/versions/0075_workshop_type_active_idempotent.py
@@ -1,0 +1,57 @@
+"""Harden workshop_types.active with idempotent SQL"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "0075_workshop_type_active_idempotent"
+down_revision = "0074_workshop_type_active"
+branch_labels = None
+depends_on = None
+
+
+_POSTGRES_STATEMENTS = (
+    "ALTER TABLE workshop_types ADD COLUMN IF NOT EXISTS active BOOLEAN NOT NULL DEFAULT TRUE",
+    "ALTER TABLE workshop_types ALTER COLUMN active SET DEFAULT TRUE",
+    """
+    UPDATE workshop_types
+       SET active = COALESCE(
+         CASE WHEN status IS NOT NULL THEN (LOWER(status) = 'active') END,
+         TRUE
+       )
+     WHERE active IS NULL
+    """,
+    "ALTER TABLE workshop_types ALTER COLUMN active SET NOT NULL",
+    "CREATE INDEX IF NOT EXISTS idx_workshop_types_active ON workshop_types(active)",
+)
+
+
+_SQLITE_STATEMENTS = (
+    "ALTER TABLE workshop_types ADD COLUMN IF NOT EXISTS active BOOLEAN NOT NULL DEFAULT 1",
+    """
+    UPDATE workshop_types
+       SET active = COALESCE(
+         CASE WHEN status IS NOT NULL THEN (LOWER(status) = 'active') END,
+         1
+       )
+     WHERE active IS NULL
+    """,
+    "CREATE INDEX IF NOT EXISTS idx_workshop_types_active ON workshop_types(active)",
+)
+
+
+def upgrade():
+    conn = op.get_bind()
+    dialect = conn.dialect.name
+    if dialect == "postgresql":
+        statements = _POSTGRES_STATEMENTS
+    else:
+        statements = _SQLITE_STATEMENTS
+
+    for statement in statements:
+        conn.execute(sa.text(statement))
+
+
+def downgrade():
+    # Forward-only migration: keep hardened column state.
+    pass

--- a/tests/test_migrations_workshop_type_active.py
+++ b/tests/test_migrations_workshop_type_active.py
@@ -1,0 +1,85 @@
+import os
+from pathlib import Path
+
+import pytest
+import sqlalchemy as sa
+from alembic import command
+from alembic.config import Config
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _alembic_config(db_url: str) -> Config:
+    config = Config(str(PROJECT_ROOT / "alembic.ini"))
+    config.set_main_option("sqlalchemy.url", db_url)
+    config.set_main_option("script_location", str(PROJECT_ROOT / "migrations"))
+    return config
+
+
+@pytest.mark.no_smoke
+def test_workshop_type_active_migration_idempotent(tmp_path):
+    db_path = tmp_path / "migration.sqlite"
+    db_url = f"sqlite:///{db_path}"
+    original_url = os.environ.get("DATABASE_URL")
+    os.environ["DATABASE_URL"] = db_url
+    config = _alembic_config(db_url)
+
+    command.upgrade(config, "head")
+    command.upgrade(config, "head")
+
+    engine = sa.create_engine(db_url)
+    try:
+        with engine.begin() as conn:
+            inspector = sa.inspect(conn)
+            columns = {col["name"]: col for col in inspector.get_columns("workshop_types")}
+            assert "active" in columns
+            active_col = columns["active"]
+            assert not active_col["nullable"]
+
+            default_clause = active_col.get("default") or active_col.get("server_default")
+            assert default_clause is not None
+            default_text = str(getattr(default_clause, "arg", default_clause))
+            normalized_default = default_text.strip("()'\"").lower()
+            assert normalized_default in {"1", "true"}
+
+            conn.execute(
+                sa.text(
+                    """
+                    INSERT INTO workshop_types (code, name, cert_series, supported_languages)
+                    VALUES (:code, :name, :series, :languages)
+                    """
+                ),
+                {
+                    "code": "TMP",
+                    "name": "Temporary",
+                    "series": "fn",
+                    "languages": '["en"]',
+                },
+            )
+            wt_id = conn.execute(
+                sa.text("SELECT id FROM workshop_types WHERE code = :code"),
+                {"code": "TMP"},
+            ).scalar_one()
+
+            active_value = conn.execute(
+                sa.text("SELECT active FROM workshop_types WHERE id = :id"),
+                {"id": wt_id},
+            ).scalar_one()
+            assert active_value in (True, 1)
+
+            conn.execute(
+                sa.text("UPDATE workshop_types SET active = 0 WHERE id = :id"),
+                {"id": wt_id},
+            )
+            toggled = conn.execute(
+                sa.text("SELECT active FROM workshop_types WHERE id = :id"),
+                {"id": wt_id},
+            ).scalar_one()
+            assert toggled in (False, 0)
+    finally:
+        engine.dispose()
+        if original_url is not None:
+            os.environ["DATABASE_URL"] = original_url
+        else:
+            os.environ.pop("DATABASE_URL", None)


### PR DESCRIPTION
## Summary
- add an idempotent SQL migration to harden workshop_types.active and ensure safe re-runs
- backfill the active flag from legacy status when needed and add an index for filtering
- document the idempotent migration approach and add a regression test that upgrades twice and validates defaults/toggling

## Testing
- PYTHONPATH=. pytest

------
https://chatgpt.com/codex/tasks/task_e_68d3ef6b1c50832ebaefa38d5c9c9585