### PR TITLE
Surface badge numbers in UI and exports

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -340,6 +340,7 @@ Two separate tables by design; emails unique per table. If both tables hold the 
 - `certificates` (session_id, participant_account_id, file_path, issued_at, layout_version; unique pair)
   Files under `/srv/certificates/<year>/<session_id>/<workshop_code>_<certificate_name_slug>_<YYYY-MM-DD>.pdf` (using `workshop_types.code`).
   `certification_number` stores the BadgeNumber (nullable VARCHAR(64), globally unique) for each issued certificate. BadgeNumbers follow `KT-<cert_series_code>-YYYY-<SessionID#####>-###`, where `###` is a per-session counter starting at `001`.
+  BadgeNumber surfaces across staff Workshop View/session detail certificate listings, the learner **My Certificates** page, and the certificates CSV export (column header `BadgeNumber`). Empty values render as blank/`—` when legacy certificates lack a number.
 
 ## 3.5 Materials
 - `materials_orders` (session_id, **format** enum: All Physical/All Digital/Mixed/SIM Only; four **physical_components** booleans; **po_number**; **latest_arrival_date**; ship_date; courier; tracking; special_instructions)

--- a/app/routes/certificates.py
+++ b/app/routes/certificates.py
@@ -1,6 +1,15 @@
-from flask import Blueprint, render_template
+from __future__ import annotations
+
+import csv
+import io
+from datetime import datetime
+
+from flask import Blueprint, Response, render_template
+from sqlalchemy.orm import selectinload
 
 from .sessions import staff_required
+from ..app import db
+from ..models import Certificate, Participant, SessionParticipant
 
 bp = Blueprint("certificates", __name__, url_prefix="/certificates")
 
@@ -9,3 +18,77 @@ bp = Blueprint("certificates", __name__, url_prefix="/certificates")
 @staff_required
 def index(current_user):
     return render_template("certificates.html")
+
+
+@bp.get("/export.csv")
+@staff_required
+def export_csv(current_user):
+    rows = (
+        db.session.query(
+            Certificate,
+            Participant,
+            SessionParticipant.completion_date,
+        )
+        .join(Participant, Certificate.participant_id == Participant.id)
+        .outerjoin(
+            SessionParticipant,
+            (SessionParticipant.session_id == Certificate.session_id)
+            & (SessionParticipant.participant_id == Certificate.participant_id),
+        )
+        .options(selectinload(Certificate.session))
+        .order_by(Certificate.issued_at.desc(), Certificate.id.desc())
+        .all()
+    )
+
+    output = io.StringIO()
+    writer = csv.writer(output)
+    writer.writerow(
+        [
+            "CertificateID",
+            "BadgeNumber",
+            "ParticipantEmail",
+            "ParticipantName",
+            "CertificateName",
+            "WorkshopName",
+            "WorkshopDate",
+            "SessionID",
+            "CompletionDate",
+            "IssuedAt",
+            "PdfPath",
+        ]
+    )
+
+    def _format_date(value: datetime | None) -> str:
+        if not value:
+            return ""
+        if isinstance(value, datetime):
+            return value.replace(microsecond=0).isoformat(sep=" ")
+        return value.isoformat() if hasattr(value, "isoformat") else str(value)
+
+    for cert, participant, completion_date in rows:
+        session = cert.session
+        workshop_date = (
+            cert.workshop_date.isoformat() if cert.workshop_date else ""
+        )
+        completion_val = (
+            completion_date.isoformat() if completion_date else ""
+        )
+        writer.writerow(
+            [
+                cert.id,
+                cert.certification_number or "",
+                participant.email,
+                participant.display_name,
+                cert.certificate_name,
+                cert.workshop_name,
+                workshop_date,
+                session.id if session else cert.session_id,
+                completion_val,
+                _format_date(cert.issued_at),
+                cert.pdf_path,
+            ]
+        )
+
+    resp = Response(output.getvalue(), mimetype="text/csv")
+    resp.headers["Content-Disposition"] = "attachment; filename=certificates.csv"
+    return resp

