### PR TITLE
Add staff certificate export under /exports

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -535,6 +535,9 @@ Two separate tables by design; emails unique per table. If both tables hold the 
 - In production, set `ALLOW_CERT_PURGE=1` to enable deletions.
 - One-off CLI `backfill_cert_paths` (run: `python manage.py backfill_cert_paths`) updates legacy `YYYY/<workshop_code>/…` rows when a `YYYY/session_id/…` file exists. Safe to skip if not needed.
 - Learner nav shows **My Certificates** only if they own ≥1 certificate; staff see **My Profile → My Certificates** only when they have certificates as participants.
+- **Exports**:
+  - `/exports/certificates.csv` – Staff only (**KT Admin**, **KT Staff**, **Certificate Manager**) CSV covering all issued certificates.
+  - `/exports/certificates.csv?session_id=<id>` – Same export scoped to a session; surfaced from staff Workshop View and Session Detail participant headers.
 
 ---
 

--- a/app/static/css/cards.css
+++ b/app/static/css/cards.css
@@ -12,6 +12,16 @@
   margin: 0 0 var(--space-3) 0;
   color: var(--kt-text);
 }
+.kt-card-title-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-2);
+  margin: 0 0 var(--space-3) 0;
+}
+.kt-card-title-row .kt-card-title {
+  margin: 0;
+}
 .kt-card + .kt-card { margin-top: var(--space-4); }
 /* make tables fit nicely inside cards */
 .kt-card table { margin: 0; }

--- a/app/templates/session_detail.html
+++ b/app/templates/session_detail.html
@@ -115,7 +115,10 @@
   {% endif %}
 </div>
 <div class="kt-card">
-<h2 class="kt-card-title">Participants</h2>
+<div class="kt-card-title-row">
+  <h2 class="kt-card-title">Participants</h2>
+  <a class="btn btn-secondary btn-sm" href="{{ url_for('certificates.export_csv') ~ '?session_id=' ~ (session.id|string) }}">Export certificates (CSV)</a>
+</div>
 {% if csa_view %}
   {% if csa_can_manage and not session.delivered and not session.participants_locked() %}
   <form action="{{ url_for('sessions.add_participant', session_id=session.id) }}" method="post" data-name-split="true">

--- a/app/templates/sessions/workshop_view.html
+++ b/app/templates/sessions/workshop_view.html
@@ -78,7 +78,10 @@
 </section>
 
 <section class="kt-card" data-prework-container>
-  <h2 class="kt-card-title">Participants</h2>
+  <div class="kt-card-title-row">
+    <h2 class="kt-card-title">Participants</h2>
+    <a class="btn btn-secondary btn-sm" href="{{ url_for('certificates.export_csv') ~ '?session_id=' ~ (session.id|string) }}">Export certificates (CSV)</a>
+  </div>
   <div class="prework-feedback" data-prework-feedback aria-live="polite"></div>
   {% if show_disable_prework and not certificate_only %}
   <div class="prework-toolbar" style="display:flex;flex-wrap:wrap;gap:var(--space-2);margin-bottom:var(--space-3);">


### PR DESCRIPTION
## Summary
- move the staff certificates export to /exports/certificates.csv with optional session filtering
- surface an "Export certificates (CSV)" action on staff Workshop View and Session Detail pages
- document the new export endpoint and tidy card headers with a shared layout helper class

## Testing
- pytest -q -m "smoke" *(fails: ValueError from passlib bcrypt backend when hashing passwords in tests)*

------
https://chatgpt.com/codex/tasks/task_e_68d6fc724528832e96c8135565a06ba1