### PR TITLE
Fix routing for /certificates/new

### DIFF
--- a/caddy/Caddyfile
+++ b/caddy/Caddyfile
@@ -14,7 +14,9 @@ cbs.ktapps.net {
     reverse_proxy app:8000
   }
   @certificate_assets {
-    path_regexp cert_assets ^/certificates/(?!new(?:$|/)).*
+    path /certificates/*
+    not path /certificates/new
+    not path /certificates/new/*
   }
   handle @certificate_assets {
     file_server


### PR DESCRIPTION
## Summary
- ensure the Caddy certificate asset handler uses Caddy's `not` matcher instead of an unsupported regex lookahead
- continue proxying `/certificates/new` and `/certificates/new/*` to the Flask app while serving other certificate assets from disk

## Testing
- `pytest tests/smoke/test_auth_roles.py -q` *(fails: bcrypt backend unavailable in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d5b95c3840832e91df9394172a5dc8