### PR TITLE
Fix routing for /certificates/new

### DIFF
--- a/caddy/Caddyfile
+++ b/caddy/Caddyfile
@@ -14,7 +14,11 @@ cbs.ktapps.net {
     reverse_proxy app:8000
   }
   @certificate_assets {
-    path_regexp cert_assets ^/certificates/(?!new(?:$|/)).*
+    path /certificates/*
+    not {
+      path /certificates/new
+      path /certificates/new/*
+    }
   }
   handle @certificate_assets {
     file_server


### PR DESCRIPTION
## Summary
- ensure the Caddy certificate asset handler uses a proper `not { ... }` block so `/certificates/new` routes bypass the static handler
- continue proxying `/certificates/new` and `/certificates/new/*` to the Flask app while serving other certificate assets from disk

## Testing
- not run (proxy configuration change only)


------
https://chatgpt.com/codex/tasks/task_e_68d5b95c3840832e91df9394172a5dc8