### PR TITLE
Restore certificate session creation flow

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -8,7 +8,7 @@ Every functional change must update this file **in the same PR**.
 - **App**: Python (Flask), Gunicorn
 - **DB**: PostgreSQL 16
 - **Proxy**: Caddy → `app:8000`
-- **Caddy config**: repo-managed at `caddy/Caddyfile` and bind-mounted to `/etc/caddy/Caddyfile`; `/certificates/*` and `/badges/*` are served via `handle` from `/srv` while Flask serves `/static/*`
+- **Caddy config**: repo-managed at `caddy/Caddyfile` and bind-mounted to `/etc/caddy/Caddyfile`; `/certificates/new*` proxies to Flask while other `/certificates/*` assets and `/badges/*` are served via `handle` from `/srv`, and Flask serves `/static/*`
 - **Docker Compose services**: `cbs-app-1`, `cbs-db-1`, `cbs-caddy-1`
 - **In-container paths**: code at `/app/app/...`; site mount at `/srv` (host `./site`)
 - **Certificate templates**: host `./data/cert-assets` is bind-mounted to `/app/app/assets`; seed it from `app/assets/` on first deploy and keep it backed up for persistence.
@@ -630,4 +630,4 @@ Route inventory lives at `sitemap.txt` (admin-only, linked from Settings) and li
 - Materials order Special instructions textarea uses the same wide alignment as the session form so its left edge matches other inputs.
 - Materials order header cards (Order details + Shipping details) share a `.materials-header-grid` two-column layout that stacks below 1100px, and the shipping location dropdown lists each location's title only.
 - Certificate-only sessions (`delivery_type = "Certificate only"`) also persist `Session.is_certificate_only = True`, automatically flip Ready for delivery on create/edit, force `no_material_order`, `no_prework`, and `prework_disabled`, hide Materials and Prework navigation (including dashboards and lists), and continue to follow the existing attendance + certificate rules.
-- KT Staff and App Admin can create certificate-only workshops via `GET/POST /certificates/new`. The form captures client, data region, workshop type, language, location, facilitators, schedule, and number of class days, marks the session ready for delivery, and redirects to the session detail page. The left nav surfaces a “New Certificate Session” link under Workshop Dashboard for these users.
+- KT Staff and App Admin can create certificate-only workshops via `GET/POST /certificates/new`. The form captures client, data region, workshop type, language, location, facilitators, schedule, and number of class days, marks the session ready for delivery, and redirects to the session detail page. The left nav surfaces a “New Certificate Session” link directly under “New Order” and before “Workshop Dashboard” for these users, and the page highlights that nav entry when active.

--- a/app/routes/certificates.py
+++ b/app/routes/certificates.py
@@ -57,7 +57,12 @@ def index(current_user):
     return render_template("certificates.html")
 
 
-@bp.route("/new", methods=["GET", "POST"], endpoint="new_session")
+@bp.route(
+    "/new",
+    methods=["GET", "POST"],
+    endpoint="new_certificate_session",
+    strict_slashes=False,
+)
 @staff_required
 def new_certificate_session(current_user):
     if is_contractor(current_user):
@@ -316,3 +321,11 @@ def new_certificate_session(current_user):
         selected_client_id=selected_client_id,
         form=form,
     )
+
+
+bp.add_url_rule(
+    "/new",
+    view_func=new_certificate_session,
+    methods=["GET", "POST"],
+    endpoint="new_session",
+)

