### PR TITLE
Add dirty guard prompts and auto-applying filters

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -47,6 +47,8 @@ Every functional change must update this file **in the same PR**.
 - `/forgot-password` redirects to `/login?forgot=1` (optionally `&email=`) to surface the forgot-password modal on the unified login page.
 - The login page uses the auth-only layout: flashes render centered above the auth card, auto-fade after ~3 seconds with no manual close, and modal spacing matches auth inputs (email field full-width) for visual alignment.
 - The login page's “Forgot password?” link keeps KT primary coloring, adds underline + focus-outline feedback on hover/focus, and maintains AA contrast (visited state included) without shifting layout.
+- Save-required forms include `data-dirty-guard="true"`, enabling `app/static/js/dirty_guard.js` to warn about unsaved changes; elements or auxiliary forms that should bypass the prompt must include `data-dirty-guard-bypass="true"`.
+- GET filter forms tagged `data-autofilter="true"` auto-submit on change/typing via `app/static/js/auto_filter.js`; templates surface a left-aligned “Clear all filters” link (use `macros/filters.clear_filters_link`) that points to the route without query parameters.
 
 ## 0.4 App Conventions & PR Hygiene
 - Keep migrations idempotent and reversible; guard enum/DDL changes carefully.

--- a/app/static/js/auto_filter.js
+++ b/app/static/js/auto_filter.js
@@ -1,0 +1,240 @@
+(function () {
+  const DEFAULT_DEBOUNCE = 400;
+  const TEXT_INPUT_TYPES = new Set([
+    'text',
+    'search',
+    'email',
+    'tel',
+    'number',
+    'url',
+    'password',
+  ]);
+
+  function shouldDebounceInput(element) {
+    const tag = (element.tagName || '').toLowerCase();
+    if (tag === 'textarea') {
+      return true;
+    }
+    const type = (element.type || '').toLowerCase();
+    if (TEXT_INPUT_TYPES.has(type) || type === '') {
+      return true;
+    }
+    return false;
+  }
+
+  function createURL(action) {
+    if (typeof window === 'undefined') {
+      return null;
+    }
+    const base = action || window.location.href;
+    try {
+      return new URL(base, window.location.href);
+    } catch (err) {
+      return null;
+    }
+  }
+
+  class AutoFilterForm {
+    constructor(form, options = {}) {
+      this.form = form;
+      this.debounceMs = options.debounceMs || DEFAULT_DEBOUNCE;
+      this.timer = null;
+      this.handleChange = this.handleChange.bind(this);
+      this.handleInput = this.handleInput.bind(this);
+      this.handleKeyDown = this.handleKeyDown.bind(this);
+      this.handleSubmit = this.handleSubmit.bind(this);
+      this.attach();
+    }
+
+    attach() {
+      const elements = Array.from(this.form.elements || []);
+      for (const el of elements) {
+        if (!el || !el.name || el.disabled) {
+          continue;
+        }
+        const tag = (el.tagName || '').toLowerCase();
+        const type = (el.type || '').toLowerCase();
+        if (tag === 'select' || type === 'checkbox' || type === 'radio') {
+          el.addEventListener('change', this.handleChange);
+        } else if (shouldDebounceInput(el)) {
+          el.addEventListener('input', this.handleInput);
+          el.addEventListener('change', this.handleChange);
+          el.addEventListener('keydown', this.handleKeyDown);
+        } else {
+          el.addEventListener('change', this.handleChange);
+        }
+      }
+      this.form.addEventListener('submit', this.handleSubmit);
+    }
+
+    handleSubmit(event) {
+      if (event) {
+        event.preventDefault();
+      }
+      this.submitNow();
+    }
+
+    handleChange() {
+      this.submitNow();
+    }
+
+    handleInput() {
+      this.scheduleSubmit();
+    }
+
+    handleKeyDown(event) {
+      if (event && event.key === 'Enter') {
+        event.preventDefault();
+        this.submitNow();
+      }
+    }
+
+    scheduleSubmit() {
+      if (this.timer) {
+        clearTimeout(this.timer);
+      }
+      this.timer = setTimeout(() => {
+        this.timer = null;
+        this.submitNow();
+      }, this.debounceMs);
+    }
+
+    submitNow() {
+      if (this.timer) {
+        clearTimeout(this.timer);
+        this.timer = null;
+      }
+      const targetUrl = this.buildTargetUrl();
+      if (!targetUrl || typeof window === 'undefined') {
+        return;
+      }
+      const current = window.location ? window.location.href : null;
+      if (current === targetUrl) {
+        return;
+      }
+      if (window.location && typeof window.location.assign === 'function') {
+        window.location.assign(targetUrl);
+      } else if (window.location) {
+        window.location.href = targetUrl;
+      }
+    }
+
+    buildTargetUrl() {
+      if (typeof window === 'undefined') {
+        return null;
+      }
+      const currentUrl = createURL(window.location.href);
+      if (!currentUrl) {
+        return null;
+      }
+      const actionAttr = this.form.getAttribute('action');
+      const baseUrl = createURL(actionAttr || currentUrl.pathname);
+      if (!baseUrl) {
+        return null;
+      }
+      const params = new URLSearchParams(currentUrl.search);
+      const elements = Array.from(this.form.elements || []).filter((el) => el && el.name && !el.disabled);
+      const names = new Set(elements.map((el) => el.name));
+      for (const name of names) {
+        params.delete(name);
+      }
+      const grouped = new Map();
+      for (const el of elements) {
+        const name = el.name;
+        const tag = (el.tagName || '').toLowerCase();
+        const type = (el.type || '').toLowerCase();
+        if (type === 'checkbox' || type === 'radio') {
+          if (!el.checked) {
+            continue;
+          }
+          this.addGroupedValue(grouped, name, el.value ?? 'on');
+          continue;
+        }
+        if (tag === 'select' && el.multiple) {
+          const options = Array.from(el.options || []);
+          let added = false;
+          for (const option of options) {
+            if (option.selected && option.value !== '') {
+              this.addGroupedValue(grouped, name, option.value);
+              added = true;
+            }
+          }
+          if (!added) {
+            // No selection means clearing the parameter.
+          }
+          continue;
+        }
+        const value = el.value ?? '';
+        if (value === '') {
+          continue;
+        }
+        this.addGroupedValue(grouped, name, value);
+      }
+      for (const [name, values] of grouped.entries()) {
+        if (!values.length) {
+          continue;
+        }
+        params.delete(name);
+        for (const value of values) {
+          params.append(name, value);
+        }
+      }
+      const serialized = params.toString();
+      baseUrl.search = serialized ? `?${serialized}` : '';
+      return baseUrl.toString();
+    }
+
+    addGroupedValue(grouped, name, value) {
+      if (!grouped.has(name)) {
+        grouped.set(name, []);
+      }
+      grouped.get(name).push(value);
+    }
+  }
+
+  class AutoFilterManager {
+    constructor() {
+      this.instances = new Set();
+    }
+
+    register(form, options) {
+      const instance = new AutoFilterForm(form, options);
+      this.instances.add(instance);
+      return instance;
+    }
+
+    initFromDocument() {
+      if (typeof document === 'undefined') {
+        return;
+      }
+      const forms = document.querySelectorAll('form[data-autofilter="true"][method="get" i]');
+      forms.forEach((form) => {
+        this.register(form, {});
+      });
+    }
+  }
+
+  const manager = new AutoFilterManager();
+
+  const api = {
+    manager,
+    AutoFilterForm,
+    registerForm(form, options) {
+      return manager.register(form, options);
+    },
+    init() {
+      manager.initFromDocument();
+    },
+  };
+
+  if (typeof window !== 'undefined') {
+    window.CBSAutoFilter = api;
+    if (typeof document !== 'undefined') {
+      if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', () => manager.initFromDocument());
+      } else {
+        manager.initFromDocument();
+      }
+    }
+  }
+})();

