### PR TITLE
Proxy certificate routes to Flask

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -8,7 +8,7 @@ Every functional change must update this file **in the same PR**.
 - **App**: Python (Flask), Gunicorn
 - **DB**: PostgreSQL 16
 - **Proxy**: Caddy → `app:8000`
-- **Caddy config**: repo-managed at `caddy/Caddyfile` and bind-mounted to `/etc/caddy/Caddyfile`; `/certificates/new*` proxies to Flask while other `/certificates/*` assets and `/badges/*` are served via `handle` from `/srv`, and Flask serves `/static/*`
+- **Caddy config**: repo-managed at `caddy/Caddyfile` and bind-mounted to `/etc/caddy/Caddyfile`; all `/certificates/*` routes proxy to Flask while `/badges/*` continue to serve from `/srv`, and Flask serves `/static/*`
 - **Docker Compose services**: `cbs-app-1`, `cbs-db-1`, `cbs-caddy-1`
 - **In-container paths**: code at `/app/app/...`; site mount at `/srv` (host `./site`)
 - **Certificate templates**: host `./data/cert-assets` is bind-mounted to `/app/app/assets`; seed it from `app/assets/` on first deploy and keep it backed up for persistence.

--- a/caddy/Caddyfile
+++ b/caddy/Caddyfile
@@ -5,23 +5,8 @@ cbs.ktapps.net {
   # Let Flask serve /static/*
   # (do NOT add a /static handler)
 
-  # Serve certificate assets directly except for dynamic staff routes.
-  @certificates_new {
-    path /certificates/new
-    path /certificates/new/*
-  }
-  handle @certificates_new {
+  handle_path /certificates/* {
     reverse_proxy app:8000
-  }
-  @certificate_assets {
-    path /certificates/*
-    not {
-      path /certificates/new
-      path /certificates/new/*
-    }
-  }
-  handle @certificate_assets {
-    file_server
   }
   handle /resources/* {
     file_server


### PR DESCRIPTION
## Summary
- proxy all /certificates/* requests through Flask by adding a single handle_path rule
- update the engineering context to document that certificates are now proxied via Flask

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d5bcd5ac5c832e8bd00524e4d84198