### PR TITLE
Fix routing for /certificates/new in Caddy

### DIFF
--- a/caddy/Caddyfile
+++ b/caddy/Caddyfile
@@ -6,13 +6,15 @@ cbs.ktapps.net {
   # (do NOT add a /static handler)
 
   # Serve certificate assets directly except for dynamic staff routes.
-  @certificates_new path /certificates/new /certificates/new/*
+  @certificates_new {
+    path /certificates/new
+    path /certificates/new/*
+  }
   handle @certificates_new {
     reverse_proxy app:8000
   }
   @certificate_assets {
-    path /certificates/*
-    not path /certificates/new /certificates/new/*
+    path_regexp cert_assets ^/certificates/(?!new(?:$|/)).*
   }
   handle @certificate_assets {
     file_server


### PR DESCRIPTION
## Summary
- ensure Caddy always proxies certificate creation routes to Flask by matching /certificates/new with an explicit matcher
- guard static certificate asset handling with a regex that excludes the dynamic creation paths

## Testing
- pytest tests/smoke/test_auth_roles.py::test_auth_roles_home_selection *(fails: bcrypt backend requires compiled extension)*

------
https://chatgpt.com/codex/tasks/task_e_68d5b361ab48832ea9094c527b55a9ed