### PR TITLE
Fix form layout wrapping for narrow certificate session page

### DIFF
--- a/app/static/css/forms.css
+++ b/app/static/css/forms.css
@@ -228,6 +228,8 @@ label {
   align-items: center;
   width: 100%;
   margin-bottom: var(--gap-y, 8px);
+  flex-wrap: wrap;
+  row-gap: var(--space-2);
 }
 
 .form-align .form-align__row--top {
@@ -243,6 +245,7 @@ label {
 
 .form-align .form-align__control {
   display: block;
+  min-width: 0;
 }
 
 .form-align .form-align__static {


### PR DESCRIPTION
## Summary
- allow `.form-align__row` flex containers to wrap when space runs out so certificate session fields stack cleanly
- ensure controls can shrink by relaxing their minimum width to avoid overflow

## Testing
- pytest tests/test_nav_menu.py -q

------
https://chatgpt.com/codex/tasks/task_e_68d7120cc188832ea80fc36ac2202f9b