### PR TITLE
Add company field for session participants

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -303,13 +303,14 @@ Two separate tables by design; emails unique per table. If both tables hold the 
  - `simulation_outlines` (6-digit **number**, **skill** enum: Systematic Troubleshooting/Frontline/Risk/PSDMxp/Refresher/Custom, **descriptor**, **level** enum: Novice/Competent/Advanced)
 - `sessions` (fk workshop_type_id, optional fk simulation_outline_id, start_date, end_date, timezone, location fields, **paper_size** enum A4/LETTER, **workshop_language** enum en/es/fr/ja/de/nl/zh, notes, crm_notes, delivered_at, finalized_at, **no_prework**, **prework_disabled** (boolean), **prework_disable_mode** (`notify`/`silent`), **no_material_order**, optional **csa_participant_account_id**)
 - `session_facilitators` (m:n users↔sessions)
-- `session_participants` (m:n participant_accounts↔sessions + per-person status)
+- `session_participants` (m:n participant_accounts↔sessions + per-person status, `completion_date`, optional `company_name` TEXT per enrollment)
 
 ### Sessions – Staff shortcuts
 
 - Session Detail exposes a **Delivered** button in the header for staff with edit rights on non–material only sessions; it posts to mark the session delivered without opening the edit form.
 - The Participants card shows an **Export all certificates (zip)** button for staff, streaming a zip of existing certificate PDFs from `/srv/certificates/<year>/<session_id>/` without regenerating files.
-- Participant CSV import on Session Detail uses a single file chooser that auto-submits and preserves the existing success/error flash behavior.
+- Participant CSV import on Session Detail uses a single file chooser that auto-submits and preserves the existing success/error flash behavior; the importer accepts an optional `Company` column mapped to `session_participants.company_name` while keeping legacy headers working.
+- Participant tables on Session Detail and Workshop View include a Company column. Add/edit forms capture the field, and authorized viewers can update it inline per participant/session row.
 
 ## 3.2 Prework
 - `prework_templates` (by workshop type & language; rich text info; unique per `(workshop_type_id, language)`)

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -536,6 +536,7 @@ class SessionParticipant(db.Model):
         db.Integer, db.ForeignKey("participants.id", ondelete="CASCADE")
     )
     completion_date = db.Column(db.Date)
