### PR TITLE
Add certificate-only session handling and gating

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -627,3 +627,4 @@ Route inventory lives at `sitemap.txt` (admin-only, linked from Settings) and li
 - Session create form keeps the Simulation Outline row aligned with adjacent fields when toggled for simulation-based workshops, and the Notes & Special instructions textarea now spans roughly 640px on desktop while remaining full-width on small screens.
 - Materials order Special instructions textarea uses the same wide alignment as the session form so its left edge matches other inputs.
 - Materials order header cards (Order details + Shipping details) share a `.materials-header-grid` two-column layout that stacks below 1100px, and the shipping location dropdown lists each location's title only.
+- Certificate-only sessions (`delivery_type = "Certificate only"`) automatically flip Ready for delivery on create/edit, hide Materials and Prework navigation (including dashboards and lists), and continue to follow the existing attendance + certificate rules.

--- a/app/routes/learner.py
+++ b/app/routes/learner.py
@@ -262,7 +262,14 @@ def my_prework():
             "my_prework.html", assignments=[], active_nav="my-prework"
         )
     assignments = (
-        PreworkAssignment.query.filter_by(participant_account_id=account_id)
+        PreworkAssignment.query.outerjoin(
+            Session, Session.id == PreworkAssignment.session_id
+        )
+        .filter(PreworkAssignment.participant_account_id == account_id)
+        .filter(
+            func.lower(func.trim(func.coalesce(Session.delivery_type, "")))
+            != "certificate only"
+        )
         .order_by(PreworkAssignment.due_at)
         .all()
     )

--- a/app/routes/materials.py
+++ b/app/routes/materials.py
@@ -30,6 +30,7 @@ from ..shared.materials import material_format_choices
 from ..shared.languages import get_language_options
 from ..shared.sessions_lifecycle import (
     enforce_material_only_rules,
+    is_certificate_only_session,
     is_material_only_session,
 )
 from ..services.materials_notifications import notify_materials_processors
@@ -91,6 +92,8 @@ def materials_access(fn):
     def wrapper(session_id: int, *args, **kwargs):
         sess = db.session.get(Session, session_id)
         if not sess:
+            abort(404)
+        if is_certificate_only_session(sess):
             abort(404)
         user = None
         user_id = flask_session.get("user_id")

--- a/app/routes/materials_orders.py
+++ b/app/routes/materials_orders.py
@@ -137,6 +137,10 @@ def list_orders():
     elif workshop_status_filter == "Closed":
         query = query.filter(Session.status == "Closed")
     query = query.filter(Session.cancelled.is_(False))
+    query = query.filter(
+        func.lower(func.trim(func.coalesce(Session.delivery_type, "")))
+        != "certificate only"
+    )
 
     if client_id:
         query = query.filter(Session.client_id == client_id)

--- a/app/shared/sessions_lifecycle.py
+++ b/app/shared/sessions_lifecycle.py
@@ -5,13 +5,37 @@ from __future__ import annotations
 from typing import Any, Iterable, Sequence
 
 
+CERTIFICATE_ONLY_TYPE = "Certificate only"
+
+
+def _normalized_delivery_type(value: Any) -> str:
+    if isinstance(value, str):
+        return value.strip().lower()
+    return ""
+
+
+def is_certificate_only(session: Any) -> bool:
+    """Return True when the session represents a certificate-only engagement."""
+
+    if session is None:
+        return False
+    delivery_type = getattr(session, "delivery_type", None)
+    return _normalized_delivery_type(delivery_type) == CERTIFICATE_ONLY_TYPE.lower()
+
+
+def is_certificate_only_session(session: Any) -> bool:
+    """Backwards-compatible alias for older imports."""
+
+    return is_certificate_only(session)
+
+
 def is_material_only(session: Any) -> bool:
     """Return True when the session represents a material-only engagement."""
 
     if session is None:
         return False
     delivery_type = getattr(session, "delivery_type", None)
-    if isinstance(delivery_type, str) and delivery_type.strip().lower() == "material only":
+    if _normalized_delivery_type(delivery_type) == "material only":
         return True
     return bool(getattr(session, "materials_only", False))
 