--- a/app/static/js/dirty_guard.js
+++ b/app/static/js/dirty_guard.js
@@ -1,0 +1,291 @@
+(function () {
+  const CONFIRM_MESSAGE = 'You have unsaved changes. Leave without saving?';
+
+  function serializeForm(form) {
+    const pairs = [];
+    const elements = Array.from(form.elements || []);
+    for (const el of elements) {
+      if (!el || !el.name || el.disabled) {
+        continue;
+      }
+      const name = el.name;
+      const type = (el.type || '').toLowerCase();
+      if (type === 'checkbox' || type === 'radio') {
+        if (!el.checked) {
+          continue;
+        }
+        pairs.push([name, el.value ?? 'on']);
+        continue;
+      }
+      if (type === 'select-multiple') {
+        const options = Array.from(el.options || []);
+        for (const option of options) {
+          if (option.selected) {
+            pairs.push([name, option.value]);
+          }
+        }
+        continue;
+      }
+      pairs.push([name, el.value ?? '']);
+    }
+    pairs.sort((a, b) => {
+      if (a[0] === b[0]) {
+        return a[1] < b[1] ? -1 : a[1] > b[1] ? 1 : 0;
+      }
+      return a[0] < b[0] ? -1 : 1;
+    });
+    return JSON.stringify(pairs);
+  }
+
+  class DirtyForm {
+    constructor(form, options = {}) {
+      this.form = form;
+      this.serialize = options.serialize || (() => serializeForm(this.form));
+      this.onDirtyChange = options.onDirtyChange || function () {};
+      this.isSubmitting = false;
+      this.isDirty = false;
+      this.initialState = this.serialize();
+      this.handleMutation = this.handleMutation.bind(this);
+      this.handleSubmit = this.handleSubmit.bind(this);
+      this.handleReset = this.handleReset.bind(this);
+      form.addEventListener('input', this.handleMutation, true);
+      form.addEventListener('change', this.handleMutation, true);
+      form.addEventListener('submit', this.handleSubmit);
+      form.addEventListener('reset', this.handleReset);
+    }
+
+    checkDirty() {
+      const current = this.serialize();
+      const isDirty = current !== this.initialState;
+      if (isDirty !== this.isDirty) {
+        this.isDirty = isDirty;
+        this.onDirtyChange(isDirty, this);
+      }
+      return this.isDirty;
+    }
+
+    handleMutation() {
+      if (this.isSubmitting) {
+        return;
+      }
+      this.checkDirty();
+    }
+
+    handleSubmit() {
+      this.isSubmitting = true;
+      this.markClean();
+      // Delay resetting submitting flag to allow navigation flow to finish.
+      setTimeout(() => {
+        this.isSubmitting = false;
+      }, 0);
+    }
+
+    handleReset() {
+      setTimeout(() => {
+        this.markClean();
+      }, 0);
+    }
+
+    markClean() {
+      this.initialState = this.serialize();
+      if (this.isDirty) {
+        this.isDirty = false;
+        this.onDirtyChange(false, this);
+      }
+    }
+  }
+
+  class DirtyGuardManager {
+    constructor() {
+      this.instances = new Map();
+      this.suppressPrompt = false;
+      this.beforeUnloadHandler = (event) => {
+        if (this.shouldPrompt()) {
+          event.preventDefault();
+          event.returnValue = '';
+          return '';
+        }
+        return undefined;
+      };
+      this.handleDocumentClick = this.handleDocumentClick.bind(this);
+      this.handleBypassSubmit = this.handleBypassSubmit.bind(this);
+      if (typeof document !== 'undefined') {
+        document.addEventListener('click', this.handleDocumentClick, true);
+        document.addEventListener('submit', this.handleBypassSubmit, true);
+      }
+    }
+
+    register(form, options) {
+      if (this.instances.has(form)) {
+        return this.instances.get(form);
+      }
+      const tracked = new DirtyForm(form, {
+        ...options,
+        onDirtyChange: () => {
+          this.updateBeforeUnload();
+        },
+      });
+      this.instances.set(form, tracked);
+      this.updateBeforeUnload();
+      return tracked;
+    }
+
+    unregister(form) {
+      if (!this.instances.has(form)) {
+        return;
+      }
+      const instance = this.instances.get(form);
+      form.removeEventListener('input', instance.handleMutation, true);
+      form.removeEventListener('change', instance.handleMutation, true);
+      form.removeEventListener('submit', instance.handleSubmit);
+      form.removeEventListener('reset', instance.handleReset);
+      this.instances.delete(form);
+      this.updateBeforeUnload();
+    }
+
+    hasDirtyForm() {
+      for (const instance of this.instances.values()) {
+        if (instance.isDirty && !instance.isSubmitting) {
+          return true;
+        }
+      }
+      return false;
+    }
+
+    shouldPrompt() {
+      if (this.suppressPrompt) {
+        return false;
+      }
+      return this.hasDirtyForm();
+    }
+
+    updateBeforeUnload() {
+      if (typeof window === 'undefined') {
+        return;
+      }
+      if (this.shouldPrompt()) {
+        window.addEventListener('beforeunload', this.beforeUnloadHandler);
+      } else {
+        window.removeEventListener('beforeunload', this.beforeUnloadHandler);
+      }
+    }
+
+    confirmNavigation() {
+      if (!this.shouldPrompt()) {
+        return true;
+      }
+      const confirmFn = (typeof window !== 'undefined' && window.confirm) || (() => true);
+      const ok = !!confirmFn(CONFIRM_MESSAGE);
+      if (ok) {
+        this.suppressNextPrompt();
+      }
+      return ok;
+    }
+
+    suppressNextPrompt() {
+      this.suppressPrompt = true;
+      setTimeout(() => {
+        this.suppressPrompt = false;
+      }, 0);
+    }
+
+    handleDocumentClick(event) {
+      const target = event.target;
+      if (!target) {
+        return;
+      }
+      const bypassEl = this.findClosestAttr(target, 'data-dirty-guard-bypass');
+      if (bypassEl) {
+        this.suppressNextPrompt();
+        return;
+      }
+      const anchor = this.findClosestAnchor(target);
+      if (!anchor) {
+        return;
+      }
+      if (anchor.target && anchor.target.toLowerCase() === '_blank') {
+        return;
+      }
+      const href = anchor.getAttribute('href');
+      if (!href || href.startsWith('#')) {
+        return;
+      }
+      if (!this.shouldPrompt()) {
+        return;
+      }
+      const ok = this.confirmNavigation();
+      if (!ok) {
+        event.preventDefault();
+        event.stopImmediatePropagation();
+      }
+    }
+
+    handleBypassSubmit(event) {
+      const target = event.target;
+      if (!target) {
+        return;
+      }
+      if (
+        typeof HTMLFormElement !== 'undefined' &&
+        target instanceof HTMLFormElement &&
+        target.hasAttribute('data-dirty-guard-bypass')
+      ) {
+        this.suppressNextPrompt();
+      }
+    }
+
+    findClosestAnchor(start) {
+      let el = start;
+      while (el && el !== document) {
+        if (typeof el.tagName === 'string' && el.tagName.toLowerCase() === 'a' && el.hasAttribute('href')) {
+          return el;
+        }
+        el = el.parentNode || el.parentElement;
+      }
+      return null;
+    }
+
+    findClosestAttr(start, attr) {
+      let el = start;
+      while (el && el !== document) {
+        if (el.hasAttribute && el.hasAttribute(attr)) {
+          return el;
+        }
+        el = el.parentNode || el.parentElement;
+      }
+      return null;
+    }
+
+    initFromDocument() {
+      if (typeof document === 'undefined') {
+        return;
+      }
+      const forms = document.querySelectorAll('form[data-dirty-guard="true"]');
+      forms.forEach((form) => this.register(form));
+    }
+  }
+
+  const manager = new DirtyGuardManager();
+
+  const api = {
+    manager,
+    DirtyForm,
+    registerForm(form, options) {
+      return manager.register(form, options);
+    },
+    init() {
+      manager.initFromDocument();
+    },
+  };
+
+  if (typeof window !== 'undefined') {
+    window.CBSDirtyGuard = api;
+    if (typeof document !== 'undefined') {
+      if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', () => manager.initFromDocument());
+      } else {
+        manager.initFromDocument();
+      }
+    }
+  }
+})();

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -58,5 +58,8 @@
     {% block content %}{% endblock %}
   </main>
 </body>
