### PR TITLE
Add certification number field to certificates model

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -339,6 +339,7 @@ Two separate tables by design; emails unique per table. If both tables hold the 
 ## 3.4 Certificates
 - `certificates` (session_id, participant_account_id, file_path, issued_at, layout_version; unique pair)
   Files under `/srv/certificates/<year>/<session_id>/<workshop_code>_<certificate_name_slug>_<YYYY-MM-DD>.pdf` (using `workshop_types.code`).
+  `certification_number` stores the BadgeNumber (nullable VARCHAR(64), globally unique) for each issued certificate.
 
 ## 3.5 Materials
 - `materials_orders` (session_id, **format** enum: All Physical/All Digital/Mixed/SIM Only; four **physical_components** booleans; **po_number**; **latest_arrival_date**; ship_date; courier; tracking; special_instructions)

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -655,6 +655,7 @@ class Certificate(db.Model):
         db.Integer, db.ForeignKey("participants.id", ondelete="CASCADE")
     )
     session_id = db.Column(db.Integer, db.ForeignKey("sessions.id", ondelete="CASCADE"))
+    certification_number = db.Column(db.String(64), unique=True)
     certificate_name = db.Column(db.String(255))
     workshop_name = db.Column(db.String(255))
     workshop_date = db.Column(db.Date)

--- a/migrations/versions/0082_certificates_badge_number.py
+++ b/migrations/versions/0082_certificates_badge_number.py
@@ -1,0 +1,46 @@
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "0082_certificates_badge_number"
+down_revision = "0081_certificate_manager_role"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+
+    columns = {col["name"] for col in inspector.get_columns("certificates")}
+    if "certification_number" not in columns:
+        op.add_column(
+            "certificates",
+            sa.Column("certification_number", sa.String(length=64), nullable=True),
+        )
+        inspector = sa.inspect(bind)
+
+    uniques = {uc["name"] for uc in inspector.get_unique_constraints("certificates")}
+    if "uq_certificates_certification_number" not in uniques:
+        op.create_unique_constraint(
+            "uq_certificates_certification_number",
+            "certificates",
+            ["certification_number"],
+        )
+
+
+def downgrade():
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+
+    uniques = {uc["name"] for uc in inspector.get_unique_constraints("certificates")}
+    if "uq_certificates_certification_number" in uniques:
+        op.drop_constraint(
+            "uq_certificates_certification_number",
+            "certificates",
+            type_="unique",
+        )
+
+    columns = {col["name"] for col in inspector.get_columns("certificates")}
+    if "certification_number" in columns:
+        op.drop_column("certificates", "certification_number")


### PR DESCRIPTION
## Summary
- add a nullable, globally unique certification_number column for issued certificates
- document the BadgeNumber field in CONTEXT.md so downstream work can reference it

## Testing
- alembic upgrade head *(fails: could not translate host name "db" to address in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d6cc97af60832e8fbbfc952af3f2a6