### PR TITLE
Align special instructions layout across forms

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -124,6 +124,7 @@ Every functional change must update this file **in the same PR**.
 - Single-line controls include default 10px horizontal and 8px vertical margins to keep adjacent fields separated; inline actions like "Add" or "Edit" links sit 8px away.
 - `.filters` and `.filter-row` provide optional flex wrapping with these gaps via `column-gap`/`row-gap`.
 - Date/datetime inputs use a compact global style (tight WebKit indicator spacing with the icon translated flush to the right edge, ~14ch width with a 160px cap) so fields stay narrow by default; add `.kt-date--wide` when a wider field is necessary. Their left padding is trimmed globally so text sits closer to the edge without affecting height or the calendar icon gutter.
+- `.form-align__control--wide` widens multiline fields (currently the session Notes and Materials Special instructions textareas) to ~640px on desktop while staying responsive below 576px.
 
 ## 0.9 Navigation & Breadcrumbs
 - Header and main navigation use `/static/css/nav.css` with `--kt-bg` background, `--kt-text`/`--kt-info` links, and Raleway headings.

--- a/app/static/css/forms.css
+++ b/app/static/css/forms.css
@@ -133,6 +133,19 @@ textarea {
   border-radius: var(--radius-md, 12px);
 }
 
+.form-align__control--wide > textarea,
+.form-align__control--wide > .form-align__static {
+  width: 640px;
+  max-width: 100%;
+}
+
+@media (max-width: 576px) {
+  .form-align__control--wide > textarea,
+  .form-align__control--wide > .form-align__static {
+    width: 100%;
+  }
+}
+
 input::placeholder,
 textarea::placeholder {
   color: var(--kt-muted);

--- a/app/templates/sessions/form.html
+++ b/app/templates/sessions/form.html
@@ -2,18 +2,6 @@
 {% block title %}{{ 'New Session' if not session or not session.id else 'Edit Session' }}{% endblock %}
 {% block extra_head %}
   {{ super() }}
-  <style>
-    #session-form .session-form__notes-row textarea {
-      width: 640px;
-      max-width: 100%;
-    }
-
-    @media (max-width: 576px) {
-      #session-form .session-form__notes-row textarea {
-        width: 100%;
-      }
-    }
-  </style>
 {% endblock %}
 {% block content %}
 <h1>{{ 'New Session' if not session or not session.id else 'Edit Session' }}</h1>
@@ -241,7 +229,7 @@
       </div>
       <div class="form-align__row session-form__notes-row">
         <label class="form-align__label" for="title">Notes & Special instructions</label>
-        <div class="form-align__control">
+        <div class="form-align__control form-align__control--wide">
           <textarea name="notes">{{ session.notes or '' }}</textarea>
         </div>
       </div>

--- a/app/templates/sessions/materials.html
+++ b/app/templates/sessions/materials.html
@@ -17,18 +17,6 @@
 </script>{% endblock %}
 {% block extra_head %}
   {{ super() }}
-  <style>
-    .materials-special-instructions textarea {
-      width: 640px;
-      max-width: 100%;
-    }
-
-    @media (max-width: 576px) {
-      .materials-special-instructions textarea {
-        width: 100%;
-      }
-    }
-  </style>
 {% endblock %}
 {% block content %}
 {% set facs = [] %}
@@ -208,9 +196,9 @@
         </div>
       </div>
     </div>
-    <div class="form-align__row form-align__row--top materials-special-instructions">
+    <div class="form-align__row form-align__row--top">
       <label class="form-align__label" for="special-instructions">Special instructions</label>
-      <div class="form-align__control">
+      <div class="form-align__control form-align__control--wide">
         {% if can_edit_materials_header('special_instructions', current_user, shipment) and not readonly %}
           <textarea id="special-instructions" name="special_instructions">{{ (form.get('special_instructions') if form else (shipment.special_instructions or '')) | trim }}</textarea>
         {% else %}


### PR DESCRIPTION
## Summary
- add a shared `.form-align__control--wide` helper for wide textareas in the form grid
- replace per-template inline styling with the shared helper on the session and materials forms
- document the new helper in CONTEXT.md for future UI work

## Testing
- PYTHONPATH=. pytest -q tests/test_materials_simulation.py::test_apply_defaults_preserves_shipping_fields

------
https://chatgpt.com/codex/tasks/task_e_68d471a64fb8832e9b875e1bb0826790