-{% block extra_js %}{% endblock %}
+{% block extra_js %}
+  <script src="{{ url_for('static', filename='js/auto_filter.js') }}" defer></script>
+  <script src="{{ url_for('static', filename='js/dirty_guard.js') }}" defer></script>
+{% endblock %}
 </html>

--- a/app/templates/clients/form.html
+++ b/app/templates/clients/form.html
@@ -3,7 +3,7 @@
 {% block content %}
 <h1>{{ 'New Client' if not client else 'Edit Client' }}</h1>
 {% if next_url %}<p><a href="{{ next_url }}">Return</a></p>{% endif %}
-<form method="post">
+<form method="post" data-dirty-guard="true">
   {% if next_url %}<input type="hidden" name="next" value="{{ next_url }}">{% endif %}
   <div><label>Name <input type="text" name="name" value="{{ client.name if client else '' }}" required></label></div>
   <div><label>SFC Link <input type="url" name="sfc_link" value="{{ client.sfc_link if client else '' }}"></label></div>

--- a/app/templates/macros/filters.html
+++ b/app/templates/macros/filters.html
@@ -1,0 +1,4 @@
+{% macro clear_filters_link(url=None, label='Clear all filters', classes='filter-clear') -%}
+  {% set target = url or request.path %}
+  <a href="{{ target }}" class="{{ classes }}">{{ label }}</a>
+{%- endmacro %}