+    company_name = db.Column(db.Text)
     __table_args__ = (
         db.UniqueConstraint(
             "session_id", "participant_id", name="uix_session_participant"

--- a/app/templates/participant_edit.html
+++ b/app/templates/participant_edit.html
@@ -12,6 +12,7 @@
   <div><label>Last name <input type="text" name="last_name" value="{{ participant.last_name }}" required></label></div>
   <div><label>Full name <input type="text" value="{{ participant.display_name }}" readonly></label></div>
   <div><label>Title <input type="text" name="title" value="{{ participant.title }}"></label></div>
+  <div><label>Company <input type="text" name="company_name" value="{{ link.company_name or '' }}"></label></div>
   <button type="submit">Save</button>
 </form>
 <p><a href="{{ back_url }}">Back</a></p>

--- a/app/templates/session_detail.html
+++ b/app/templates/session_detail.html
@@ -121,6 +121,7 @@
     <input type="text" name="last_name" class="js-name-last" placeholder="Last name" required>
     <input type="email" name="email" placeholder="Email" required>
     <input type="text" name="title" placeholder="Title">
+    <input type="text" name="company_name" placeholder="Company">
     <button type="submit">Add Participant</button>
   </form>
   <form action="{{ url_for('sessions.import_csv', session_id=session.id) }}" method="post" enctype="multipart/form-data">
@@ -129,7 +130,7 @@
     <div class="inline-gap-sm">
       <label for="{{ import_input_id }}" class="btn">Import CSV</label>
       <a href="{{ url_for('sessions.sample_csv', session_id=session.id) }}">Download sample CSV</a>
-      <span class="form-align__help">Sample uses First &amp; Last name columns; legacy FullName is still accepted.</span>
+      <span class="form-align__help">Sample uses First &amp; Last name columns, includes an optional Company column, and legacy FullName is still accepted.</span>
     </div>
   </form>
   {% if import_errors %}
@@ -148,7 +149,7 @@
   <div class="kt-table-wrapper">
     <table class="kt-table">
       <thead>
-        <tr><th scope="col">Full Name</th><th scope="col">Email</th><th scope="col">Title</th><th scope="col">Certificate</th><th scope="col">Actions</th></tr>
+        <tr><th scope="col">Full Name</th><th scope="col">Email</th><th scope="col">Title</th><th scope="col">Company</th><th scope="col">Certificate</th><th scope="col">Actions</th></tr>
       </thead>
       <tbody>
         {% if participants %}
@@ -157,6 +158,17 @@
           <td>{{ row.participant.display_name }}{% if row.participant.account and row.participant.account.certificate_name %} ({{ row.participant.account.certificate_name }}){% endif %}</td>
           <td>{{ row.participant.email }}</td>
           <td>{{ row.participant.title }}</td>
+          <td>
+            {% if csa_can_manage and not session.delivered and not session.participants_locked() %}
+            <form action="{{ url_for('sessions.update_participant_company', session_id=session.id, participant_id=row.participant.id) }}" method="post" class="inline-company-form">
+              <input type="hidden" name="next" value="{{ participants_return }}">
+              <input type="text" name="company_name" value="{{ row.link.company_name or '' }}" placeholder="Company">
+              <button type="submit" class="btn btn-secondary btn-sm">Save</button>
+            </form>
+            {% else %}
+            {{ row.link.company_name or '—' }}
+            {% endif %}
+          </td>
           <td>
             {% if row.pdf_path %}
               {% if badge_filename %}
@@ -178,7 +190,7 @@
         </tr>
         {% endfor %}
         {% else %}
-          {% with colspan=5 %}
+          {% with colspan=6 %}
 
             {% include 'shared/_table_empty.html' %}
 
@@ -195,6 +207,7 @@
     <input type="text" name="last_name" class="js-name-last" placeholder="Last name" required>
     <input type="email" name="email" placeholder="Email" required>
     <input type="text" name="title" placeholder="Title">
+    <input type="text" name="company_name" placeholder="Company">
     <button type="submit">Add Participant</button>
   </form>
     <form action="{{ url_for('sessions.import_csv', session_id=session.id) }}" method="post" enctype="multipart/form-data">
@@ -203,7 +216,7 @@
       <div class="inline-gap-sm">
         <label for="{{ import_input_id }}" class="btn">Import CSV</label>
         <a href="{{ url_for('sessions.sample_csv', session_id=session.id) }}">Download sample CSV</a>
-        <span class="form-align__help">Sample uses First &amp; Last name columns; legacy FullName is still accepted.</span>
+        <span class="form-align__help">Sample uses First &amp; Last name columns, includes an optional Company column, and legacy FullName is still accepted.</span>
       </div>
     </form>
   {% if import_errors %}
@@ -238,6 +251,7 @@
             <th scope="col"{% if attendance_days %} rowspan="2"{% endif %}>Full Name</th>
             <th scope="col"{% if attendance_days %} rowspan="2"{% endif %}>Email</th>
             <th scope="col"{% if attendance_days %} rowspan="2"{% endif %}>Title</th>
+            <th scope="col"{% if attendance_days %} rowspan="2"{% endif %}>Company</th>
             {% if attendance_days %}
             <th scope="colgroup" colspan="{{ attendance_days|length }}">Attendance</th>
             {% endif %}
@@ -259,6 +273,16 @@
             <td>{{ row.participant.display_name }}{% if row.participant.account and row.participant.account.certificate_name %} ({{ row.participant.account.certificate_name }}){% endif %}</td>
             <td>{{ row.participant.email }}</td>
             <td>{{ row.participant.title }}</td>
+            <td>
+              {% if not session.delivered and not session.participants_locked() %}
+              <form action="{{ url_for('sessions.update_participant_company', session_id=session.id, participant_id=row.participant.id) }}" method="post" class="inline-company-form">
+                <input type="text" name="company_name" value="{{ row.link.company_name or '' }}" placeholder="Company">
+                <button type="submit" class="btn btn-secondary btn-sm">Save</button>
+              </form>
+              {% else %}
+              {{ row.link.company_name or '—' }}
+              {% endif %}
+            </td>
             {% if attendance_days %}
               {% set attendance = row.attendance if row.attendance is defined else {} %}
               {% for day in attendance_days %}

--- a/app/templates/sessions/workshop_view.html
+++ b/app/templates/sessions/workshop_view.html
@@ -108,6 +108,7 @@
     <input type="text" name="last_name" class="js-name-last" placeholder="Last name" required>
     <input type="email" name="email" placeholder="Email" required>
     <input type="text" name="title" placeholder="Title">
+    <input type="text" name="company_name" placeholder="Company">
     <button type="submit" class="btn btn-secondary">Add Participant</button>
   </form>
   <form action="{{ url_for('sessions.import_csv', session_id=session.id) }}" method="post" enctype="multipart/form-data">
@@ -116,7 +117,7 @@
     <div class="inline-gap-sm">
       <label for="{{ import_input_id }}" class="btn">Import CSV</label>
       <a href="{{ url_for('sessions.sample_csv', session_id=session.id) }}">Download sample CSV</a>
-      <span class="form-align__help">Sample uses First &amp; Last name columns; legacy FullName is still accepted.</span>
+      <span class="form-align__help">Sample uses First &amp; Last name columns, includes an optional Company column, and legacy FullName is still accepted.</span>
     </div>
   </form>
   {% if import_errors %}
@@ -153,6 +154,7 @@
             <th scope="col"{% if attendance_days %} rowspan="2"{% endif %}>Full Name</th>
             <th scope="col"{% if attendance_days %} rowspan="2"{% endif %}>Email</th>
             <th scope="col"{% if attendance_days %} rowspan="2"{% endif %}>Title</th>
+            <th scope="col"{% if attendance_days %} rowspan="2"{% endif %}>Company</th>
             {% if attendance_days %}
             <th style="text-align: center;" scope="colgroup" colspan="{{ attendance_days|length }}">Attendance</th>
             {% endif %}
@@ -175,6 +177,17 @@
             <td>{{ row.participant.display_name }}{% if row.participant.account and row.participant.account.certificate_name %} ({{ row.participant.account.certificate_name }}){% endif %}</td>
             <td>{{ row.participant.email }}</td>
             <td>{{ row.participant.title }}</td>
+            <td>
+              {% if can_manage_participants %}
+              <form action="{{ url_for('sessions.update_participant_company', session_id=session.id, participant_id=row.participant.id) }}" method="post" class="inline-company-form">
+                <input type="hidden" name="next" value="{{ workshop_return }}">
+                <input type="text" name="company_name" value="{{ row.link.company_name or '' }}" placeholder="Company">
+                <button type="submit" class="btn btn-secondary btn-sm">Save</button>
+              </form>
+              {% else %}
+              {{ row.link.company_name or '—' }}
+              {% endif %}
+            </td>
             {% if attendance_days %}
               {% set attendance = row.attendance if row.attendance is defined else {} %}
               {% for day in attendance_days %}
@@ -246,7 +259,7 @@
           </tr>
           {% else %}
           <tr>
-            <td colspan="{{ 7 + (attendance_days|length if attendance_days else 0) }}">No participants added yet.</td>
+            <td colspan="{{ 8 + (attendance_days|length if attendance_days else 0) }}">No participants added yet.</td>
           </tr>
           {% endfor %}
         </tbody>

--- a/migrations/versions/0078_session_participant_company_name.py
+++ b/migrations/versions/0078_session_participant_company_name.py
@@ -1,0 +1,30 @@
+"""Add company name to session participants
+
+Revision ID: 0078_session_participant_company_name
+Revises: 0077_split_names_first_last
+Create Date: 2025-01-20 00:00:00.000000
+"""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "0078_session_participant_company_name"
+down_revision = "0077_split_names_first_last"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        "session_participants",
+        sa.Column("company_name", sa.Text(), nullable=True),
+    )
+
+
+def downgrade():
+    op.drop_column("session_participants", "company_name")
+


### PR DESCRIPTION
## Summary
- add an optional `company_name` column to `session_participants` with an Alembic migration and ORM mapping
- surface company inputs across add/edit/import flows and inline table editing in session detail and workshop views
- include the company column in CSV samples and update tests/documentation for the new field

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d565678d6c832e9303c7cb18fab74b