@@ -56,6 +80,8 @@ def has_materials(
     """Return True when the session involves any materials activity."""
 
     if session is None:
+        return False
+    if is_certificate_only(session):
         return False
     if is_material_only(session):
         return True

--- a/app/templates/my_sessions.html
+++ b/app/templates/my_sessions.html
@@ -119,7 +119,7 @@
                 <a href="{{ url_for('learner.my_certs') }}">Certificate</a>
               {% elif s.start_date <= today %}
                 <a href="{{ url_for('learner.my_resources') }}">Resources</a>
-              {% elif assignment and assignment.status != 'WAIVED' %}
+              {% elif assignment and assignment.status != 'WAIVED' and (s.delivery_type|default('', true)|lower != 'certificate only') %}
                 <a href="{{ url_for('learner.my_prework') }}">Go to Prework</a>
               {% endif %}
             </td>

--- a/app/templates/session_detail.html
+++ b/app/templates/session_detail.html
@@ -8,6 +8,7 @@
 {% set delivery_label = session.delivery_type or '—' %}
 {% set status_label = session.computed_status %}
 {% set workshop_heading = session.id ~ ' ' ~ session.title ~ ': ' ~ workshop_code ~ ' (' ~ delivery_label ~ ') - ' ~ status_label %}
+{% set certificate_only = certificate_only_session|default(False) %}
 {% set import_input_id = 'participant-import-' ~ session.id %}
 <h1>{{ workshop_heading }}</h1>
 <p><a href="{{ url_for('sessions.list_sessions', **back_params) }}">Back to Sessions</a></p>
@@ -87,10 +88,12 @@
 </p>
 <nav class="kt-tabs">
   <a href="{{ url_for('sessions.session_detail', session_id=session.id) }}" aria-current="page">Details</a>
-  {% if not material_only_session and session.workshop_type and (current_user.is_app_admin or current_user.is_admin or current_user.is_kt_delivery or current_user.is_kt_contractor) %}
+  {% if not material_only_session and not certificate_only and session.workshop_type and (current_user.is_app_admin or current_user.is_admin or current_user.is_kt_delivery or current_user.is_kt_contractor) %}
   <a href="{{ url_for('sessions.session_prework', session_id=session.id) }}">Prework</a>
   {% endif %}
+  {% if not certificate_only %}
   <a href="{{ url_for('materials.materials_view', session_id=session.id) }}">Materials Order</a>
+  {% endif %}
 </nav>
 {% endif %}
 {% if not material_only_session %}

--- a/app/templates/sessions/form.html
+++ b/app/templates/sessions/form.html
@@ -107,7 +107,7 @@
         <div class="form-align__control">
           <select name="delivery_type" id="delivery-type" required>
             <option value="">--Select--</option>
-            {% for opt in ['Onsite','Virtual','Self-paced','Hybrid'] %}
+            {% for opt in ['Onsite','Virtual','Self-paced','Hybrid','Certificate only'] %}
             <option value="{{ opt }}" {% if session and session.delivery_type==opt %}selected{% endif %}>{{ opt }}</option>
             {% endfor %}
           </select>

--- a/app/templates/sessions/materials.html
+++ b/app/templates/sessions/materials.html
@@ -23,10 +23,11 @@
 {% set facs = [] %}
 {% if sess.lead_facilitator %}{% set _ = facs.append(sess.lead_facilitator) %}{% endif %}
 {% for fac in sess.facilitators %}{% set _ = facs.append(fac) %}{% endfor %}
+{% set certificate_only = (sess.delivery_type|default('', true)|lower == 'certificate only') %}
 <h1>Material Order {{ sess.id }} - {{ sess.title }} ({{ status }})</h1>
 <nav class="kt-tabs">
   <a href="{{ url_for('sessions.session_detail', session_id=sess.id) }}">Details</a>
-  {% if not sess.materials_only and sess.workshop_type %}
+  {% if not sess.materials_only and not certificate_only and sess.workshop_type %}
   <a href="{{ url_for('sessions.session_prework', session_id=sess.id) }}">Prework</a>
   {% endif %}
   <a href="{{ url_for('materials.materials_view', session_id=sess.id) }}" aria-current="page">Materials Order</a>

--- a/app/templates/sessions/prework.html
+++ b/app/templates/sessions/prework.html
@@ -2,10 +2,13 @@
 {% block title %}Prework - {{ session.title }}{% endblock %}
 {% block content %}
 <h1>Prework for {{ session.title }}</h1>
+{% set certificate_only = (session.delivery_type|default('', true)|lower == 'certificate only') %}
 <nav class="kt-tabs">
   <a href="{{ url_for('sessions.session_detail', session_id=session.id) }}">Details</a>
   <a href="{{ url_for('sessions.session_prework', session_id=session.id) }}" aria-current="page">Prework</a>
+  {% if not certificate_only %}
   <a href="{{ url_for('materials.materials_view', session_id=session.id) }}">Materials Order</a>
+  {% endif %}
 </nav>
 {% include "sessions/_prework_summary.html" %}
 <form method="post">

--- a/app/templates/sessions/workshop_view.html
+++ b/app/templates/sessions/workshop_view.html
@@ -4,6 +4,7 @@
 {% set delivery_label = session.delivery_type or '—' %}
 {% set status_label = session.computed_status %}
 {% set workshop_heading = session.id ~ ' ' ~ session.title ~ ': ' ~ workshop_code ~ ' (' ~ delivery_label ~ ') - ' ~ status_label %}
+{% set certificate_only = certificate_only_session|default(False) %}
 {% block title %}{{ workshop_heading }}{% endblock %}
 {% block content %}
 {% set highlight_lifecycle_fields = (not session.delivered) and (not session.finalized) %}
@@ -79,7 +80,7 @@
 <section class="kt-card" data-prework-container>
   <h2 class="kt-card-title">Participants</h2>
   <div class="prework-feedback" data-prework-feedback aria-live="polite"></div>
-  {% if show_disable_prework %}
+  {% if show_disable_prework and not certificate_only %}
   <div class="prework-toolbar" style="display:flex;flex-wrap:wrap;gap:var(--space-2);margin-bottom:var(--space-3);">
     <form action="{{ url_for('sessions.send_prework', session_id=session.id) }}" method="post" data-prework-send>
       <input type="hidden" name="next" value="{{ workshop_return }}">
@@ -94,7 +95,7 @@
       <button type="submit" class="btn btn-danger">No prework &amp; don&rsquo;t send accounts</button>
     </form>
   </div>
-  {% elif can_send_prework %}
+  {% elif can_send_prework and not certificate_only %}
   <form action="{{ url_for('sessions.send_prework', session_id=session.id) }}" method="post" style="margin-bottom: var(--space-3);" data-prework-send>
     <input type="hidden" name="next" value="{{ workshop_return }}">
     <button type="submit" class="btn btn-secondary">Send prework to all not submitted</button>

--- a/tests/test_certificate_only.py
+++ b/tests/test_certificate_only.py
@@ -1,0 +1,238 @@
+from datetime import date
+
+from app.app import db
+from app.models import (
+    Client,
+    Language,
+    MaterialOrderItem,
+    Session,
+    SessionShipping,
+    User,
+    WorkshopType,
+)
+
+
+def _seed_language():
+    if not Language.query.filter_by(name="English").first():
+        db.session.add(Language(name="English", sort_order=1))
+        db.session.flush()
+
+
+def _login(client, user_id):
+    with client.session_transaction() as sess:
+        sess["user_id"] = user_id
+
+
+def _base_form_payload(session: Session) -> dict[str, str]:
+    return {
+        "title": session.title,
+        "client_id": str(session.client_id),
+        "region": session.region,
+        "workshop_type_id": str(session.workshop_type_id or ""),
+        "delivery_type": session.delivery_type or "",
+        "workshop_language": session.workshop_language,
+        "capacity": str(session.capacity or 10),
+        "number_of_class_days": str(session.number_of_class_days or 1),
+        "start_date": session.start_date.isoformat() if session.start_date else date.today().isoformat(),
+        "end_date": session.end_date.isoformat() if session.end_date else date.today().isoformat(),
+        "daily_start_time": "08:00",
+        "daily_end_time": "17:00",
+        "timezone": session.timezone or "UTC",
+    }
+
+
+def test_certificate_only_session_autoready_on_create(app, client):
+    with app.app_context():
+        _seed_language()
+        admin = User(email="admin@example.com", is_admin=True)
+        admin.set_password("pw")
+        workshop_type = WorkshopType(code="WT", name="Workshop", cert_series="fn")
+        client_record = Client(name="Client", status="active")
+        db.session.add_all([admin, workshop_type, client_record])
+        db.session.commit()
+        admin_id = admin.id
+        wt_id = workshop_type.id
+        client_id = client_record.id
+
+    _login(client, admin_id)
+
+    payload = {
+        "title": "Certificate Session",
+        "client_id": str(client_id),
+        "region": "NA",
+        "workshop_type_id": str(wt_id),
+        "delivery_type": "Certificate only",
+        "workshop_language": "en",
+        "capacity": "15",
+        "number_of_class_days": "1",
+        "start_date": date.today().isoformat(),
+        "end_date": date.today().isoformat(),
+        "daily_start_time": "09:00",
+        "daily_end_time": "17:00",
+        "timezone": "UTC",
+    }
+
+    response = client.post("/sessions/new", data=payload, follow_redirects=False)
+    assert response.status_code == 302
+
+    with app.app_context():
+        created = Session.query.filter_by(title="Certificate Session").one()
+        assert created.ready_for_delivery is True
+        assert created.materials_ordered is False
+
+
+def test_certificate_only_edit_sets_ready(app, client):
+    with app.app_context():
+        _seed_language()
+        admin = User(email="admin@example.com", is_admin=True)
+        admin.set_password("pw")
+        workshop_type = WorkshopType(code="WT2", name="Workshop 2", cert_series="fn")
+        client_record = Client(name="Client", status="active")
+        session = Session(
+            title="Editable Session",
+            start_date=date.today(),
+            end_date=date.today(),
+            workshop_language="en",
+            region="NA",
+            number_of_class_days=1,
+            capacity=12,
+            delivery_type="Onsite",
+            ready_for_delivery=False,
+        )
+        session.client = client_record
+        session.workshop_type = workshop_type
+        db.session.add_all([admin, workshop_type, client_record, session])
+        db.session.commit()
+        admin_id = admin.id
+        session_id = session.id
+
+    _login(client, admin_id)
+
+    with app.app_context():
+        sess = db.session.get(Session, session_id)
+        payload = _base_form_payload(sess)
+        payload.update({
+            "delivery_type": "Certificate only",
+            "workshop_type_id": str(sess.workshop_type_id),
+            "client_id": str(sess.client_id),
+        })
+
+    response = client.post(
+        f"/sessions/{session_id}/edit",
+        data=payload,
+        follow_redirects=False,
+    )
+    assert response.status_code == 302
+
+    with app.app_context():
+        refreshed = db.session.get(Session, session_id)
+        assert refreshed.ready_for_delivery is True
+        assert refreshed.materials_ordered is False
+
+
+def test_certificate_only_blocks_materials_and_prework_routes(app, client):
+    with app.app_context():
+        _seed_language()
+        admin = User(email="admin@example.com", is_admin=True)
+        admin.set_password("pw")
+        workshop_type = WorkshopType(code="WT3", name="Workshop 3", cert_series="fn")
+        client_record = Client(name="Client", status="active")
+        session = Session(
+            title="Blocked Session",
+            start_date=date.today(),
+            end_date=date.today(),
+            workshop_language="en",
+            region="NA",
+            number_of_class_days=1,
+            capacity=10,
+            delivery_type="Certificate only",
+            ready_for_delivery=True,
+        )
+        session.client = client_record
+        session.workshop_type = workshop_type
+        db.session.add_all([admin, workshop_type, client_record, session])
+        db.session.commit()
+        admin_id = admin.id
+        session_id = session.id
+
+    _login(client, admin_id)
+
+    prework = client.get(
+        f"/sessions/{session_id}/prework", follow_redirects=False
+    )
+    assert prework.status_code == 302
+    assert prework.headers["Location"].endswith(f"/sessions/{session_id}")
+
+    materials = client.get(
+        f"/sessions/{session_id}/materials", follow_redirects=False
+    )
+    assert materials.status_code == 404
+
+
+def test_materials_dashboard_excludes_certificate_only(app, client):
+    with app.app_context():
+        _seed_language()
+        admin = User(email="admin@example.com", is_admin=True)
+        admin.set_password("pw")
+        wt = WorkshopType(code="WT4", name="Workshop 4", cert_series="fn")
+        client_record = Client(name="Client", status="active")
+        cert_session = Session(
+            title="Cert Materials",
+            start_date=date.today(),
+            end_date=date.today(),
+            workshop_language="en",
+            region="NA",
+            number_of_class_days=1,
+            capacity=8,
+            delivery_type="Certificate only",
+            ready_for_delivery=True,
+        )
+        cert_session.client = client_record
+        cert_session.workshop_type = wt
+        other_session = Session(
+            title="Regular Materials",
+            start_date=date.today(),
+            end_date=date.today(),
+            workshop_language="en",
+            region="NA",
+            number_of_class_days=1,
+            capacity=8,
+            delivery_type="Onsite",
+        )
+        other_session.client = client_record
+        other_session.workshop_type = wt
+        db.session.add_all([admin, wt, client_record, cert_session, other_session])
+        db.session.flush()
+        db.session.add_all(
+            [
+                SessionShipping(
+                    session_id=cert_session.id,
+                    order_type="KT-Run Standard materials",
+                ),
+                SessionShipping(
+                    session_id=other_session.id,
+                    order_type="KT-Run Standard materials",
+                ),
+                MaterialOrderItem(
+                    session_id=other_session.id,
+                    catalog_ref="manual:1",
+                    title_snapshot="Kit",
+                    quantity=1,
+                    language="en",
+                    format="Digital",
+                    processed=True,
+                ),
+            ]
+        )
+        db.session.commit()
+        admin_id = admin.id
+        cert_id = cert_session.id
+        other_id = other_session.id
+
+    _login(client, admin_id)
+
+    resp = client.get("/materials")
+    assert resp.status_code == 200
+    html = resp.get_data(as_text=True)
+    assert "Regular Materials" in html
+    assert "Cert Materials" not in html


### PR DESCRIPTION
## Summary
- add certificate-only detection in the shared session lifecycle helpers
- auto-mark certificate-only sessions ready for delivery and hide materials/prework UI and routes
- filter certificate-only sessions from dashboards and update context documentation and tests

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d552ee8648832eb4bcb44e87f9ee30