--- a/app/templates/materials_orders.html
+++ b/app/templates/materials_orders.html
@@ -1,10 +1,11 @@
 {% extends 'base.html' %}
+{% from 'macros/filters.html' import clear_filters_link %}
 {% block title %}Materials Dashboard{% endblock %}
 {% block content %}
 {% set breadcrumbs = [{'href': url_for('home'), 'label': 'Home'}, {'label': 'Materials Dashboard'}] %}
 <h1>Materials Dashboard</h1>
 {% include 'shared/_breadcrumbs.html' %}
-<form method="get">
+<form method="get" data-autofilter="true">
   <label>Client
     <select name="client_id">
       <option value="">All</option>
@@ -29,13 +30,14 @@
       {% endfor %}
     </select>
   </label>
-  <button type="submit">Filter</button>
   <input type="hidden" name="sort" value="{{ sort }}">
   <input type="hidden" name="dir" value="{{ dir }}">
   {% if workshop_status_param is not none %}
   <input type="hidden" name="workshop_status" value="{{ workshop_status_param }}">
   {% endif %}
 </form>
+
+<p class="filter-clear">{{ clear_filters_link(url_for('materials_orders.list_orders')) }}</p>
 
   {% if workshop_status_filter == 'not_closed' %}
     <a href="{{ url_for('materials_orders.list_orders', client_id=client_id, order_type=order_type, status=status, sort=sort, dir=dir, workshop_status='all') }}">Show closed sessions</a>

--- a/app/templates/sessions.html
+++ b/app/templates/sessions.html
@@ -1,4 +1,5 @@
 {% extends 'base.html' %}
+{% from 'macros/filters.html' import clear_filters_link %}
 {% block title %}Sessions{% endblock %}
 {% block content %}
 {% set breadcrumbs = [{'href': url_for('home'), 'label': 'Home'}, {'label': 'Workshops'}] %}
@@ -11,7 +12,7 @@
 <p><a href="{{ url_for('sessions.list_sessions', global=1) }}">Show Global Sessions</a></p>
 {% endif %}
 
-<form method="get">
+<form method="get" data-autofilter="true">
   <div>
     <input type="text" name="q" placeholder="Search" value="{{ params.get('q','') }}">
     <label>Status
@@ -47,9 +48,9 @@
   </div>
   <input type="hidden" name="sort" value="{{ sort }}">
   <input type="hidden" name="dir" value="{{ direction }}">
-  <button type="submit">Filter</button>
-  <a href="{{ url_for('sessions.list_sessions') }}">Clear</a>
 </form>
+
+<p class="filter-clear">{{ clear_filters_link(url_for('sessions.list_sessions')) }}</p>
 
 <p class="table-summary">Showing {{ total_sessions }} workshops</p>
 {% if not sessions %}

--- a/app/templates/sessions/form.html
+++ b/app/templates/sessions/form.html
@@ -2,7 +2,7 @@
 {% block title %}{{ 'New Session' if not session or not session.id else 'Edit Session' }}{% endblock %}
 {% block content %}
 <h1>{{ 'New Session' if not session or not session.id else 'Edit Session' }}</h1>
-<form method="post">
+<form method="post" data-dirty-guard="true">
   <div class="kt-card form-align session-form__section">
     <h2 class="kt-card-title">Order information</h2>
     {% set _title = title_override if title_override is not none else session.title %}

--- a/app/templates/settings_cert_templates/form.html
+++ b/app/templates/settings_cert_templates/form.html
@@ -2,7 +2,7 @@
 {% block title %}Certificate Series{% endblock %}
 {% block content %}
 <h1>{{ 'Edit' if series else 'New' }} Series</h1>
-<form method="post">
+<form method="post" data-dirty-guard="true">
   <div><label>Code <input type="text" name="code" value="{{ series.code if series else '' }}" {% if series %}readonly{% endif %}></label></div>
   <div><label>Name <input type="text" name="name" value="{{ series.name if series else '' }}"></label></div>
   <div><label><input type="checkbox" name="is_active" {% if not series or series.is_active %}checked{% endif %}> Active</label></div>

