### PR TITLE
Show prework headlines in summaries

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -315,7 +315,7 @@ Two separate tables by design; emails unique per table. If both tables hold the 
 - `prework_invites` (session_id, participant_id, sender_id, sent_at; records every invite attempt for invite status tracking)
 - Prework editor exposes a language selector limited to the workshop type’s supported languages; switching languages loads or creates that language’s template and questions without affecting others.
 - A **Copy from workshop** control lets staff pick a source workshop type and language, copying that template’s questions (and info text) into the current language after confirming replacements when questions already exist.
-- Workshop View and the staff Prework tab show a read-only summary grouped by question with bullets formatted as "**Name**; answer; answer2" using ';' separators (multi-part answers join with '; ' and multiline responses collapse to spaces). Question prompts render sanitized rich text (allowing `<p>`, `<br>`, `<strong>`, `<em>`, `<ul>`, `<ol>`, `<li>`, and `<a href target="_blank" rel="noopener">`) so formatting is preserved without exposing unsafe markup.
+- Workshop View and the staff Prework tab show a read-only summary grouped by question with bullets formatted as "**Name**; answer; answer2" using ';' separators (multi-part answers join with '; ' and multiline responses collapse to spaces). Each question displays only its headline — the explicit question title when provided, otherwise the first line of the sanitized prompt — so long instructional paragraphs stay hidden; empty prompts surface as "(Untitled question)".
 - Learner submissions keep every entered response (including the first item in list questions) in order; whitespace-only rows are dropped during save.
 
 ## 3.3 Resources

--- a/app/templates/sessions/_prework_summary.html
+++ b/app/templates/sessions/_prework_summary.html
@@ -7,7 +7,7 @@
   {% elif prework_summary %}
     {% for group in prework_summary %}
       {% if group.responses %}
-        <div class="kt-card-title rich-text">{{ group.question }}</div>
+        <div class="kt-card-title rich-text">{{ group.question_headline }}</div>
         <ul>
           {% for response in group.responses %}
             <li><strong>{{ response.name }}</strong>{% if response.answer_text %}; {{ response.answer_text }}{% endif %}</li>

--- a/tests/test_prework_summary.py
+++ b/tests/test_prework_summary.py
@@ -1,0 +1,112 @@
+from app.app import db
+from app.models import (
+    ParticipantAccount,
+    PreworkAnswer,
+    PreworkAssignment,
+    PreworkQuestion,
+    PreworkTemplate,
+    Session,
+    WorkshopType,
+)
+from app.shared.prework_summary import get_session_prework_summary
+
+
+def _build_prework_summary(app, question_text: str, *, answer_text: str = "Answer"):
+    with app.app_context():
+        workshop_type = WorkshopType(
+            code="WT1",
+            name="Workshop",
+            cert_series="std",
+        )
+        db.session.add(workshop_type)
+        db.session.flush()
+
+        session = Session(
+            title="Test Session",
+            workshop_type_id=workshop_type.id,
+            workshop_language="en",
+        )
+        db.session.add(session)
+        db.session.flush()
+
+        template = PreworkTemplate(
+            workshop_type_id=workshop_type.id,
+            language="en",
+            is_active=True,
+            require_completion=True,
+        )
+        db.session.add(template)
+        db.session.flush()
+
+        question = PreworkQuestion(
+            template_id=template.id,
+            position=1,
+            text=question_text,
+            required=True,
+            kind="TEXT",
+        )
+        db.session.add(question)
+        db.session.flush()
+
+        account = ParticipantAccount(
+            email="alice@example.com",
+            full_name="Alice Example",
+        )
+        db.session.add(account)
+        db.session.flush()
+
+        assignment = PreworkAssignment(
+            session_id=session.id,
+            participant_account_id=account.id,
+            template_id=template.id,
+            snapshot_json={
+                "questions": [
+                    {
+                        "index": 1,
+                        "text": question_text,
+                        "required": True,
+                        "kind": "TEXT",
+                        "min_items": None,
+                        "max_items": None,
+                    }
+                ]
+            },
+        )
+        db.session.add(assignment)
+        db.session.flush()
+
+        answer = PreworkAnswer(
+            assignment_id=assignment.id,
+            question_index=1,
+            item_index=0,
+            answer_text=answer_text,
+        )
+        db.session.add(answer)
+
+        db.session.commit()
+
+        return get_session_prework_summary(session.id)
+
+
+def test_prework_summary_uses_first_line_of_multiparagraph_question(app):
+    question_text = "<p>What are your goals?</p><p>Share details for the facilitator.</p>"
+    summary = _build_prework_summary(app, question_text)
+
+    assert summary[0]["question_headline"] == "What are your goals?"
+    assert summary[0]["responses"][0]["answer_text"] == "Answer"
+
+
+def test_prework_summary_strips_html_formatting_for_headline(app):
+    question_text = "<p><strong>Describe your plan</strong><br>Include <em>details</em> in full.</p>"
+    summary = _build_prework_summary(app, question_text)
+
+    assert summary[0]["question_headline"] == "Describe your plan"
+    assert summary[0]["responses"][0]["name"] == "Alice Example"
+
+
+def test_prework_summary_handles_single_line_question(app):
+    question_text = "Share one word to describe today."
+    summary = _build_prework_summary(app, question_text)
+
+    assert summary[0]["question_headline"] == "Share one word to describe today."
+    assert summary[0]["responses"][0]["answer_text"] == "Answer"


### PR DESCRIPTION
## Summary
- derive a question headline for facilitator prework summaries using the explicit title or the first line of the prompt with a safe fallback
- render only the headline in the workshop/staff prework summary card while keeping response formatting intact
- document the behavior in CONTEXT.md and cover multi-line, HTML, and single-line prompts with new tests

## Testing
- PYTHONPATH=. pytest

------
https://chatgpt.com/codex/tasks/task_e_68d4256d6bb4832e9d68115bd6165362