### PR TITLE
Align materials special instructions textarea

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -624,3 +624,4 @@ Route inventory lives at `sitemap.txt` (admin-only, linked from Settings) and li
 - Session create/edit forms filter workshop locations based on delivery type: Onsite shows onsite-only, Virtual shows virtual-only, incompatible selections are cleared, and an inline notice surfaces when no locations match.
 - Shared welcome partial now splits display names via Python `.split()` to avoid the unavailable Jinja `|split` filter while preserving graceful handling for empty or single-word names.
 - Session create form keeps the Simulation Outline row aligned with adjacent fields when toggled for simulation-based workshops, and the Notes & Special instructions textarea now spans roughly 640px on desktop while remaining full-width on small screens.
+- Materials order Special instructions textarea uses the same wide alignment as the session form so its left edge matches other inputs.

--- a/app/templates/sessions/materials.html
+++ b/app/templates/sessions/materials.html
@@ -17,32 +17,6 @@
 </script>{% endblock %}
 {% block extra_head %}
   {{ super() }}
-  <style>
-    .materials-special-instructions {
-      align-items: flex-start;
-    }
-
-    .materials-special-instructions .form-align__label {
-      align-self: flex-start;
-    }
-
-    .materials-special-instructions .form-align__control {
-      flex: 1 1 0;
-      max-width: 640px;
-    }
-
-    .materials-special-instructions textarea {
-      width: 100%;
-
-      max-width: 100%;
-    }
-
-    @media (max-width: 576px) 
-      .materials-special-instructions .form-align__control {
-        max-width: 100%;
-      }
-    }
-  </style>
 {% endblock %}
 {% block content %}
 {% set facs = [] %}
@@ -222,7 +196,7 @@
         </div>
       </div>
     </div>
-    <div class="form-align__row materials-special-instructions">
+    <div class="form-align__row session-form__notes-row">
       <label class="form-align__label" for="special-instructions">Special instructions</label>
       <div class="form-align__control form-align__control--wide">
         {% if can_edit_materials_header('special_instructions', current_user, shipment) and not readonly %}


### PR DESCRIPTION
## Summary
- align the materials special instructions row with the standard form grid
- reuse the wide textarea styling from the session form and drop custom CSS
- document the materials textarea alignment in CONTEXT

## Testing
- PYTHONPATH=. pytest -q -m "smoke"


------
https://chatgpt.com/codex/tasks/task_e_68d4a0768ee0832e83b48eaf67a27983