--- a/app/templates/settings_cert_templates/templates.html
+++ b/app/templates/settings_cert_templates/templates.html
@@ -85,16 +85,16 @@
 <h1>Template Mapping for {{ series.name }} ({{ series.code }})</h1>
 <div id="template-preview-config" data-preview-url="{{ url_for('settings_cert_templates.preview_series', series_id=series.id) }}" data-preview-token="{{ preview_csrf }}"></div>
 <div style="margin-bottom: 1em;">
-  <form method="post" action="{{ url_for('settings_cert_templates.upload_pdfs', series_id=series.id) }}" enctype="multipart/form-data" style="display:inline;">
-    <input type="file" id="pdf_files" name="files" accept=".pdf" multiple style="display:none" onchange="this.form.submit()">
-    <button type="button" onclick="document.getElementById('pdf_files').click()">Upload certificate templates (PDFs)</button>
+  <form method="post" action="{{ url_for('settings_cert_templates.upload_pdfs', series_id=series.id) }}" enctype="multipart/form-data" style="display:inline;" data-dirty-guard-bypass="true">
+    <input type="file" id="pdf_files" name="files" accept=".pdf" multiple style="display:none" onchange="this.form.submit()" data-dirty-guard-bypass="true">
+    <button type="button" onclick="document.getElementById('pdf_files').click()" data-dirty-guard-bypass="true">Upload certificate templates (PDFs)</button>
   </form>
-  <form method="post" action="{{ url_for('settings_cert_templates.upload_badges', series_id=series.id) }}" enctype="multipart/form-data" style="display:inline; margin-left: 0.5em;">
-    <input type="file" id="badge_files" name="files" accept=".webp" multiple style="display:none" onchange="this.form.submit()">
-    <button type="button" onclick="document.getElementById('badge_files').click()">Upload badges (WEBP)</button>
+  <form method="post" action="{{ url_for('settings_cert_templates.upload_badges', series_id=series.id) }}" enctype="multipart/form-data" style="display:inline; margin-left: 0.5em;" data-dirty-guard-bypass="true">
+    <input type="file" id="badge_files" name="files" accept=".webp" multiple style="display:none" onchange="this.form.submit()" data-dirty-guard-bypass="true">
+    <button type="button" onclick="document.getElementById('badge_files').click()" data-dirty-guard-bypass="true">Upload badges (WEBP)</button>
   </form>
 </div>
-<form method="post">
+<form method="post" data-dirty-guard="true">
   <input type="hidden" name="csrf_token" value="{{ preview_csrf }}">
   <div class="kt-table-wrapper">
     <table class="kt-table">

--- a/app/templates/settings_languages/form.html
+++ b/app/templates/settings_languages/form.html
@@ -2,7 +2,7 @@
 {% block title %}Languages{% endblock %}
 {% block content %}
 <h1>{{ 'Edit' if lang else 'New' }} Language</h1>
-<form method="post">
+<form method="post" data-dirty-guard="true">
   <div>Name:
     <input type="text" name="name" value="{{ lang.name if lang else '' }}" maxlength="120">
   </div>

--- a/app/templates/settings_mail.html
+++ b/app/templates/settings_mail.html
@@ -5,7 +5,7 @@
 <h1 class="kt-card-title">Mail & Notification</h1>
 <h2>SMTP Settings</h2>
 <p>Updated: {{ settings.updated_at }}</p>
-<form method="post">
+<form method="post" data-dirty-guard="true">
   <label>SMTP Host
   <input type="text" name="smtp_host" value="{{ settings.smtp_host or '' }}" autocomplete="off"></label>
   <label>SMTP Port
@@ -22,14 +22,14 @@
   <label><input type="checkbox" name="use_ssl" {% if settings.use_ssl %}checked{% endif %}> Use SSL</label>
   <button type="submit">Save</button>
 </form>
-<form method="post" action="{{ url_for('settings_mail.test_send') }}">
-  <button type="submit">Send test email</button>
+<form method="post" action="{{ url_for('settings_mail.test_send') }}" data-dirty-guard-bypass="true">
+  <button type="submit" data-dirty-guard-bypass="true">Send test email</button>
 </form>
 
 <h2>Processors</h2>
 <p>Assign processors per region and processing type.</p>
 <p class="form-help">Emails for materials orders are sent to the processors listed here, by Region and Processing Type.</p>
-<form method="post" action="{{ url_for('settings_mail.save_processors') }}" id="proc-form">
+<form method="post" action="{{ url_for('settings_mail.save_processors') }}" id="proc-form" data-dirty-guard="true">
   <div class="kt-table-wrapper">
     <table class="kt-table">
       <thead>

--- a/app/templates/settings_materials/form.html
+++ b/app/templates/settings_materials/form.html
@@ -2,7 +2,7 @@
 {% block title %}{{ label }} Materials{% endblock %}
 {% block content %}
 <h1>{{ label }} Materials</h1>
-<form method="post">
+<form method="post" data-dirty-guard="true">
   <div>Title:
     <input type="text" name="title" value="{{ opt.title if opt else '' }}" maxlength="160">
   </div>

--- a/app/templates/settings_resources/form.html
+++ b/app/templates/settings_resources/form.html
@@ -6,7 +6,7 @@
 {% endblock %}
 {% block content %}
 <h1>{% if resource %}Edit{% else %}New{% endif %} Resource</h1>