--- a/app/routes/sessions.py
+++ b/app/routes/sessions.py
@@ -1618,7 +1618,12 @@ def session_detail(session_id: int, sess, current_user, csa_view, csa_account):
     require_full_attendance = False
     if not material_only:
         rows = (
-            db.session.query(SessionParticipant, Participant, Certificate.pdf_path)
+            db.session.query(
+                SessionParticipant,
+                Participant,
+                Certificate.pdf_path,
+                Certificate.certification_number,
+            )
             .options(selectinload(SessionParticipant.company_client))
             .join(Participant, SessionParticipant.participant_id == Participant.id)
             .outerjoin(
@@ -1630,8 +1635,13 @@ def session_detail(session_id: int, sess, current_user, csa_view, csa_account):
             .all()
         )
         participants = [
-            {"participant": participant, "link": link, "pdf_path": pdf_path}
-            for link, participant, pdf_path in rows
+            {
+                "participant": participant,
+                "link": link,
+                "pdf_path": pdf_path,
+                "certification_number": certification_number,
+            }
+            for link, participant, pdf_path, certification_number in rows
         ]
         attendance_days = list(
             range(1, (sess.number_of_class_days or 0) + 1)

--- a/app/routes/workshops.py
+++ b/app/routes/workshops.py
@@ -178,7 +178,12 @@ def workshop_view(session_id: int, current_user):
     client_options: list[Client] = []
     if not material_only:
         rows = (
-            db.session.query(SessionParticipant, Participant, Certificate.pdf_path)
+            db.session.query(
+                SessionParticipant,
+                Participant,
+                Certificate.pdf_path,
+                Certificate.certification_number,
+            )
             .options(selectinload(SessionParticipant.company_client))
             .join(Participant, SessionParticipant.participant_id == Participant.id)
             .outerjoin(
@@ -191,13 +196,14 @@ def workshop_view(session_id: int, current_user):
         )
         statuses = get_participant_prework_status(session.id)
         participants = []
-        for link, participant, pdf_path in rows:
+        for link, participant, pdf_path, certification_number in rows:
             status = statuses.get(participant.id)
             participants.append(
                 {
                     "participant": participant,
                     "link": link,
                     "pdf_path": pdf_path,
+                    "certification_number": certification_number,
                     "prework_status": status,
                     "prework_summary": summarize_prework_status(status),
                 }

--- a/app/templates/my_certificates.html
+++ b/app/templates/my_certificates.html
@@ -6,14 +6,20 @@
 <ul>
 {% for c in certs %}
   <li>
-    {{ c.workshop_name }} - {{ c.workshop_date }}
-    <a href="{{ '/certificates/' ~ c.pdf_path }}">Certificate</a>
-    {% set badge_file = cert_badges.get(c.id) %}
-    {% if badge_file %}
-      {% set badge_url = '/badges/' ~ badge_file %}
-      <a href="{{ badge_url }}" download><img src="{{ badge_url }}" alt="badge" style="height:20px;width:auto;vertical-align:middle;"></a>
-      <a href="{{ badge_url }}" download>Badge</a>
-    {% endif %}
+    <div class="inline-gap-sm" style="flex-wrap:wrap;display:flex;align-items:center;">
+      <span>{{ c.workshop_name }} - {{ c.workshop_date }}</span>
+      <a href="{{ '/certificates/' ~ c.pdf_path }}">Certificate</a>
+      {% set badge_file = cert_badges.get(c.id) %}
+      {% if badge_file %}
+        {% set badge_url = '/badges/' ~ badge_file %}
+        <a href="{{ badge_url }}" download><img src="{{ badge_url }}" alt="badge" style="height:20px;width:auto;vertical-align:middle;"></a>
+        <a href="{{ badge_url }}" download>Badge</a>
+      {% endif %}
+    </div>
+    <div>
+      <strong>BadgeNumber:</strong>
+      <span>{{ c.certification_number or '—' }}</span>
+    </div>
   </li>
 {% endfor %}
 </ul>

--- a/app/templates/session_detail.html
+++ b/app/templates/session_detail.html
@@ -194,6 +194,10 @@
                 <a href="{{ badge_url }}" download>Badge</a>
               {% endif %}
               <a href="/certificates/{{ row.pdf_path }}">Certificate</a>
+              <div>
+                <strong>BadgeNumber:</strong>
+                <span>{{ row.certification_number or '—' }}</span>
+              </div>
             {% endif %}
           </td>
           <td>
@@ -352,6 +356,10 @@
                   <a href="{{ badge_url }}" download>Badge</a>
                 {% endif %}
                 <a href="/certificates/{{ row.pdf_path }}">Certificate</a>
+                <div>
+                  <strong>BadgeNumber:</strong>
+                  <span>{{ row.certification_number or '—' }}</span>
+                </div>
               {% endif %}
             </td>
             <td>

--- a/app/templates/sessions/workshop_view.html
+++ b/app/templates/sessions/workshop_view.html
@@ -273,6 +273,10 @@
                   <a href="{{ badge_url }}" download>Badge</a>
                 {% endif %}
                 <a href="/certificates/{{ row.pdf_path }}">Certificate</a>
+                <div>
+                  <strong>BadgeNumber:</strong>
+                  <span>{{ row.certification_number or '—' }}</span>
+                </div>
               {% endif %}
             </td>
             <td>


### PR DESCRIPTION
## Summary
- display each certificate's BadgeNumber on staff workshop/session participant tables and the learner My Certificates list
- include the BadgeNumber column in the certificates CSV export while keeping legacy rows blank
- document BadgeNumber visibility across UI and exports in CONTEXT.md

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d6dc94f4ec832eaf940caf00ea9bb3