--- a/app/shared/nav.py
+++ b/app/shared/nav.py
@@ -25,7 +25,7 @@ NEW_ORDER: MenuItem = {
 NEW_CERTIFICATE_SESSION: MenuItem = {
     "id": "new_certificate_session",
     "label": "New Certificate Session",
-    "endpoint": "certificates.new_session",
+    "endpoint": "certificates.new_certificate_session",
 }
 WORKSHOP_DASHBOARD: MenuItem = {
     "id": "sessions",
@@ -172,8 +172,8 @@ VIEW_MENUS: Dict[str, List[MenuItem]] = {
     "ADMIN": [
         HOME,
         NEW_ORDER,
-        WORKSHOP_DASHBOARD,
         NEW_CERTIFICATE_SESSION,
+        WORKSHOP_DASHBOARD,
         MATERIAL_DASHBOARD,
         SURVEYS,
         PROFILE_GROUP,
@@ -183,8 +183,8 @@ VIEW_MENUS: Dict[str, List[MenuItem]] = {
     "SESSION_MANAGER": [
         HOME,
         NEW_ORDER,
-        WORKSHOP_DASHBOARD,
         NEW_CERTIFICATE_SESSION,
+        WORKSHOP_DASHBOARD,
         MATERIAL_DASHBOARD,
         SURVEYS,
         PROFILE_GROUP,
@@ -194,8 +194,8 @@ VIEW_MENUS: Dict[str, List[MenuItem]] = {
     "SESSION_ADMIN": [
         HOME,
         MY_SESSIONS,
-        WORKSHOP_DASHBOARD,
         NEW_CERTIFICATE_SESSION,
+        WORKSHOP_DASHBOARD,
         MATERIAL_DASHBOARD,
         PROFILE_GROUP,
         LOGOUT,
@@ -203,8 +203,8 @@ VIEW_MENUS: Dict[str, List[MenuItem]] = {
     "MATERIAL_MANAGER": [
         HOME,
         NEW_ORDER,
-        MATERIAL_DASHBOARD,
         NEW_CERTIFICATE_SESSION,
+        MATERIAL_DASHBOARD,
         PROFILE_GROUP,
         {"id": "settings", "label": "Settings", "children": SETTINGS_MATERIAL_MANAGER},
         LOGOUT,
@@ -212,8 +212,8 @@ VIEW_MENUS: Dict[str, List[MenuItem]] = {
     "DELIVERY": [
         HOME,
         MY_SESSIONS,
-        WORKSHOP_DASHBOARD,
         NEW_CERTIFICATE_SESSION,
+        WORKSHOP_DASHBOARD,
         SURVEYS,
         PROFILE_GROUP,
         {"id": "settings", "label": "Settings", "children": SETTINGS_DELIVERY},

--- a/caddy/Caddyfile
+++ b/caddy/Caddyfile
@@ -5,8 +5,13 @@ cbs.ktapps.net {
   # Let Flask serve /static/*
   # (do NOT add a /static handler)
 
-  # Serve these directly from /srv without stripping the prefix
-  handle /certificates/* {
+  # Serve certificate assets directly except for dynamic staff routes.
+  @certificates_new path_regexp certNew ^/certificates/new(?:/.*)?$
+  handle @certificates_new {
+    reverse_proxy app:8000
+  }
+  @certificate_assets path_regexp certAssets ^/certificates/(?!new(?:/|$)).*
+  handle @certificate_assets {
     file_server
   }
   handle /resources/* {

--- a/sitemap.txt
+++ b/sitemap.txt
@@ -8,6 +8,7 @@
 /sessions                – Staff/CSA: list with filters; excludes Material only sessions
 /materials               – Materials dashboard; shows only materials-enabled sessions (includes Material only orders)
 /sessions/new            – Create session (staff only)
+/certificates/new        – Create certificate-only session (KT Staff/App Admin)
 /sessions/<id>           – Session detail (overview + tabs)
 /workshops/<id>         – Workshop runner view (Delivery/Contractor; also used when a user has KT Facilitator among roles; Materials card hidden for materials-only sessions which redirect to /sessions/<id>; Resources card lists session-language facilitator/Both resources; Prework summary card groups responses by question with ';' separators)
 /sessions/<id>/prework  – Staff Prework tab (summary card mirrors workshop view and sits above assignment management/send controls)

--- a/tests/smoke/test_auth_roles.py
+++ b/tests/smoke/test_auth_roles.py
@@ -78,6 +78,11 @@ def test_auth_roles_home_selection(app, client):
     assert "Switch views here." in admin_html
     assert "<label>View:</label>" in admin_html
     assert "Switch to Admin" not in admin_html
+    cert_form = client.get("/certificates/new")
+    assert cert_form.status_code == 200
+    assert "New Certificate Session" in cert_form.get_data(as_text=True)
+    cert_form_slash = client.get("/certificates/new/")
+    assert cert_form_slash.status_code == 200
     response = client.get(
         "/settings/view", query_string={"view": "MATERIAL_MANAGER"}, follow_redirects=False
     )

--- a/tests/test_nav_menu.py
+++ b/tests/test_nav_menu.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from app.app import db
+from app.models import Language, User
+
+
+def _login(client, user_id: int) -> None:
+    with client.session_transaction() as sess:
+        sess["user_id"] = user_id
+
+
+def _ensure_language() -> None:
+    if not Language.query.filter_by(name="English").first():
+        db.session.add(Language(name="English", sort_order=1, is_active=True))
+        db.session.flush()
+
+
+def test_sidebar_positions_new_certificate_session(app, client):
+    with app.app_context():
+        _ensure_language()
+        admin = User(email="admin@example.com", is_admin=True, is_app_admin=True)
+        admin.set_password("pw")
+        db.session.add(admin)
+        db.session.commit()
+        admin_id = admin.id
+
+    _login(client, admin_id)
+
+    response = client.get("/home", follow_redirects=True)
+    assert response.status_code == 200
+    html = response.get_data(as_text=True)
+    nav_start = html.index('<nav class="kt-nav">')
+    nav_end = html.index("</nav>", nav_start)
+    nav_html = html[nav_start:nav_end]
+    assert "/certificates/new" in nav_html
+    new_order_index = nav_html.index("New Order")
+    cert_index = nav_html.index("New Certificate Session")
+    workshop_index = nav_html.index("Workshop Dashboard")
+    assert new_order_index < cert_index < workshop_index
+
+    cert_page = client.get("/certificates/new")
+    assert cert_page.status_code == 200
+    page_html = cert_page.get_data(as_text=True)
+    nav_start = page_html.index('<nav class="kt-nav">')
+    nav_end = page_html.index("</nav>", nav_start)
+    nav_html = page_html[nav_start:nav_end]
+    link_start = nav_html.index('<a href="/certificates/new"')
+    link_end = nav_html.index("</a>", link_start)
+    link_markup = nav_html[link_start:link_end]
+    assert 'aria-current="page"' in link_markup
+


### PR DESCRIPTION
## Summary
- expose the certificate-only session creation form at `/certificates/new`, delegating to the existing template and logic while guarding non-staff access
- update the staff sidebar so "New Certificate Session" links to the canonical route, appears directly under "New Order", and highlights correctly; document the canonical path in CONTEXT.md and sitemap.txt
- ensure Caddy always proxies `/certificates/new*` to Flask ahead of static handlers and cover the route/nav behavior with smoke + navigation tests

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d59f2b4c84832e8794e7caadbb0ce5