-<form method="post" enctype="multipart/form-data">
+<form method="post" enctype="multipart/form-data" data-dirty-guard="true">
   <label>Name <input type="text" name="name" value="{{ resource.name if resource else '' }}"></label><br>
   <label>Type
     <select name="type">

--- a/app/templates/settings_resources/list.html
+++ b/app/templates/settings_resources/list.html
@@ -1,10 +1,11 @@
 {% extends 'base.html' %}
+{% from 'macros/filters.html' import clear_filters_link %}
 {% block title %}Resources{% endblock %}
 {% block content %}
 <div class="kt-card">
 <h1 class="kt-card-title">Resources</h1>
 <p><a href="{{ url_for('settings_resources.new_resource') }}">New Resource</a></p>
-<form method="get" class="filters">
+<form method="get" class="filters" data-autofilter="true">
   <div class="filter-row">
     <label>Audience
       <select name="audience">
@@ -22,10 +23,9 @@
         {% endfor %}
       </select>
     </label>
-    <button type="submit" class="btn btn-secondary btn-sm">Filter</button>
-    <a href="{{ url_for('settings_resources.list_resources') }}" class="btn btn-link">Clear</a>
   </div>
 </form>
+<p class="filter-clear">{{ clear_filters_link(url_for('settings_resources.list_resources'), classes='btn btn-link') }}</p>
 <div class="kt-table-wrapper">
   <table class="kt-table">
     <thead>

--- a/app/templates/users/list.html
+++ b/app/templates/users/list.html
@@ -1,4 +1,5 @@
 {% extends 'base.html' %}
+{% from 'macros/filters.html' import clear_filters_link %}
 {% block title %}Users{% endblock %}
 {% block content %}
 {% set breadcrumbs = [{'href': url_for('home'), 'label': 'Home'}, {'label': 'Users'}] %}
@@ -6,7 +7,7 @@
 {% include 'shared/_breadcrumbs.html' %}
 <p><a class="btn btn-success" href="{{ url_for('users.new_user') }}">New User</a> | <a href="#" id="role-matrix-link">Role Matrix</a></p>
 
-<form method="get" action="{{ url_for('users.list_users') }}">
+<form method="get" action="{{ url_for('users.list_users') }}" data-autofilter="true">
   <input type="text" name="q" value="{{ q }}" placeholder="Search" autocomplete="off">
   <select name="region" autocomplete="off">
     <option value="" {% if not region %}selected{% endif %}>All Regions</option>
@@ -15,10 +16,11 @@
     <option value="SEA" {% if region=='SEA' %}selected{% endif %}>SEA</option>
     <option value="Other" {% if region=='Other' %}selected{% endif %}>Other</option>
   </select>
-  <button type="submit">Filter</button>
 </form>
 
-<form method="post" action="{{ url_for('users.bulk_update') }}">
+<p class="filter-clear">{{ clear_filters_link(url_for('users.list_users')) }}</p>
+
+<form method="post" action="{{ url_for('users.bulk_update') }}" data-dirty-guard="true">
 <div class="kt-table-wrapper">
   <table class="kt-table">
     <thead>

--- a/app/templates/workshop_types/form.html
+++ b/app/templates/workshop_types/form.html
@@ -8,7 +8,7 @@
 {% else %}
 <h1>New Workshop Type</h1>
 {% endif %}
-<form method="post">
+<form method="post" data-dirty-guard="true">
   <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
   {% include 'workshop_types/_fields.html' %}
   {% include 'workshop_types/_defaults_table.html' %}

--- a/tests/js/auto_filter.test.js
+++ b/tests/js/auto_filter.test.js
@@ -1,0 +1,187 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+const assert = require('assert');
+
+class FakeField {
+  constructor(name, value, options = {}) {
+    this.name = name;
+    this.value = value;
+    this.disabled = false;
+    this.type = options.type || 'text';
+    this.tagName = options.tagName || 'INPUT';
+    this.checked = options.checked || false;
+    this.multiple = options.multiple || false;
+    this.options = options.options || [];
+    this._listeners = {};
+  }
+
+  addEventListener(type, handler) {
+    if (!this._listeners[type]) {
+      this._listeners[type] = [];
+    }
+    this._listeners[type].push(handler);
+  }
+
+  dispatch(type, event = {}) {
+    const handlers = this._listeners[type] || [];
+    const evt = {
+      target: this,
+      preventDefault: () => {},
+      stopImmediatePropagation: () => {},
+      ...event,
+    };
+    handlers.forEach((handler) => handler(evt));
+    return evt;
+  }
+}
+
+class FakeForm {
+  constructor(options = {}) {
+    this.elements = [];
+    this._listeners = {};
+    this.attributes = {};
+    this.method = (options.method || 'get').toLowerCase();
+    if (options.action) {
+      this.attributes.action = options.action;
+    }
+  }
+
+  addEventListener(type, handler) {
+    if (!this._listeners[type]) {
+      this._listeners[type] = [];
+    }
+    this._listeners[type].push(handler);
+  }
+
+  dispatch(type, event = {}) {
+    const handlers = this._listeners[type] || [];
+    const evt = {
+      target: event.target || this,
+      preventDefault: () => {},
+      stopImmediatePropagation: () => {},
+      ...event,
+    };
+    handlers.forEach((handler) => handler(evt));
+    return evt;
+  }
+
+  getAttribute(name) {
+    if (name === 'method') {
+      return this.method;
+    }
+    return this.attributes[name] || null;
+  }
+}
+
+function createContext() {
+  const document = {
+    readyState: 'complete',
+    addEventListener() {},
+    querySelectorAll() {
+      return [];
+    },
+  };
+  const locationCalls = [];
+  const window = {
+    location: {
+      href: 'https://example.com/',
+      assign(url) {
+        locationCalls.push(url);
+        this.href = url;
+      },
+    },
+    addEventListener() {},
+    removeEventListener() {},
+  };
+  const sandbox = {
+    window,
+    document,
+    console,
+    setTimeout,
+    clearTimeout,
+    URL,
+    URLSearchParams,
+  };
+  sandbox.globalThis = sandbox;
+  sandbox.__locationCalls = locationCalls;
+  return sandbox;
+}
+
+async function run() {
+  const sandbox = createContext();
+  const codePath = path.join(__dirname, '..', '..', 'app', 'static', 'js', 'auto_filter.js');
+  const code = fs.readFileSync(codePath, 'utf8');
+  vm.createContext(sandbox);
+  vm.runInContext(code, sandbox);
+
+  const autoFilter = sandbox.window.CBSAutoFilter;
+  assert.ok(autoFilter, 'Auto filter API should be present');
+
+  // Test immediate select change submits with preserved params.
+  sandbox.window.location.href = 'https://example.com/users?page=2';
+  sandbox.__locationCalls.length = 0;
+  const selectField = new FakeField('region', '', { tagName: 'SELECT', type: 'select-one' });
+  selectField.options = [
+    { value: '', selected: true },
+    { value: 'EU', selected: false },
+  ];
+  const selectForm = new FakeForm({ action: 'https://example.com/users', method: 'get' });
+  selectForm.elements = [selectField];
+  autoFilter.registerForm(selectForm, {});
+  selectField.value = 'EU';
+  selectField.options[0].selected = false;
+  selectField.options[1].selected = true;
+  selectField.dispatch('change');
+  assert.strictEqual(sandbox.__locationCalls.length, 1, 'Select change triggers submit');
+  assert.strictEqual(
+    sandbox.__locationCalls[0],
+    'https://example.com/users?page=2&region=EU',
+    'Existing params preserved and new one added'
+  );
+
+  // Test debounced text input and clearing value.
+  sandbox.window.location.href = 'https://example.com/materials?status=open';
+  sandbox.__locationCalls.length = 0;
+  const textField = new FakeField('q', '', { type: 'text', tagName: 'INPUT' });
+  const textForm = new FakeForm({ action: 'https://example.com/materials', method: 'get' });
+  textForm.elements = [textField];
+  autoFilter.registerForm(textForm, { debounceMs: 50 });
+  textField.value = 'kits';
+  textField.dispatch('input');
+  await new Promise((resolve) => setTimeout(resolve, 30));
+  assert.strictEqual(sandbox.__locationCalls.length, 0, 'Debounce prevents early submit');
+  await new Promise((resolve) => setTimeout(resolve, 40));
+  assert.strictEqual(sandbox.__locationCalls.length, 1, 'Debounce elapsed triggers submit');
+  assert.strictEqual(
+    sandbox.__locationCalls[0],
+    'https://example.com/materials?status=open&q=kits',
+    'Query appended alongside preserved params'
+  );
+
+  sandbox.__locationCalls.length = 0;
+  textField.value = '';
+  textField.dispatch('input');
+  await new Promise((resolve) => setTimeout(resolve, 60));
+  assert.strictEqual(
+    sandbox.__locationCalls[0],
+    'https://example.com/materials?status=open',
+    'Clearing input removes parameter'
+  );
+
+  // Test pressing Enter submits immediately.
+  sandbox.__locationCalls.length = 0;
+  textField.value = 'rush';
+  textField.dispatch('keydown', { key: 'Enter' });
+  assert.strictEqual(sandbox.__locationCalls.length, 1, 'Enter key triggers immediate submit');
+  assert.strictEqual(
+    sandbox.__locationCalls[0],
+    'https://example.com/materials?status=open&q=rush',
+    'Enter submission sets current value'
+  );
+}
+
+run().catch((err) => {
+  console.error(err);
+  process.exitCode = 1;
+});

--- a/tests/js/dirty_guard.test.js
+++ b/tests/js/dirty_guard.test.js
@@ -1,0 +1,170 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+const assert = require('assert');
+
+class FakeField {
+  constructor(name, value, options = {}) {
+    this.name = name;
+    this.value = value;
+    this.disabled = false;
+    this.type = options.type || 'text';
+    this.tagName = options.tagName || 'INPUT';
+    this.checked = options.checked || false;
+    this.multiple = options.multiple || false;
+    this.options = options.options || [];
+    this._listeners = {};
+  }
+
+  addEventListener(type, handler) {
+    if (!this._listeners[type]) {
+      this._listeners[type] = [];
+    }
+    this._listeners[type].push(handler);
+  }
+
+  removeEventListener(type, handler) {
+    if (!this._listeners[type]) {
+      return;
+    }
+    this._listeners[type] = this._listeners[type].filter((fn) => fn !== handler);
+  }
+
+  dispatch(type, event = {}) {
+    const handlers = this._listeners[type] || [];
+    const evt = {
+      target: this,
+      preventDefault: () => {},
+      stopImmediatePropagation: () => {},
+      ...event,
+    };
+    handlers.forEach((handler) => handler(evt));
+    return evt;
+  }
+}
+
+class FakeForm {
+  constructor(elements) {
+    this.elements = elements;
+    this._listeners = {};
+    this.attributes = {};
+  }
+
+  addEventListener(type, handler) {
+    if (!this._listeners[type]) {
+      this._listeners[type] = [];
+    }
+    this._listeners[type].push(handler);
+  }
+
+  removeEventListener(type, handler) {
+    if (!this._listeners[type]) {
+      return;
+    }
+    this._listeners[type] = this._listeners[type].filter((fn) => fn !== handler);
+  }
+
+  dispatch(type, event = {}) {
+    const handlers = this._listeners[type] || [];
+    const evt = {
+      target: event.target || this,
+      preventDefault: () => {},
+      stopImmediatePropagation: () => {},
+      ...event,
+    };
+    handlers.forEach((handler) => handler(evt));
+    return evt;
+  }
+
+  hasAttribute(name) {
+    return Object.prototype.hasOwnProperty.call(this.attributes, name);
+  }
+}
+
+function createContext() {
+  const windowListeners = new Map();
+  const window = {
+    _listeners: windowListeners,
+    location: { href: 'https://example.com/', assign() {}, replace() {} },
+    addEventListener(type, handler) {
+      if (!windowListeners.has(type)) {
+        windowListeners.set(type, new Set());
+      }
+      windowListeners.get(type).add(handler);
+    },
+    removeEventListener(type, handler) {
+      if (!windowListeners.has(type)) {
+        return;
+      }
+      windowListeners.get(type).delete(handler);
+      if (windowListeners.get(type).size === 0) {
+        windowListeners.delete(type);
+      }
+    },
+    confirm: () => true,
+  };
+  const document = {
+    readyState: 'complete',
+    addEventListener() {},
+    querySelectorAll() {
+      return [];
+    },
+  };
+  const sandbox = {
+    window,
+    document,
+    console,
+    setTimeout,
+    clearTimeout,
+    HTMLFormElement: FakeForm,
+  };
+  sandbox.globalThis = sandbox;
+  return sandbox;
+}
+
+async function run() {
+  const sandbox = createContext();
+  const codePath = path.join(__dirname, '..', '..', 'app', 'static', 'js', 'dirty_guard.js');
+  const code = fs.readFileSync(codePath, 'utf8');
+  vm.createContext(sandbox);
+  vm.runInContext(code, sandbox);
+
+  const guardApi = sandbox.window.CBSDirtyGuard;
+  assert.ok(guardApi, 'Dirty guard API should be available on window');
+
+  const field = new FakeField('name', 'original');
+  const form = new FakeForm([field]);
+  const tracked = guardApi.registerForm(form);
+  assert.strictEqual(tracked.isDirty, false, 'Form starts clean');
+  assert.strictEqual(guardApi.manager.hasDirtyForm(), false, 'Manager reports clean');
+
+  field.value = 'updated';
+  form.dispatch('input', { target: field });
+  assert.strictEqual(tracked.isDirty, true, 'Field change marks form dirty');
+  assert.strictEqual(guardApi.manager.hasDirtyForm(), true, 'Manager sees dirty form');
+  assert.strictEqual(sandbox.window._listeners.has('beforeunload'), true, 'beforeunload handler registered');
+
+  let confirmCalls = 0;
+  sandbox.window.confirm = () => {
+    confirmCalls += 1;
+    return false;
+  };
+  const confirmResult = guardApi.manager.confirmNavigation();
+  assert.strictEqual(confirmCalls, 1, 'Confirm dialog invoked');
+  assert.strictEqual(confirmResult, false, 'Navigation blocked when cancelled');
+
+  sandbox.window.confirm = () => true;
+  const confirmAllow = guardApi.manager.confirmNavigation();
+  assert.strictEqual(confirmAllow, true, 'Navigation proceeds when confirmed');
+
+  form.dispatch('submit');
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  assert.strictEqual(tracked.isDirty, false, 'Submitting clears dirty state');
+  assert.strictEqual(guardApi.manager.hasDirtyForm(), false, 'Manager reflects clean state');
+  assert.strictEqual(sandbox.window._listeners.has('beforeunload'), false, 'beforeunload handler removed');
+}
+
+run().catch((err) => {
+  console.error(err);
+  process.exitCode = 1;
+});

--- a/tests/test_frontend_behaviors.py
+++ b/tests/test_frontend_behaviors.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent
+
+
+def _run_node_test(script_name: str) -> None:
+    script_path = ROOT / "js" / script_name
+    result = subprocess.run(["node", str(script_path)], capture_output=True, text=True)
+    if result.returncode != 0:
+        output = result.stdout + "\n" + result.stderr
+        raise AssertionError(f"Node test {script_name} failed:\n{output.strip()}")
+
+
+def test_dirty_guard_js() -> None:
+    _run_node_test("dirty_guard.test.js")
+
+
+def test_auto_filter_js() -> None:
+    _run_node_test("auto_filter.test.js")


### PR DESCRIPTION
## Summary
- add shared `dirty_guard.js` and wire data-dirty-guard attributes to save-required forms so unsaved changes trigger a confirmation
- introduce `auto_filter.js` with a clear-filters macro and update list templates to auto-submit filters and expose a Clear all filters link
- add node-backed pytest hooks to exercise the new scripts and document the behaviors in CONTEXT

## Testing
- PYTHONPATH=. pytest

------
https://chatgpt.com/codex/tasks/task_e_68d42f6c3ac8832e87c4acb37b9b7de4